### PR TITLE
Test-project pytest migration — PR-A (prep, inert)

### DIFF
--- a/lex/test_project/tests/api_layer/test_10a_crud_endpoints.py
+++ b/lex/test_project/tests/api_layer/test_10a_crud_endpoints.py
@@ -25,6 +25,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, API_SIMPLE, ApiSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 class TestCluster10a_CRUDEndpoints(E2ETestCase):
     """One/List endpoint smoke tests at the HTTP layer."""

--- a/lex/test_project/tests/api_layer/test_10b_history_endpoint.py
+++ b/lex/test_project/tests/api_layer/test_10b_history_endpoint.py
@@ -19,6 +19,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, API_SIMPLE, ApiSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 class TestCluster10b_HistoryEndpoint(E2ETestCase):
     """History endpoint smoke."""

--- a/lex/test_project/tests/api_layer/test_10c_many_endpoint.py
+++ b/lex/test_project/tests/api_layer/test_10c_many_endpoint.py
@@ -21,6 +21,10 @@ from rest_framework import status
 
 from ..crud_api.models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 class TestCluster10c_ManyEndpoint(E2ETestCase):
     """Scenario 10.7 — ``many/`` DELETE selected rows."""

--- a/lex/test_project/tests/api_layer/test_10e_schema_introspection.py
+++ b/lex/test_project/tests/api_layer/test_10e_schema_introspection.py
@@ -43,6 +43,10 @@ from .models import (
     SchemaItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 class TestCluster10e_CreateFieldInfo(TestCase):
     """10.11 / 10.12 / 10.13 — ``create_field_info`` per-field contract."""

--- a/lex/test_project/tests/api_layer/test_10f_global_search.py
+++ b/lex/test_project/tests/api_layer/test_10f_global_search.py
@@ -42,6 +42,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, SchemaItem
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 def _container(model_class, *, container_id=None, title=None):
     """Build a lightweight stand-in for :class:`ModelContainer`."""

--- a/lex/test_project/tests/api_layer/test_10g_one_endpoint_lifecycle.py
+++ b/lex/test_project/tests/api_layer/test_10g_one_endpoint_lifecycle.py
@@ -25,6 +25,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, API_SIMPLE, ApiSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 class TestCluster10g_OneEndpointLifecycle(E2ETestCase):
     """Detail-endpoint lifecycle paths."""

--- a/lex/test_project/tests/api_layer/test_10h_lex_api_sdk.py
+++ b/lex/test_project/tests/api_layer/test_10h_lex_api_sdk.py
@@ -36,6 +36,10 @@ from django.test import SimpleTestCase
 
 from lex.api.views.lex_api import LexAPI
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 # ----------------------------------------------------------------------
 # 10.17  build_attachments_from_paths

--- a/lex/test_project/tests/api_layer/test_10i_fields_view_and_list_ui.py
+++ b/lex/test_project/tests/api_layer/test_10i_fields_view_and_list_ui.py
@@ -58,6 +58,10 @@ from lex.api.views.model_info.Fields import (
     create_list_ui_info,
 )
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 # --------------------------------------------------------------------- #
 # Helpers — synthesise the few attributes `Fields.get` actually touches.

--- a/lex/test_project/tests/api_layer/test_10j_filter_backends_and_storage.py
+++ b/lex/test_project/tests/api_layer/test_10j_filter_backends_and_storage.py
@@ -41,6 +41,10 @@ from lex.api.filters.GenericFilters import (
 )
 from lex.utilities.storage.custom_storage import CustomDefaultStorage
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 def _make_request(get_params=None, query_params=None):
     """Build a request stub flexible enough for every backend."""

--- a/lex/test_project/tests/api_layer/test_10k_destroy_with_payload_mixin.py
+++ b/lex/test_project/tests/api_layer/test_10k_destroy_with_payload_mixin.py
@@ -40,6 +40,10 @@ from lex.api.views.model_entries.mixins.DestroyOneWithPayloadMixin import (
     _unwrap_historical_instance,
 )
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 def _build_view(instance, *, user_authenticated=True, serializer_data=None):
     """Build a minimal mixin instance with the DRF view contract.

--- a/lex/test_project/tests/api_layer/test_10l_file_download_view.py
+++ b/lex/test_project/tests/api_layer/test_10l_file_download_view.py
@@ -34,6 +34,10 @@ from django.test import SimpleTestCase
 
 from lex.api.views.file_operations.FileDownload import FileDownloadView
 
+import pytest
+
+pytestmark = pytest.mark.api_layer
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/lex/test_project/tests/audit_logging/test_6a_api_audit.py
+++ b/lex/test_project/tests/audit_logging/test_6a_api_audit.py
@@ -32,6 +32,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, AUDIT_SIMPLE, AuditSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 class TestCluster06a_APIAuditLog(E2ETestCase):
     """API path writes AuditLog rows — live under the Pass B2 fixture."""

--- a/lex/test_project/tests/audit_logging/test_6b_calculation_audit.py
+++ b/lex/test_project/tests/audit_logging/test_6b_calculation_audit.py
@@ -37,6 +37,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, AuditAtomicCalc
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 AUDIT_ATOMIC = "auditatomiccalc"
 
 

--- a/lex/test_project/tests/audit_logging/test_6c_actor_resolution.py
+++ b/lex/test_project/tests/audit_logging/test_6c_actor_resolution.py
@@ -24,6 +24,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, AUDIT_SIMPLE, AuditSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 class TestCluster06c_ActorResolution(E2ETestCase):
     """Actor resolution for created_by / edited_by."""

--- a/lex/test_project/tests/audit_logging/test_6d_payload_and_gfk.py
+++ b/lex/test_project/tests/audit_logging/test_6d_payload_and_gfk.py
@@ -40,6 +40,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 from .extra_models import AUDIT_PREVAL, AuditPreValItem
 from .models import ALL_MODELS, AUDIT_SIMPLE, AuditSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 class TestCluster06d_PayloadAndGFK(E2ETestCase):
     """Full payload shape + GenericForeignKey populated end-to-end."""

--- a/lex/test_project/tests/audit_logging/test_6e_bulk_audit.py
+++ b/lex/test_project/tests/audit_logging/test_6e_bulk_audit.py
@@ -27,6 +27,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, AUDIT_SIMPLE, AuditSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 class TestCluster06e_BulkAuditLog(E2ETestCase):
     """``BulkAuditLogMixin`` writes one audit row per affected record."""

--- a/lex/test_project/tests/audit_logging/test_6f_resilience.py
+++ b/lex/test_project/tests/audit_logging/test_6f_resilience.py
@@ -30,6 +30,10 @@ from lex.audit_logging.mixins.AuditLogMixin import (
 )
 from lex.audit_logging.utils.content_types import safe_get_content_type
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 def _make_pg_operational_error(pgcode):
     """Construct an OperationalError with a populated ``pgcode``."""

--- a/lex/test_project/tests/audit_logging/test_6g_immutability.py
+++ b/lex/test_project/tests/audit_logging/test_6g_immutability.py
@@ -29,6 +29,10 @@ from lex.audit_logging.models.AuditLog import AuditLog
 from lex.audit_logging.models.AuditLogStatus import AuditLogStatus
 from lex.core.models.LexModel import PermissionResult
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 class _FakeUserContext:
     """Stand-in for ``UserContext`` — the permission methods only call

--- a/lex/test_project/tests/audit_logging/test_6h_cache_manager.py
+++ b/lex/test_project/tests/audit_logging/test_6h_cache_manager.py
@@ -36,6 +36,10 @@ from django.core.cache import caches
 from django.test import SimpleTestCase
 from lex.audit_logging.utils.CacheManager import CacheManager
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 class TestCluster06h_CacheManagerKeyBuilder(SimpleTestCase):
     """``build_cache_key`` shape contract."""

--- a/lex/test_project/tests/audit_logging/test_6i_calculation_via_api.py
+++ b/lex/test_project/tests/audit_logging/test_6i_calculation_via_api.py
@@ -68,6 +68,10 @@ from .models import (
     AuditNonAtomicCalc,
 )
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 class _CalcAuditViaAPIMixin:
     """Shared assertions for the four (atomic × success/failure) cases.

--- a/lex/test_project/tests/audit_logging/test_6j_audit_utils.py
+++ b/lex/test_project/tests/audit_logging/test_6j_audit_utils.py
@@ -52,6 +52,10 @@ from lex.audit_logging.utils.DataModels import (
     ContextResolutionError,
 )
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 # ---------------------------------------------------------------------------
 # AuditLoggingConfig parser

--- a/lex/test_project/tests/audit_logging/test_6k_model_contracts.py
+++ b/lex/test_project/tests/audit_logging/test_6k_model_contracts.py
@@ -61,6 +61,10 @@ from lex.core.mixins.ModelModificationRestriction import (
     AdminReportsModificationRestriction,
 )
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 # =====================================================================
 # AuditLog — declarative contracts

--- a/lex/test_project/tests/audit_logging/test_6l_context_and_gfk_resolution.py
+++ b/lex/test_project/tests/audit_logging/test_6l_context_and_gfk_resolution.py
@@ -58,6 +58,10 @@ from lex.audit_logging.utils.content_types import safe_get_generic_related_objec
 from lex.audit_logging.utils.ContextResolver import ContextResolver
 from lex.audit_logging.utils.DataModels import ContextInfo, ContextResolutionError
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 # ---------------------------------------------------------------------------
 # Helpers — synthetic Django-like model instance (no DB, no app registration)

--- a/lex/test_project/tests/audit_logging/test_6m_lexlogger_and_websocket.py
+++ b/lex/test_project/tests/audit_logging/test_6m_lexlogger_and_websocket.py
@@ -55,6 +55,10 @@ from django.test import SimpleTestCase
 from lex.audit_logging.handlers.LexLogger import LexLogger, LexLogLevel
 from lex.audit_logging.handlers.WebSocketHandler import WebSocketHandler
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 # ---------------------------------------------------------------------------
 # 1) LexLogLevel constants — pinned so the public log-level surface stays stable

--- a/lex/test_project/tests/audit_logging/test_6n_audit_log_serializers.py
+++ b/lex/test_project/tests/audit_logging/test_6n_audit_log_serializers.py
@@ -46,6 +46,10 @@ from lex.audit_logging.serializers.AuditLogSerializer import (
     AuditLogReferenceSerializer,
 )
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 # ----------------------------------------------------------------------
 # 6.141  Read-only scopes mixin

--- a/lex/test_project/tests/audit_logging/test_6o_bulk_audit_normalize.py
+++ b/lex/test_project/tests/audit_logging/test_6o_bulk_audit_normalize.py
@@ -29,6 +29,10 @@ from django.test import SimpleTestCase
 
 from lex.audit_logging.mixins.BulkAuditLogMixin import BulkAuditLogMixin
 
+import pytest
+
+pytestmark = pytest.mark.audit_logging
+
 
 def _target(pk):
     """Cheap target stand-in. `_attach_related_instance_id` only needs `pk`."""

--- a/lex/test_project/tests/calculation_logging/test_15a_builder_api.py
+++ b/lex/test_project/tests/calculation_logging/test_15a_builder_api.py
@@ -14,6 +14,10 @@ from lex.audit_logging.utils.ModelContext import model_logging_context
 from . import _CalcLogTestCase
 from .models import LogRootCalc
 
+import pytest
+
+pytestmark = pytest.mark.calculation_logging
+
 
 class TestCluster15a_BuilderAPI(_CalcLogTestCase):
     """LexLogger builder methods produce the right CalculationLog content."""

--- a/lex/test_project/tests/calculation_logging/test_15b_child_node_creation.py
+++ b/lex/test_project/tests/calculation_logging/test_15b_child_node_creation.py
@@ -11,6 +11,10 @@ from lex.audit_logging.models.CalculationLog import CalculationLog
 from . import _CalcLogTestCase
 from .models import LogLoudChild, LogRootCalc
 
+import pytest
+
+pytestmark = pytest.mark.calculation_logging
+
 
 class TestCluster15b_LoudChildren(_CalcLogTestCase):
     """Loud children produce a CalculationLog row each, all chaining

--- a/lex/test_project/tests/calculation_logging/test_15c_silent_and_mixed.py
+++ b/lex/test_project/tests/calculation_logging/test_15c_silent_and_mixed.py
@@ -13,6 +13,10 @@ from lex.audit_logging.models.CalculationLog import CalculationLog
 from . import _CalcLogTestCase
 from .models import LogLoudChild, LogRootCalc, LogSilentChild
 
+import pytest
+
+pytestmark = pytest.mark.calculation_logging
+
 
 class TestCluster15c_SilentAndMixed(_CalcLogTestCase):
     """Silent children produce no rows; mixed siblings produce exactly

--- a/lex/test_project/tests/calculation_logging/test_15d_three_level_chain.py
+++ b/lex/test_project/tests/calculation_logging/test_15d_three_level_chain.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 from . import _CalcLogTestCase
 from .models import LogGrandchildCalc, LogMiddleCombinatoric
 
+import pytest
+
+pytestmark = pytest.mark.calculation_logging
+
 
 class TestCluster15d_ThreeLevelChain(_CalcLogTestCase):
     """parent_log chains correctly across multiple hops."""

--- a/lex/test_project/tests/calculation_logging/test_15e_combinatorial_pipeline.py
+++ b/lex/test_project/tests/calculation_logging/test_15e_combinatorial_pipeline.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 from . import _CalcLogTestCase
 from .models import LogConditionalChild, LogLoudChild
 
+import pytest
+
+pytestmark = pytest.mark.calculation_logging
+
 
 class TestCluster15e_CombinatorialPipeline(_CalcLogTestCase):
     """Combinatorial expansion + per-instance row keying."""

--- a/lex/test_project/tests/calculation_logging/test_15f_save_boundary.py
+++ b/lex/test_project/tests/calculation_logging/test_15f_save_boundary.py
@@ -27,6 +27,10 @@ from .models import (
     LogMiddleSavedCalc,
 )
 
+import pytest
+
+pytestmark = pytest.mark.calculation_logging
+
 
 class TestCluster15f_HierarchyAcrossSave(_CalcLogTestCase):
     """parent_log chains correctly even when an inner CalculationModel

--- a/lex/test_project/tests/calculations/test_7a_atomic.py
+++ b/lex/test_project/tests/calculations/test_7a_atomic.py
@@ -25,6 +25,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, AtomicCalc, FailingCalc
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 class TestCluster07a_Atomic(E2ETestCase):
     """Atomic calculation state transitions."""

--- a/lex/test_project/tests/calculations/test_7b_non_atomic.py
+++ b/lex/test_project/tests/calculations/test_7b_non_atomic.py
@@ -22,6 +22,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, NonAtomicCalc
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 class TestCluster07b_NonAtomic(E2ETestCase):
     """Non-atomic calculation state transitions."""

--- a/lex/test_project/tests/calculations/test_7c_hierarchy.py
+++ b/lex/test_project/tests/calculations/test_7c_hierarchy.py
@@ -24,6 +24,10 @@ from .models import (
     NonAtomicParentCalc, ParentCalc,
 )
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 class TestCluster07c_Hierarchy(E2ETestCase):
     """Parent/child calculation propagation."""

--- a/lex/test_project/tests/calculations/test_7d_state_guards.py
+++ b/lex/test_project/tests/calculations/test_7d_state_guards.py
@@ -22,6 +22,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, FailingCalc
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 class TestCluster07d_StateGuards(E2ETestCase):
     """Idempotency and re-entrancy guards."""

--- a/lex/test_project/tests/calculations/test_7e_persistence_internals.py
+++ b/lex/test_project/tests/calculations/test_7e_persistence_internals.py
@@ -58,6 +58,10 @@ from .models import (
     PersistenceProbeCalc,
 )
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #  Helper-level safety-net tests (no DB needed — pure logic).

--- a/lex/test_project/tests/calculations/test_7f_combination_engine.py
+++ b/lex/test_project/tests/calculations/test_7f_combination_engine.py
@@ -51,6 +51,10 @@ from lex.core.mixins.CalculatedModelMixin import (
     _normalize_field_values,
 )
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 # --------------------------------------------------------------------
 # Lightweight fakes

--- a/lex/test_project/tests/calculations/test_7g_create_pipeline.py
+++ b/lex/test_project/tests/calculations/test_7g_create_pipeline.py
@@ -31,6 +31,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CombinatorialCalc
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 class TestCluster07g_CreatePipeline(E2ETestCase):
     """End-to-end ``create()`` pipeline on a non-atomic combinatorial model."""

--- a/lex/test_project/tests/calculations/test_7h_celery_dispatch.py
+++ b/lex/test_project/tests/calculations/test_7h_celery_dispatch.py
@@ -29,6 +29,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CombinatorialCalc
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 class TestCluster07h_CeleryDispatch(E2ETestCase):
     """Celery-branch dispatch of the ``create()`` pipeline."""

--- a/lex/test_project/tests/calculations/test_7i_atomicity_matrix.py
+++ b/lex/test_project/tests/calculations/test_7i_atomicity_matrix.py
@@ -41,6 +41,10 @@ from .models import (
     NonAtomicParentNonAtomicChildMatrixCalc,
 )
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 class TestCluster07i_AtomicityMatrix(E2ETestCase):
     """Exhaustive parent/child atomicity and failure propagation matrix."""

--- a/lex/test_project/tests/calculations/test_7j_three_level_matrix.py
+++ b/lex/test_project/tests/calculations/test_7j_three_level_matrix.py
@@ -57,6 +57,10 @@ from .models import (
     TRIPLE_CLASSES,
 )
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 # ---------------------------------------------------------------------
 # Per-(p_atomic, c_atomic) → (parent_cls, child_cls) lookup so the
 # test runner can fetch the persisted "middle" and "leaf" rows after

--- a/lex/test_project/tests/calculations/test_7k_exceptions_restrictions_xlsx.py
+++ b/lex/test_project/tests/calculations/test_7k_exceptions_restrictions_xlsx.py
@@ -68,6 +68,10 @@ from lex.core.mixins.ModelModificationRestriction import (
     ModelModificationRestriction,
 )
 
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 
 # ---------------------------------------------------------------------
 # 7.122–7.124 — small helpers

--- a/lex/test_project/tests/calculations/test_7l_recalc_queue.py
+++ b/lex/test_project/tests/calculations/test_7l_recalc_queue.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytestmark = pytest.mark.calculations
+
 # """
 # Cluster 7l: ``ObjectsToRecalculateStore`` + ``CalculatedModelUpdateHandler``.
 #

--- a/lex/test_project/tests/celery_async/test_8a_sync_fallback.py
+++ b/lex/test_project/tests/celery_async/test_8a_sync_fallback.py
@@ -24,6 +24,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CelerySyncCalc
 
+import pytest
+
+pytestmark = pytest.mark.celery_async
+
 
 class TestCluster08a_SyncFallback(E2ETestCase):
     """Synchronous fallback when Celery is off."""

--- a/lex/test_project/tests/celery_async/test_8b_dispatch_context.py
+++ b/lex/test_project/tests/celery_async/test_8b_dispatch_context.py
@@ -18,6 +18,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CeleryCalc, CelerySyncCalc
 
+import pytest
+
+pytestmark = pytest.mark.celery_async
+
 
 class TestCluster08b_DispatchContext(E2ETestCase):
     """8.5 / 8.6 — dispatch context and worker-recursion behavior."""

--- a/lex/test_project/tests/celery_async/test_8g_task_infrastructure.py
+++ b/lex/test_project/tests/celery_async/test_8g_task_infrastructure.py
@@ -69,6 +69,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CeleryCalc
 
+import pytest
+
+pytestmark = pytest.mark.celery_async
+
 
 def _reset_ctx():
     """Reset the module-level ContextVars so each scenario starts clean."""

--- a/lex/test_project/tests/celery_async/test_8h_eager_end_to_end.py
+++ b/lex/test_project/tests/celery_async/test_8h_eager_end_to_end.py
@@ -71,6 +71,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CeleryCalc
 
+import pytest
+
+pytestmark = pytest.mark.celery_async
+
 
 # ---------------------------------------------------------------------
 # Shared eager-mode fixture

--- a/lex/test_project/tests/celery_async/test_8i_scope_contracts.py
+++ b/lex/test_project/tests/celery_async/test_8i_scope_contracts.py
@@ -58,6 +58,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CeleryCalc
 
+import pytest
+
+pytestmark = pytest.mark.celery_async
+
 
 # ---------------------------------------------------------------------
 # Shared fixture — eager Celery + clean ContextVars

--- a/lex/test_project/tests/celery_async/test_8j_task_bodies.py
+++ b/lex/test_project/tests/celery_async/test_8j_task_bodies.py
@@ -53,6 +53,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CelerySyncCalc
 
+import pytest
+
+pytestmark = pytest.mark.celery_async
+
 
 # ════════════════════════════════════════════════════════════════════════
 # 8.31 – 8.35: load_data

--- a/lex/test_project/tests/celery_async/test_8k_redis_broker_integration.py
+++ b/lex/test_project/tests/celery_async/test_8k_redis_broker_integration.py
@@ -45,6 +45,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, CeleryCalc
 
+import pytest
+
+pytestmark = pytest.mark.celery_async
+
 
 RUN_ENV = "LEX_RUN_REDIS_CELERY_TESTS"
 REDIS_URL_ENV = "LEX_CELERY_REDIS_TEST_URL"

--- a/lex/test_project/tests/celery_async/test_8l_celery_dispatcher.py
+++ b/lex/test_project/tests/celery_async/test_8l_celery_dispatcher.py
@@ -37,6 +37,10 @@ from django.test import SimpleTestCase
 from lex.core.exceptions import CeleryDispatchError
 from lex.core.tasks.CeleryTaskDispatcher import CeleryTaskDispatcher
 
+import pytest
+
+pytestmark = pytest.mark.celery_async
+
 
 # ----------------------------------------------------------------------
 # Helpers

--- a/lex/test_project/tests/crud_api/test_2a_create.py
+++ b/lex/test_project/tests/crud_api/test_2a_create.py
@@ -21,6 +21,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.crud_api
+
 
 class TestCluster02a_Create(E2ETestCase):
     """POST /api/<model>/create/"""

--- a/lex/test_project/tests/crud_api/test_2b_read.py
+++ b/lex/test_project/tests/crud_api/test_2b_read.py
@@ -19,6 +19,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.crud_api
+
 
 class TestCluster02b_Read(E2ETestCase):
     """GET detail + list endpoints."""

--- a/lex/test_project/tests/crud_api/test_2c_update.py
+++ b/lex/test_project/tests/crud_api/test_2c_update.py
@@ -20,6 +20,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.crud_api
+
 
 class TestCluster02c_Update(E2ETestCase):
     """PATCH / PUT /api/<model>/<pk>/"""

--- a/lex/test_project/tests/crud_api/test_2d_delete.py
+++ b/lex/test_project/tests/crud_api/test_2d_delete.py
@@ -20,6 +20,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.crud_api
+
 
 class TestCluster02d_Delete(E2ETestCase):
     """DELETE /api/<model>/<pk>/"""

--- a/lex/test_project/tests/crud_api/test_2e_bulk.py
+++ b/lex/test_project/tests/crud_api/test_2e_bulk.py
@@ -20,6 +20,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.crud_api
+
 
 class TestCluster02e_BulkOperations(E2ETestCase):
     """DELETE-only bulk write contract for the ``many/`` endpoint."""

--- a/lex/test_project/tests/crud_api/test_2f_missing_scenarios.py
+++ b/lex/test_project/tests/crud_api/test_2f_missing_scenarios.py
@@ -22,6 +22,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.crud_api
+
 
 class TestCluster02f_MissingScenarios(E2ETestCase):
     """The final non-bulk scenarios required for Cluster 2 to reach 🟢."""

--- a/lex/test_project/tests/crud_api/test_2f_ordering.py
+++ b/lex/test_project/tests/crud_api/test_2f_ordering.py
@@ -22,6 +22,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.crud_api
+
 
 class TestCluster02f_Ordering(E2ETestCase):
     """``?ordering=`` contract."""

--- a/lex/test_project/tests/crud_api/test_2g_filtering.py
+++ b/lex/test_project/tests/crud_api/test_2g_filtering.py
@@ -26,6 +26,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, SIMPLE, SimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.crud_api
+
 
 class TestCluster02g_Filtering(E2ETestCase):
     """Query-param filtering contract on the list endpoint."""

--- a/lex/test_project/tests/exports/test_13a_legacy_export.py
+++ b/lex/test_project/tests/exports/test_13a_legacy_export.py
@@ -40,6 +40,10 @@ from .models import (
     ExportMaskedItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.exports
+
 
 def _read_xlsx_response(resp) -> pd.DataFrame:
     """Collect ``FileResponse`` streaming bytes → DataFrame.

--- a/lex/test_project/tests/exports/test_13b_ag_grid_export.py
+++ b/lex/test_project/tests/exports/test_13b_ag_grid_export.py
@@ -44,6 +44,10 @@ from .models import (
 )
 from .test_13a_legacy_export import _assert_msg, _read_xlsx_response
 
+import pytest
+
+pytestmark = pytest.mark.exports
+
 
 def _ag_flat_payload(columns: list[dict]) -> dict:
     """Minimal AG payload for a flat (non-grouped) export."""

--- a/lex/test_project/tests/exports/test_13c_grouped_selected.py
+++ b/lex/test_project/tests/exports/test_13c_grouped_selected.py
@@ -35,6 +35,10 @@ from .models import (
 )
 from .test_13a_legacy_export import _assert_msg, _read_xlsx_response
 
+import pytest
+
+pytestmark = pytest.mark.exports
+
 
 def _grouped_payload(group_key_paths):
     """Return an AG payload with a single ``rowGroupCols=[category]``

--- a/lex/test_project/tests/exports/test_13d_auth_edge.py
+++ b/lex/test_project/tests/exports/test_13d_auth_edge.py
@@ -33,6 +33,10 @@ from .models import (
 )
 from .test_13a_legacy_export import _assert_msg, _read_xlsx_response
 
+import pytest
+
+pytestmark = pytest.mark.exports
+
 
 class TestCluster13d_AuthAndFieldMask(E2ETestCase):
     """Auth gate (13.11) + non-uniform per-row export mask (13.12)."""

--- a/lex/test_project/tests/exports/test_13e_streaming_fast_export.py
+++ b/lex/test_project/tests/exports/test_13e_streaming_fast_export.py
@@ -53,6 +53,10 @@ from .models import (
 )
 from .test_13a_legacy_export import _assert_msg
 
+import pytest
+
+pytestmark = pytest.mark.exports
+
 
 def _read_xlsx_stream(resp) -> pd.DataFrame:
     """Read an xlsx produced by the **streaming** export paths.

--- a/lex/test_project/tests/history/test_5_11_fallback_snapshot.py
+++ b/lex/test_project/tests/history/test_5_11_fallback_snapshot.py
@@ -46,6 +46,10 @@ import unittest
 from django.test import SimpleTestCase
 from lex.api.views.model_entries.History import HistoryModelEntry
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 class _FakeField:
     """Minimal stand-in for ``Field`` — ``_get_snapshot`` only reads

--- a/lex/test_project/tests/history/test_5a_basic_history.py
+++ b/lex/test_project/tests/history/test_5a_basic_history.py
@@ -21,6 +21,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, HistSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 class TestCluster05a_BasicHistory(E2ETestCase):
     """Basic history trail contract."""

--- a/lex/test_project/tests/history/test_5b_calculation_history.py
+++ b/lex/test_project/tests/history/test_5b_calculation_history.py
@@ -30,6 +30,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, HistAtomicCalc
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 class TestCluster05b_CalculationHistory(E2ETestCase):
     """Calculation lifecycle produces a full history trail."""

--- a/lex/test_project/tests/history/test_5c_history_api.py
+++ b/lex/test_project/tests/history/test_5c_history_api.py
@@ -20,6 +20,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, HIST_SIMPLE, HistSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 class TestCluster05c_HistoryAPI(E2ETestCase):
     """History endpoint contract."""

--- a/lex/test_project/tests/history/test_5g_valid_to_chaining.py
+++ b/lex/test_project/tests/history/test_5g_valid_to_chaining.py
@@ -23,6 +23,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, HistSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 class TestCluster05g_ValidToChaining(E2ETestCase):
     """``valid_to`` of row N must equal ``valid_from`` of row N+1."""

--- a/lex/test_project/tests/history/test_5h_suppression_toolkit.py
+++ b/lex/test_project/tests/history/test_5h_suppression_toolkit.py
@@ -25,6 +25,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, HistSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 class TestCluster05h_SuppressionToolkit(E2ETestCase):
     """The four documented knobs beyond ``skip_history_when_saving``."""

--- a/lex/test_project/tests/history/test_5i_api_contract.py
+++ b/lex/test_project/tests/history/test_5i_api_contract.py
@@ -37,6 +37,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, HIST_SIMPLE, HistSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 def _meta_history_wired_for_hist_simple() -> bool:
     """Probe whether ``HistSimpleItem`` has a *real* L2 manager attached.

--- a/lex/test_project/tests/history/test_5j_snapshot_actor.py
+++ b/lex/test_project/tests/history/test_5j_snapshot_actor.py
@@ -23,6 +23,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, HIST_SIMPLE, HistSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 class TestCluster05j_SnapshotAndActor(E2ETestCase):
     """Snapshot completeness + ``history_user`` stamping."""

--- a/lex/test_project/tests/history/test_5k_metahistory.py
+++ b/lex/test_project/tests/history/test_5k_metahistory.py
@@ -28,6 +28,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, HistSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 def _meta_model_for(model_class):
     """Resolve ``MetaHistorical<Model>``. The ``meta_history`` manager

--- a/lex/test_project/tests/history/test_5l_future_valid_from.py
+++ b/lex/test_project/tests/history/test_5l_future_valid_from.py
@@ -51,6 +51,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, HistSimpleItem
 
+import pytest
+
+pytestmark = pytest.mark.history
+
 
 def _l2_wired() -> bool:
     """L2 (MetaHistorical) is wired on the *historical* model — probe at

--- a/lex/test_project/tests/init/initial_data/test_1c_initial_data.py
+++ b/lex/test_project/tests/init/initial_data/test_1c_initial_data.py
@@ -27,6 +27,10 @@ import unittest
 from pathlib import Path
 from unittest import TestCase
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 # Seed file is at tests/fixtures/test_seed.json — two levels up from
 # this file (we live in tests/init/initial_data/).
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures"

--- a/lex/test_project/tests/init/initial_data/test_1f_seed_idempotency.py
+++ b/lex/test_project/tests/init/initial_data/test_1f_seed_idempotency.py
@@ -37,6 +37,10 @@ from lex.lex_app.tests.ProcessAdminTestCase import ProcessAdminTestCase
 from lex.test_project.tests.crud_api.models import SimpleItem
 from lex.tests.e2e._e2e_test_case import E2ETestCase
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures"
 
 

--- a/lex/test_project/tests/init/initial_data/test_1i_initial_data_journey.py
+++ b/lex/test_project/tests/init/initial_data/test_1i_initial_data_journey.py
@@ -57,6 +57,10 @@ from lex.lex_app.tests.ProcessAdminTestCase import ProcessAdminTestCase
 from lex.test_project.tests.crud_api.models import SimpleItem
 from lex.tests.e2e._e2e_test_case import E2ETestCase
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 FIXTURES = Path(__file__).resolve().parent.parent.parent / "fixtures"
 
 

--- a/lex/test_project/tests/init/test_1a_lex_setup.py
+++ b/lex/test_project/tests/init/test_1a_lex_setup.py
@@ -25,6 +25,10 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 class TestCluster01a_LexSetup(TestCase):
     """``lex setup`` — pure scaffolding, no Django required."""

--- a/lex/test_project/tests/init/test_1b_default_authz.py
+++ b/lex/test_project/tests/init/test_1b_default_authz.py
@@ -23,6 +23,10 @@ from __future__ import annotations
 import unittest
 from unittest import TestCase
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 class TestCluster01b_DefaultAuthzContract(TestCase):
     """Published defaults must not drift silently."""

--- a/lex/test_project/tests/init/test_1b_lex_init.py
+++ b/lex/test_project/tests/init/test_1b_lex_init.py
@@ -26,6 +26,10 @@ from io import StringIO
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 class TestCluster01b_LexInit(TestCase):
     """Handler-level tests for ``lex Init``."""

--- a/lex/test_project/tests/init/test_1d_init_helpers.py
+++ b/lex/test_project/tests/init/test_1d_init_helpers.py
@@ -45,6 +45,10 @@ from lex.lex_app.management.commands.init import (
     update_env_file,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 # ---------------------------------------------------------------------
 # Helpers

--- a/lex/test_project/tests/init/test_1e_keycloak_sync_manager.py
+++ b/lex/test_project/tests/init/test_1e_keycloak_sync_manager.py
@@ -37,6 +37,10 @@ from lex.lex_app.management.commands.init import (
     KeycloakSyncManager,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 # ---------------------------------------------------------------------
 # Fixture: a KeycloakSyncManager whose kc_manager is a MagicMock.

--- a/lex/test_project/tests/init/test_1f_keycloak_drift.py
+++ b/lex/test_project/tests/init/test_1f_keycloak_drift.py
@@ -38,6 +38,10 @@ from lex.lex_app.management.commands.init import (
     set_state,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 # ---------------------------------------------------------------------
 # Fixture — a KeycloakSyncManager with every external boundary stubbed.

--- a/lex/test_project/tests/init/test_1g_sync_manager_admin.py
+++ b/lex/test_project/tests/init/test_1g_sync_manager_admin.py
@@ -46,6 +46,10 @@ from lex.lex_app.management.commands.init import (
     KeycloakSyncManager,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 def _make_sync_manager(client_uuid: str = "test-client-uuid"):
     """Match the 1e fixture — bypass ``__init__``, stub kc_manager."""

--- a/lex/test_project/tests/init/test_1h_bootstrap_flow.py
+++ b/lex/test_project/tests/init/test_1h_bootstrap_flow.py
@@ -43,6 +43,10 @@ from lex.lex_app.management.commands.init import (
     wait_for_keycloak_setup_v2,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 def _http_response(status_code=200, json_body=None, raise_for_status=False, text=""):
     """Build a ``requests``-shaped response stand-in."""

--- a/lex/test_project/tests/init/test_1j_client_preflight.py
+++ b/lex/test_project/tests/init/test_1j_client_preflight.py
@@ -45,6 +45,10 @@ from lex.lex_app.management.commands.init import (
     _redirect_uris_indicate_development,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 # ---------------------------------------------------------------------
 # Fixtures (same shape as 1e / 1g): bypass __init__ + stub kc_manager.
 # ---------------------------------------------------------------------

--- a/lex/test_project/tests/init/test_1k_client_preflight_integration.py
+++ b/lex/test_project/tests/init/test_1k_client_preflight_integration.py
@@ -73,6 +73,10 @@ from lex.lex_app.management.commands.init import (
     _redirect_uris_indicate_development,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 def _resolve_integration_env_file() -> Path | None:
     """Resolve the ``.env`` to source for Keycloak integration tests.

--- a/lex/test_project/tests/init/test_1l_full_pipeline_integration.py
+++ b/lex/test_project/tests/init/test_1l_full_pipeline_integration.py
@@ -93,6 +93,10 @@ from lex.lex_app.management.commands.init import (
     KeycloakSyncManager,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 def _resolve_integration_env_file() -> Path | None:
     """Resolve the ``.env`` to source for Keycloak integration tests.

--- a/lex/test_project/tests/init/test_1m_cli_commands.py
+++ b/lex/test_project/tests/init/test_1m_cli_commands.py
@@ -53,6 +53,10 @@ from click.testing import CliRunner
 from generate_pycharm_configs import generate_pycharm_configs
 from lex.bin.lex import _SKIP_BOOTSTRAP_COMMANDS, lex
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 # ---------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------

--- a/lex/test_project/tests/init/test_1n_init_helper_paths.py
+++ b/lex/test_project/tests/init/test_1n_init_helper_paths.py
@@ -38,6 +38,10 @@ from lex.lex_app.management.commands.init import (
     _is_non_fatal_keycloak_import_timeout,
 )
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 class TestCluster01n_KeycloakErrorFormatter(SimpleTestCase):
     """``_format_keycloak_import_error_details`` shapes operator logs."""

--- a/lex/test_project/tests/init/test_1o_lazy_imports_and_helpers.py
+++ b/lex/test_project/tests/init/test_1o_lazy_imports_and_helpers.py
@@ -46,6 +46,10 @@ import types
 import unittest
 from unittest import TestCase
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 # ---------------------------------------------------------------------
 # 1.110–1.118 — process_admin lazy __getattr__
 # ---------------------------------------------------------------------

--- a/lex/test_project/tests/init/test_1p_settings_urls_views.py
+++ b/lex/test_project/tests/init/test_1p_settings_urls_views.py
@@ -54,6 +54,10 @@ from unittest import TestCase, mock
 from django.test import Client
 from django.urls import reverse, NoReverseMatch
 
+import pytest
+
+pytestmark = pytest.mark.init
+
 
 # ---------------------------------------------------------------------
 # 1.125–1.130 — settings.py constants

--- a/lex/test_project/tests/journeys/test_journey_a_invoice_lifecycle.py
+++ b/lex/test_project/tests/journeys/test_journey_a_invoice_lifecycle.py
@@ -33,6 +33,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, INVOICE, Invoice
 
+import pytest
+
+pytestmark = pytest.mark.journeys
+
 
 class TestJourneyA_InvoiceLifecycle_Admin(AuthenticatedE2ETestCase):
     """Admin walks an invoice through create → update → delete."""

--- a/lex/test_project/tests/journeys/test_journey_b_portfolio_calculation.py
+++ b/lex/test_project/tests/journeys/test_journey_b_portfolio_calculation.py
@@ -29,6 +29,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, JourneyPortfolio, JourneyPosition
 
+import pytest
+
+pytestmark = pytest.mark.journeys
+
 
 class TestJourneyB_PortfolioCalculation(E2ETestCase):
     """Parent/child calculation, happy path + failure + recovery."""

--- a/lex/test_project/tests/journeys/test_journey_c_role_aware_visibility.py
+++ b/lex/test_project/tests/journeys/test_journey_c_role_aware_visibility.py
@@ -29,6 +29,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, EMPLOYEE, Employee
 
+import pytest
+
+pytestmark = pytest.mark.journeys
+
 
 class TestJourneyC_EmployeeVisibility_Superuser(AuthenticatedE2ETestCase):
     """Superuser sees every field on list + detail."""

--- a/lex/test_project/tests/journeys/test_journey_d_audit_trail.py
+++ b/lex/test_project/tests/journeys/test_journey_d_audit_trail.py
@@ -33,6 +33,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, INVOICE, Invoice
 
+import pytest
+
+pytestmark = pytest.mark.journeys
+
 
 class TestJourneyD_AuditTrail(AuthenticatedE2ETestCase):
     """Admin walks an invoice through its lifecycle, then audits the trail."""

--- a/lex/test_project/tests/journeys/test_journey_e_validation_gate.py
+++ b/lex/test_project/tests/journeys/test_journey_e_validation_gate.py
@@ -32,6 +32,10 @@ from lex.tests.e2e._authenticated_e2e_test_case import AuthenticatedE2ETestCase
 
 from .models import ALL_MODELS, VALIDATED_INVOICE, ValidatedInvoice
 
+import pytest
+
+pytestmark = pytest.mark.journeys
+
 
 class TestJourneyE_ValidationGate(AuthenticatedE2ETestCase):
     """Customer API pushes a mix of valid/invalid records; gates must hold."""

--- a/lex/test_project/tests/permissions/test_4a_field_level.py
+++ b/lex/test_project/tests/permissions/test_4a_field_level.py
@@ -36,6 +36,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, FIELD_LEVEL, FieldLevelItem
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 class TestCluster04a_FieldLevel_Superuser(AuthenticatedE2ETestCase):
     """Superuser sees every field."""

--- a/lex/test_project/tests/permissions/test_4b_action_level.py
+++ b/lex/test_project/tests/permissions/test_4b_action_level.py
@@ -24,6 +24,10 @@ from rest_framework import status
 
 from .models import ALL_MODELS, PROTECTED, ProtectedItem
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 class TestCluster04b_ActionLevel(E2ETestCase):
     """Action-level permission contract — non-admin caller."""

--- a/lex/test_project/tests/permissions/test_4c_keycloak_fallback.py
+++ b/lex/test_project/tests/permissions/test_4c_keycloak_fallback.py
@@ -28,6 +28,10 @@ from lex.tests.e2e._authenticated_e2e_test_case import AuthenticatedE2ETestCase
 
 from .models import ALL_MODELS, KeycloakItem
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 def _make_uc(user, *, scopes=frozenset()) -> UserContext:
     """Build a UserContext matching what middleware would produce."""

--- a/lex/test_project/tests/permissions/test_4d_user_context.py
+++ b/lex/test_project/tests/permissions/test_4d_user_context.py
@@ -26,6 +26,10 @@ from django.contrib.auth.models import AnonymousUser, User
 from django.test import RequestFactory, TestCase
 from lex.core.models.LexModel import UserContext
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 class TestCluster04d_UserContext(TestCase):
     """UserContext.from_request / from_request_base contract."""

--- a/lex/test_project/tests/permissions/test_4e_filter_backend.py
+++ b/lex/test_project/tests/permissions/test_4e_filter_backend.py
@@ -38,6 +38,10 @@ from .models import (
     FilterBackendItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 def _seed_mixed_rows() -> None:
     """Create four rows: two public, two secret."""

--- a/lex/test_project/tests/permissions/test_4f_serializer_mixin.py
+++ b/lex/test_project/tests/permissions/test_4f_serializer_mixin.py
@@ -58,6 +58,10 @@ from rest_framework.test import APIRequestFactory
 
 from .models import FieldLevelItem, ProtectedItem
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 # --------------------------------------------------------------------
 # 4.19 — camelCase → snake_case translation

--- a/lex/test_project/tests/permissions/test_4g_user_permissions_api.py
+++ b/lex/test_project/tests/permissions/test_4g_user_permissions_api.py
@@ -53,6 +53,10 @@ from lex.api.middleware.keycloak_permissions import (
 from lex.api.utils import helpers as api_helpers
 from lex.core.models.LexModel import LexModel
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 def _with_default_permission_read(model_cls):
     """Temporarily swap a model's ``permission_read`` back to the

--- a/lex/test_project/tests/permissions/test_4h_full_deny_matrix.py
+++ b/lex/test_project/tests/permissions/test_4h_full_deny_matrix.py
@@ -43,6 +43,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, EXPORT_DENIED, ExportDeniedItem
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 def _read_xlsx_response(resp) -> pd.DataFrame:
     """Collect a ``FileResponse`` into a DataFrame.

--- a/lex/test_project/tests/permissions/test_4i_permission_helpers.py
+++ b/lex/test_project/tests/permissions/test_4i_permission_helpers.py
@@ -57,6 +57,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, FieldLevelItem, OwnedItem, ProtectedItem
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #  Helpers — UserContext factories

--- a/lex/test_project/tests/permissions/test_4j_filter_backends.py
+++ b/lex/test_project/tests/permissions/test_4j_filter_backends.py
@@ -67,6 +67,10 @@ from lex.api.views.model_entries.filter_backends import (
     UserReadRestrictionFilterBackend,
 )
 
+import pytest
+
+pytestmark = pytest.mark.permissions
+
 
 # ---------------------------------------------------------------------------
 # Shared test helpers

--- a/lex/test_project/tests/queries/test_14a_query_params.py
+++ b/lex/test_project/tests/queries/test_14a_query_params.py
@@ -40,6 +40,10 @@ from .models import (
     QueryItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.queries
+
 
 class TestCluster14a_QueryParamFilters(E2ETestCase):
     """``GET /api/model_entries/queryitem/list?...`` — query-param filtering."""

--- a/lex/test_project/tests/queries/test_14b_ag_post_filter_model.py
+++ b/lex/test_project/tests/queries/test_14b_ag_post_filter_model.py
@@ -41,6 +41,10 @@ from .models import (
     QueryItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.queries
+
 
 def _base_ag_request(**overrides) -> dict:
     """Minimal AG Grid request body — override any subset of keys."""

--- a/lex/test_project/tests/queries/test_14c_ag_post_group_pivot.py
+++ b/lex/test_project/tests/queries/test_14c_ag_post_group_pivot.py
@@ -38,6 +38,10 @@ from .models import (
     QueryItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.queries
+
 
 def _ag(**overrides) -> dict:
     req = {

--- a/lex/test_project/tests/queries/test_14e_secondary_branches.py
+++ b/lex/test_project/tests/queries/test_14e_secondary_branches.py
@@ -50,6 +50,10 @@ from .models import (
     QueryItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.queries
+
 
 def _base_ag_request(**overrides) -> dict:
     req = {

--- a/lex/test_project/tests/queries/test_14h_list_query_paths.py
+++ b/lex/test_project/tests/queries/test_14h_list_query_paths.py
@@ -37,6 +37,10 @@ from .models import (
     QueryItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.queries
+
 
 class TestCluster14h_ListQueryPaths(E2ETestCase):
     """List endpoint multi-feature combinations."""

--- a/lex/test_project/tests/serializers/test_12a_history_meta_scopes.py
+++ b/lex/test_project/tests/serializers/test_12a_history_meta_scopes.py
@@ -31,6 +31,10 @@ from .models import (
     ProtectedWideItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.serializers
+
 
 class TestCluster12a_HistoryMetaScopes(E2ETestCase):
     """History-snapshot & MetaHistory / edit-scope shape."""

--- a/lex/test_project/tests/serializers/test_12a_read_contract.py
+++ b/lex/test_project/tests/serializers/test_12a_read_contract.py
@@ -33,6 +33,10 @@ from .models import (
     WideItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.serializers
+
 FRAMEWORK_KEYS = {"id", "id_field", "short_description", "lex_reserved_scopes"}
 
 

--- a/lex/test_project/tests/serializers/test_12b_type_roundtrip.py
+++ b/lex/test_project/tests/serializers/test_12b_type_roundtrip.py
@@ -29,6 +29,10 @@ from .models import (
     WideItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.serializers
+
 
 class TestCluster12b_TypeRoundTrip(E2ETestCase):
     """One field per type — POST → GET round-trip fidelity."""

--- a/lex/test_project/tests/serializers/test_12c_list_and_many.py
+++ b/lex/test_project/tests/serializers/test_12c_list_and_many.py
@@ -29,6 +29,10 @@ from .models import (
     WideItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.serializers
+
 # Framework-managed keys every serialized row carries (mirrors 12a).
 FRAMEWORK_KEYS = {"id", "id_field", "short_description", "lex_reserved_scopes"}
 

--- a/lex/test_project/tests/serializers/test_12d_audit_log_payload.py
+++ b/lex/test_project/tests/serializers/test_12d_audit_log_payload.py
@@ -42,6 +42,10 @@ from rest_framework.test import APIRequestFactory
 
 from .models import ALL_MODELS, ProtectedWideItem, RelatedItem, WideItem
 
+import pytest
+
+pytestmark = pytest.mark.serializers
+
 
 class TestCluster12d_AuditLogPayloadFiltering(E2ETestCase):
     """Serialize an AuditLog row as a non-admin — assert payload is filtered.

--- a/lex/test_project/tests/serializers/test_12e_factory.py
+++ b/lex/test_project/tests/serializers/test_12e_factory.py
@@ -40,6 +40,10 @@ from rest_framework import serializers as drf_serializers
 
 from .models import WideItem
 
+import pytest
+
+pytestmark = pytest.mark.serializers
+
 FRAMEWORK_INTERNALS = {ID_FIELD_NAME, SHORT_DESCR_NAME, LEX_SCOPES_NAME, "id"}
 
 

--- a/lex/test_project/tests/serializers/test_12f_write_paths.py
+++ b/lex/test_project/tests/serializers/test_12f_write_paths.py
@@ -41,6 +41,10 @@ from .models import (
     TaggableItem,
 )
 
+import pytest
+
+pytestmark = pytest.mark.serializers
+
 
 class TestCluster12f_WritePaths(E2ETestCase):
     """``/api/<model>/create/`` + ``/api/<model>/<pk>/`` for M2M + FK."""

--- a/lex/test_project/tests/signals_ws/test_9_7_suppression_guards.py
+++ b/lex/test_project/tests/signals_ws/test_9_7_suppression_guards.py
@@ -46,6 +46,10 @@ from lex.core.services.bitemporal_signals import (
     suppress_meta_sys_to_chaining,
 )
 
+import pytest
+
+pytestmark = pytest.mark.signals_ws
+
 
 class TestCluster09_SuppressionGuards(SimpleTestCase):
     """Unit contract for the three bitemporal suppression guards."""

--- a/lex/test_project/tests/signals_ws/test_9a_state_and_broadcast.py
+++ b/lex/test_project/tests/signals_ws/test_9a_state_and_broadcast.py
@@ -19,6 +19,10 @@ from lex.core.models.CalculationModel import CalculationModel
 from lex.core.signals.ActiveCalculationStateStore import ActiveCalculationStateStore
 from lex.core.signals.CalculationSignals import update_calculation_status
 
+import pytest
+
+pytestmark = pytest.mark.signals_ws
+
 
 class DummySignalCalc(CalculationModel):
     """Unmanaged calculation model sufficient for signal-level tests."""

--- a/lex/test_project/tests/signals_ws/test_9c_cache_cleanup.py
+++ b/lex/test_project/tests/signals_ws/test_9c_cache_cleanup.py
@@ -28,6 +28,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, SigAtomicCalc
 
+import pytest
+
+pytestmark = pytest.mark.signals_ws
+
 
 class TestCluster09c_CacheCleanup(E2ETestCase):
     """CacheManager.cleanup_calculation root-vs-child discipline."""

--- a/lex/test_project/tests/signals_ws/test_9d_active_calculation_state_store.py
+++ b/lex/test_project/tests/signals_ws/test_9d_active_calculation_state_store.py
@@ -40,6 +40,10 @@ from lex.core.signals.ActiveCalculationStateStore import (
     ActiveCalculationStateStore,
 )
 
+import pytest
+
+pytestmark = pytest.mark.signals_ws
+
 
 class FakeCalcModel9d(CalculationModel):
     """Unmanaged ``CalculationModel`` subclass for resolver tests."""

--- a/lex/test_project/tests/stress/test_11a_seed_baseline.py
+++ b/lex/test_project/tests/stress/test_11a_seed_baseline.py
@@ -20,6 +20,10 @@ from .models import (
     ALL_MODELS, StressCounterparty, StressInvoice, StressPeriod,
 )
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 
 class TestCluster11a_SeedBaseline(StressTestCase):
     """11.1 / 11.2 — insertion paths at volume."""

--- a/lex/test_project/tests/stress/test_11b_list.py
+++ b/lex/test_project/tests/stress/test_11b_list.py
@@ -18,6 +18,10 @@ from django.db import connection
 from ._stress_test_case import StressTestCase
 from .models import ALL_MODELS, INVOICE, StressInvoice
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 
 class TestCluster11b_ListEndpoint(StressTestCase):
     """11.3 / 11.4 — paginated reads + filtered sorts at volume."""

--- a/lex/test_project/tests/stress/test_11c_export.py
+++ b/lex/test_project/tests/stress/test_11c_export.py
@@ -22,6 +22,10 @@ import io
 from ._stress_test_case import StressTestCase
 from .models import ALL_MODELS, INVOICE, StressInvoice
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 
 class TestCluster11c_Export(StressTestCase):
     """11.5 / 11.6 — bulk export."""

--- a/lex/test_project/tests/stress/test_11d_period_calc.py
+++ b/lex/test_project/tests/stress/test_11d_period_calc.py
@@ -30,6 +30,10 @@ from .models import (
     StressInvoice, StressPeriod,
 )
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 
 class TestCluster11d_PeriodCalculations(StressTestCase):
     """11.7 / 11.8 / 11.9 — period aggregation and dependency chain."""

--- a/lex/test_project/tests/stress/test_11e_bulk_api.py
+++ b/lex/test_project/tests/stress/test_11e_bulk_api.py
@@ -19,6 +19,10 @@ from rest_framework import status
 from ._stress_test_case import StressTestCase
 from .models import ALL_MODELS, INVOICE, StressInvoice
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 
 class TestCluster11e_BulkAPI(StressTestCase):
     """11.10 / 11.11 — supported bulk delete + ORM update baseline."""

--- a/lex/test_project/tests/stress/test_11f_growth_and_scale.py
+++ b/lex/test_project/tests/stress/test_11f_growth_and_scale.py
@@ -27,6 +27,10 @@ from lex.core.models.LexModel import PermissionResult
 from ._stress_test_case import StressTestCase
 from .models import ALL_MODELS, INVOICE, StressInvoice
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 
 class TestCluster11f_Concurrency(StressTestCase):
     """11.12 — concurrent writes."""

--- a/lex/test_project/tests/stress/test_11g_fk_heavy_export.py
+++ b/lex/test_project/tests/stress/test_11g_fk_heavy_export.py
@@ -60,6 +60,10 @@ from .models import (
     FK_HEAVY_MODELS, StressCounterparty, StressPeriod,
 )
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 # Row counts per volume tier. The point of this cluster is FK fan-out
 # at volume; 25k is the target. SMALL scales to 2.5k so local /
 # PR runs stay under a minute without losing the N+1 signal.

--- a/lex/test_project/tests/stress/test_11h_calc_log_overhead.py
+++ b/lex/test_project/tests/stress/test_11h_calc_log_overhead.py
@@ -47,6 +47,10 @@ from lex.audit_logging.models.CalculationLog import CalculationLog
 from ._stress_test_case import StressTestCase
 from .models import ALL_MODELS
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 
 class TestCluster11h_CalculationLogOverhead(StressTestCase):
     """11.22 — CalculationLog.log per-call cost, live pipeline vs no-op."""

--- a/lex/test_project/tests/stress/test_11i_save_fingerprint.py
+++ b/lex/test_project/tests/stress/test_11i_save_fingerprint.py
@@ -44,6 +44,10 @@ from .models import (
     ALL_MODELS, StressCounterparty, StressInvoice, StressPeriod,
 )
 
+import pytest
+
+pytestmark = pytest.mark.stress
+
 
 class TestCluster11i_SaveSqlFingerprint(StressTestCase):
     """Pin down which SQL statements ``LexModel.save()`` actually runs."""

--- a/lex/test_project/tests/validation_hooks/test_3a_pre_validation.py
+++ b/lex/test_project/tests/validation_hooks/test_3a_pre_validation.py
@@ -22,6 +22,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, PreValidatedItem
 
+import pytest
+
+pytestmark = pytest.mark.validation_hooks
+
 
 class TestCluster03a_PreValidation(E2ETestCase):
     """pre_validation cancels the save."""

--- a/lex/test_project/tests/validation_hooks/test_3b_post_validation.py
+++ b/lex/test_project/tests/validation_hooks/test_3b_post_validation.py
@@ -23,6 +23,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, PostValidatedItem
 
+import pytest
+
+pytestmark = pytest.mark.validation_hooks
+
 
 class TestCluster03b_PostValidation(E2ETestCase):
     """post_validation rollback semantics."""

--- a/lex/test_project/tests/validation_hooks/test_3c_hook_ordering.py
+++ b/lex/test_project/tests/validation_hooks/test_3c_hook_ordering.py
@@ -23,6 +23,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, HookOrderItem
 
+import pytest
+
+pytestmark = pytest.mark.validation_hooks
+
 
 class TestCluster03c_HookOrdering(E2ETestCase):
     """Standard lifecycle hook ordering."""

--- a/lex/test_project/tests/validation_hooks/test_3d_recursion_guard.py
+++ b/lex/test_project/tests/validation_hooks/test_3d_recursion_guard.py
@@ -21,6 +21,10 @@ from lex.tests.e2e._e2e_test_case import E2ETestCase
 
 from .models import ALL_MODELS, PostValidatedItem
 
+import pytest
+
+pytestmark = pytest.mark.validation_hooks
+
 
 class TestCluster03d_RecursionGuard(E2ETestCase):
     """The recursion guard must hold."""

--- a/lex_test_config.yaml
+++ b/lex_test_config.yaml
@@ -1,0 +1,40 @@
+# Lex test-group configuration — single source of truth for `python -m lex pytest`.
+# Loaded by lex/tools/test_groups.py at project_root.
+
+tests_entrypoint: lex/test_project/tests
+
+# Recipients are intentionally empty for now. The reporting/email surface is
+# implemented in test_groups.py but not yet turned on. When stakeholders are
+# decided, populate this list and per-group receivers below.
+receivers: []
+
+report:
+  output_dir: reports
+
+email:
+  from_email: "noreply@example.com"
+  from_name: "Lex Reports"
+  reply_to: "noreply@example.com"
+  subject_prefix: "Lex test report"
+
+# Group names match the cluster folder names under lex/test_project/tests/.
+# One test module → one marker via module-level `pytestmark = pytest.mark.<group>`.
+# Sub-cluster selection (e.g. 7k, 1o, 6n) uses `-k` against the existing
+# test_N_M_* method naming, not finer-grained markers.
+groups:
+  - { name: init,                description: "Cluster 1 — Project bootstrap, lex setup, lex Init, Keycloak sync, seed data." }
+  - { name: crud_api,            description: "Cluster 2 — CRUD via REST API (POST/GET/PATCH/DELETE)." }
+  - { name: validation_hooks,    description: "Cluster 3 — pre_validation / post_validation hooks." }
+  - { name: permissions,         description: "Cluster 4 — Field- and action-level access control." }
+  - { name: history,             description: "Cluster 5 — History rows, bitemporal chaining, MetaHistory." }
+  - { name: audit_logging,       description: "Cluster 6 — AuditLogMixin lifecycle, audit finalization." }
+  - { name: calculations,        description: "Cluster 7 — Calculation state machine, atomic/non-atomic, parent→child chains." }
+  - { name: calculation_logging, description: "Cluster 7 logging surface — calculation-log tree, builder API." }
+  - { name: celery_async,        description: "Cluster 8 — Celery dispatch, sync fallback, FireAndForget / WaitForTasks." }
+  - { name: signals_ws,          description: "Cluster 9 — Signals, WebSocket consumers, active-state store." }
+  - { name: api_layer,           description: "Cluster 10 — REST endpoints (history, bulk, files, SharePoint, schema)." }
+  - { name: stress,              description: "Cluster 11 — ~20k-row workload tests. Opt-in via -m stress." }
+  - { name: serializers,         description: "Cluster 12 — Serializer contract: JSON shape, type round-trip, reserved scopes." }
+  - { name: exports,             description: "Cluster 13 — Export endpoint, AG Grid flat/grouped, FK display names." }
+  - { name: queries,             description: "Cluster 14 — AG Grid query endpoint, filter/sort/group models." }
+  - { name: journeys,            description: "End-to-end multi-cluster user journeys." }


### PR DESCRIPTION
## Summary
- Adds `lex_test_config.yaml` at the repo root with 16 cluster groups, matching the folder structure under `lex/test_project/tests/`.
- Adds module-level `pytestmark = pytest.mark.<group>` to every test file (138 modules touched). Files under nested sub-folders (e.g. `init/initial_data/`) use their top-level cluster name as the marker, matching the 16 groups declared in the YAML.

This PR is **inert** under the existing `lex test` runner — Django ignores `pytestmark` attributes. Spec: [docs/superpowers/specs/2026-05-27-test-project-pytest-migration-design.md](docs/superpowers/specs/2026-05-27-test-project-pytest-migration-design.md), PR-A section.

## Test plan
- [ ] CI's existing `lex test` invocations stay green
- [ ] `python -m lex pytest -m "not stress" --collect-only` collects the suite cleanly (no marker errors, no unconfigured-group errors). Verify from the project venv at `project_example/.venv` since this PR's preflight could not run that step from system Python.
- [ ] `find lex/test_project/tests -name 'test_*.py' -exec grep -L 'pytestmark = pytest.mark.' {} +` returns no files

🤖 Generated with [Claude Code](https://claude.com/claude-code)