### PR TITLE
Test-project pytest migration — PR-C (docs)

### DIFF
--- a/lex/test_project/test-plan/index.md
+++ b/lex/test_project/test-plan/index.md
@@ -94,6 +94,10 @@ lex/test_project/
     └── stress/                # Stress / load harness
 ```
 
+Each cluster folder name is also its pytest group. The marker is declared
+once per test module via `pytestmark = pytest.mark.<group>`; the canonical
+group list lives in `lex_test_config.yaml` at the repo root.
+
 **Naming convention:** test files inside a cluster folder follow `test_<Nx>_<slug>.py` where `Nx` is the cluster number + sub-cluster letter (e.g. `2a`, `7g`). The PR-gate workflow enforces this regex on Copilot-authored test files.
 
 ---

--- a/lex/test_project/test-plan/progress/conventions.md
+++ b/lex/test_project/test-plan/progress/conventions.md
@@ -38,6 +38,10 @@ When a test exposes a framework bug:
 4. Move on — don't block the test suite on the fix
 5. When the bug is fixed, remove `@unittest.expectedFailure` — the test should now pass naturally
 
+`@pytest.mark.xfail(strict=True)` is an acceptable equivalent for tests
+authored after the pytest cutover, but existing `@unittest.expectedFailure`
+markers are not bulk-converted.
+
 ---
 
 ## User Experience: Making Tests Readable
@@ -78,6 +82,11 @@ def test_02_01_create_sets_timestamps(self):
     self.assertEqual(item.created_by, "Initial Data Upload")
 ```
 
+Tests live in a `tests/<cluster_slug>/` folder. The folder's name is the
+pytest group. At the top of each test module,
+`pytestmark = pytest.mark.<cluster_slug>` declares the group once and
+applies it to every test in the file.
+
 ### Assertion Messages
 
 Every assertion has a human-readable failure message:
@@ -103,24 +112,33 @@ class TestCluster02_CRUDLifecycle(E2ETestCase):
     e2e_models = [SimpleItem, TrackedItem]
 ```
 
+Classes inherit from `E2ETestCase` as before; no per-class `@pytest.mark`
+decoration is needed because the module-level `pytestmark` already applies
+to every test in the file.
+
 ---
 
 ## How to Run Tests
 
-### Run all clusters
+### Run all clusters (excluding stress)
 ```bash
 source ~/LUND_IT/ArmiraCashflowDB/.venv/bin/activate
-lex test lex.test_project.tests --noinput
+python -m lex pytest -m "not stress"
 ```
 
 ### Run a single cluster
 ```bash
-lex test lex.test_project.tests.test_02_crud_lifecycle --noinput
+python -m lex pytest -m crud_api
+```
+
+### Run a single scenario by ID
+```bash
+python -m lex pytest -k "2_1"
 ```
 
 ### Run with coverage
 ```bash
-coverage run --source=lex manage.py test lex.test_project.tests --noinput
+coverage run -m lex pytest -m "not stress"
 coverage report
 ```
 

--- a/lex/test_project/test-plan/test-writing-plan.md
+++ b/lex/test_project/test-plan/test-writing-plan.md
@@ -494,6 +494,13 @@ Same as cluster-doc Golden Rule. Reproduced here to keep this doc self-contained
 6. Bare `except:` is banned — always `except Exception:` (or a specific subclass).
 7. If a test exposes a real bug → `@unittest.expectedFailure` with a tracker entry, **don't weaken it.**
 
+---
+
+> **Runner note (May 2026):** this suite runs under `python -m lex pytest`.
+> New batches add `pytestmark = pytest.mark.<cluster_slug>` to each test
+> module. See [`progress/conventions.md` §How to Run Tests](progress/conventions.md#how-to-run-tests)
+> for the runner commands.
+
 
 
 


### PR DESCRIPTION
## Summary
- `conventions.md`, `index.md`, `test-writing-plan.md` updated to reference `python -m lex pytest`.
- All Golden Rule / Quality Gates / §9 rules sections are byte-identical to the pre-PR version (verified by sha256 checksums during implementation).
- **`CLAUDE.md` skipped** — the local `CLAUDE.md` in this working tree is **untracked** in git and contains no `lex test ... lex.test_project.tests` invocation to split. The plan assumed a tracked file with that reference; neither premise held here, so this PR makes no `CLAUDE.md` change. If a tracked `CLAUDE.md` is later added, the same edit can be applied as a follow-up.

Depends on PR-A (#509) and PR-B (#511). Spec: [docs/superpowers/specs/2026-05-27-test-project-pytest-migration-design.md](docs/superpowers/specs/2026-05-27-test-project-pytest-migration-design.md), PR-C section.

## Test plan
- [ ] Every code block in `conventions.md` is copy-pasteable into a shell and works
- [x] `git diff origin/lex-app-v2 -- lex/test_project/test-plan/test-clusters.md` is empty
- [x] Quality Gates section sha256 matches pre-edit (`914e52cb…ed8e0a`)
- [x] §9 7-rules sha256 matches pre-edit (`89e421e6…ac1b24`)
- [ ] A new contributor can write a test in a new sub-cluster using only the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)