### PR TITLE
Hotfix pytest cutover: test-DB setup + order-agnostic summary parser

### DIFF
--- a/.github/scripts/run_showcase_suite.py
+++ b/.github/scripts/run_showcase_suite.py
@@ -50,26 +50,45 @@ DJANGO_ENV = {
 
 
 # ── Output parsing ──────────────────────────────────────────────────
-# Pytest summary line examples (order of categories varies by version):
+# Pytest summary line examples (category order varies by version and by
+# what categories are non-zero):
 #   ===== 42 passed in 7.12s =====
 #   ===== 3 failed, 39 passed, 2 skipped in 8.45s =====
 #   ===== 1 xfailed, 41 passed in 7.20s =====
 #   ===== 1 error in 0.45s =====
-# Categories can be: passed, failed, errors, skipped, xfailed, xpassed,
-# deselected, warnings. We extract counts order-agnostically.
-_PYTEST_SUMMARY_RE = re.compile(
-    r"^=+ "
-    r"(?:(?P<failed>\d+) failed,? ?)?"
-    r"(?:(?P<passed>\d+) passed,? ?)?"
-    r"(?:(?P<skipped>\d+) skipped,? ?)?"
-    r"(?:(?P<xfailed>\d+) xfailed,? ?)?"
-    r"(?:(?P<xpassed>\d+) xpassed,? ?)?"
-    r"(?:(?P<errors>\d+) errors?,? ?)?"
-    r"(?:(?P<deselected>\d+) deselected,? ?)?"
-    r"(?:(?P<warnings>\d+) warnings?,? ?)?"
-    r"in (?P<duration>[\d.]+)s =+",
+#   ===== 1 warning, 37 errors in 8.44s =====   (collection failures)
+#
+# We parse this in two steps to be genuinely order-agnostic:
+#   1. ``_PYTEST_SUMMARY_LINE_RE`` matches the whole line and captures
+#      the comma-separated category clause and the wall-clock duration.
+#   2. ``_PYTEST_CATEGORY_TOKEN_RE`` is applied to the clause to pull
+#      out every ``<N> <word>`` pair regardless of order.
+# This replaces an earlier hard-coded-order regex that silently reported
+# ``0 errors`` whenever pytest emitted ``warning`` before ``errors``.
+_PYTEST_SUMMARY_LINE_RE = re.compile(
+    r"^=+\s+(?P<body>.+?)\s+in\s+(?P<duration>[\d.]+)s\s+=+\s*$",
     re.MULTILINE,
 )
+_PYTEST_CATEGORY_TOKEN_RE = re.compile(
+    r"(?P<count>\d+)\s+(?P<word>[a-zA-Z]+)"
+)
+# Map every pytest category word to its manifest bucket. Singulars and
+# plurals collapse to the same bucket so "1 error" and "37 errors" both
+# count.
+_PYTEST_CATEGORY_TO_BUCKET = {
+    "passed":     "passed",
+    "failed":     "failed",
+    "error":      "errors",
+    "errors":     "errors",
+    "skipped":    "skipped",
+    "xfailed":    "xfailed",
+    "xpassed":    "xpassed",
+    # Recognised-but-ignored buckets (kept so unknown-word warnings stay
+    # signal, not noise):
+    "deselected": None,
+    "warning":    None,
+    "warnings":   None,
+}
 
 # ── Per-test parsing for the customer report ───────────────────────
 # Pytest -v test-result lines look like:
@@ -153,27 +172,34 @@ def _parse_summary(output: str) -> dict[str, int | float | str]:
     """
     Parse pytest's trailing summary line into the manifest shape.
 
-    Pytest's category order varies between releases; the regex is
-    order-agnostic for the seven categories pytest emits. We find the
-    *last* match in the output (pytest prints the summary line as the
-    very last line of the run; finditer + last guards against partial
-    matches earlier in the buffer).
+    Two-step parse so category order doesn't matter:
+
+    * find the *last* line of the form ``==== <body> in <N>s ====`` —
+      pytest always prints the summary as the final boxed line, so the
+      last match is the authoritative one;
+    * tokenise ``<body>`` into every ``<N> <word>`` pair and fold each
+      into its bucket via ``_PYTEST_CATEGORY_TO_BUCKET``.
+
+    "1 warning, 37 errors in 8.44s" now correctly reports 37 errors;
+    the old hard-coded-order regex reported 0.
     """
-    ran = 0
-    wall_s = 0.0
     counts = {"passed": 0, "failed": 0, "errors": 0,
               "skipped": 0, "xfailed": 0, "xpassed": 0}
+    wall_s = 0.0
+    ran = 0
 
     last_match = None
-    for m in _PYTEST_SUMMARY_RE.finditer(output):
+    for m in _PYTEST_SUMMARY_LINE_RE.finditer(output):
         last_match = m
     if last_match is not None:
-        g = last_match.groupdict()
-        for key in counts:
-            v = g.get(key)
-            if v is not None:
-                counts[key] = int(v)
-        wall_s = float(g["duration"])
+        wall_s = float(last_match.group("duration"))
+        body = last_match.group("body")
+        for tok in _PYTEST_CATEGORY_TOKEN_RE.finditer(body):
+            word = tok.group("word").lower()
+            count = int(tok.group("count"))
+            bucket = _PYTEST_CATEGORY_TO_BUCKET.get(word)
+            if bucket is not None:
+                counts[bucket] += count
         ran = sum(counts.values())
 
     outcome = "success" if counts["failed"] == 0 and counts["errors"] == 0 else "failure"

--- a/lex/bin/lex.py
+++ b/lex/bin/lex.py
@@ -429,6 +429,25 @@ def pytest_cmd(ctx):
     # code is included in the measured project coverage.
     _bootstrap_django()
 
+    # Stand up Django's test database the same way `manage.py test` /
+    # DiscoverRunner.run_tests() does:
+    #   1. setup_test_environment() — installs the test client, RequestFactory
+    #      patches, deprecation-warning filter etc.
+    #   2. DiscoverRunner.setup_databases() — creates the ``test_<dbname>``
+    #      database (or `test_<NAME>` from the settings TEST overrides), runs
+    #      migrations, and re-points ``connection.settings_dict["NAME"]``
+    #      so any TestCase / TransactionTestCase / SimpleTestCase subclass
+    #      that touches the ORM hits the test DB, not the production one.
+    # Without this, every unittest.TestCase-derived test errors at setUp with
+    # `database "<prod name>" does not exist` because Django's runner machinery
+    # never ran.
+    from django.test.runner import DiscoverRunner
+    from django.test.utils import setup_test_environment, teardown_test_environment
+
+    setup_test_environment()
+    _db_runner = DiscoverRunner(verbosity=1, interactive=False, keepdb=False)
+    _old_db_config = _db_runner.setup_databases()
+
     started_at = time.perf_counter()
     try:
         exit_code = _pytest.main(forwarded, plugins=[plugin])
@@ -436,6 +455,10 @@ def pytest_cmd(ctx):
         # Raised from pytest_collection_modifyitems on marker/group mismatch.
         raise click.ClickException(str(exc)) from exc
     finally:
+        try:
+            _db_runner.teardown_databases(_old_db_config)
+        finally:
+            teardown_test_environment()
         plugin.run_duration = f"{time.perf_counter() - started_at:.1f} s"
         if coverage_runner is not None:
             try:


### PR DESCRIPTION
## Summary
The showcase CI run after #513 surfaced two bugs in the pytest cutover that hid each other. This PR fixes both.

### Bug 1 — Test database never created
Every `E2ETestCase` (inherits from `TransactionTestCase`) errored at `setUp` with:
```
FATAL: database "db_***-app" does not exist
```
Under `lex test`, Django's `DiscoverRunner.run_tests()` calls `setup_test_environment()` + `setup_databases()` before tests run, which creates `test_<dbname>`, runs migrations, and repoints `connection.settings_dict["NAME"]`. Under `lex pytest`, **none of that happened** — `_bootstrap_django()` only calls `django.setup()`, so tests connected to the literal production DB name.

**Fix:** `lex/bin/lex.py:pytest_cmd` now wraps the `pytest.main(...)` call with `DiscoverRunner.setup_databases()` / `teardown_databases()` plus `setup_test_environment()` / `teardown_test_environment()` — mirroring what the Django runner did internally.

### Bug 2 — Summary parser order-dependent (masked Bug 1 in the manifest)
After Bug 1 fired, pytest printed:
```
======================== 1 warning, 37 errors in 8.44s =========================
```
`run_showcase_suite.py` reported `0 errors / outcome=success` because `_PYTEST_SUMMARY_RE` had categories hard-coded in order `failed→passed→skipped→xfailed→xpassed→errors→deselected→warnings`, but pytest emitted `warning` *before* `errors`. The comment claimed "order-agnostic" but the regex wasn't.

**Fix:** Replaced with a two-step parse: match the boxed summary line, then tokenise the body into `<N> <word>` pairs and fold them into buckets via a word→bucket map. Verified against five pytest output shapes including the exact CI failure line.

## Test plan
- [x] Local parser unit tests against 5 pytest output shapes (warning-first, pure-pass, mixed, pure-error, multi-summary last-wins)
- [ ] CI runs `python -m lex pytest lex/test_project/tests/crud_api` end-to-end and the per-cluster setUp succeeds (test DB exists)
- [ ] Manifest from `run_showcase_suite.py` reports the same counts pytest itself prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)