### PR TITLE
Use COPILOT_PAT for auto-merge enablement in PR gate

### DIFF
--- a/.github/workflows/copilot_pr_gate.yml
+++ b/.github/workflows/copilot_pr_gate.yml
@@ -291,7 +291,15 @@ jobs:
       - name: Apply auto-merge (modes A/B)
         if: steps.mode.outputs.mode != 'fix-and-test'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # COPILOT_PAT, not GITHUB_TOKEN. The `gh pr merge --auto` call
+          # invokes the `enablePullRequestAutoMerge` GraphQL mutation,
+          # which the default workflow token cannot call in repos with
+          # branch protection requiring review — fails with
+          # "Resource not accessible by integration". The classic PAT
+          # acts as a real user and has the required permission. Same
+          # constraint that drives PAT usage in copilot_coverage_check.yml
+          # and copilot_test_bot.yml.
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr edit  "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "auto-merge"


### PR DESCRIPTION
## Summary

- `gh pr merge --auto` invokes the `enablePullRequestAutoMerge` GraphQL mutation. The default `GITHUB_TOKEN` cannot call this in repos with branch protection requiring review — fails with `Resource not accessible by integration` (observed on PR #523).
- Switch the gate's auto-merge step to `COPILOT_PAT`, same pattern already used by `copilot_test_bot.yml`, `copilot_label_on_issue_open.yml`, and `copilot_coverage_check.yml`.

## Test plan
- [ ] Merge this PR.
- [ ] Re-run the failed "Apply auto-merge (modes A/B)" step on PR #523 — should now succeed and put #523 on auto-merge.
- [ ] (Indirect) next Copilot mode-A or mode-B PR completes the full gate → auto-merge cycle without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)