### PR TITLE
Add query-tolerant health path matcher (demo: triggers coverage gate)

### DIFF
--- a/lex/lex_app/fast_health.py
+++ b/lex/lex_app/fast_health.py
@@ -15,6 +15,32 @@ def is_fast_health_path(path: str) -> bool:
     return path in FAST_HEALTH_PATHS
 
 
+def match_health_request_path(path: str) -> bool:
+    """Return True if ``path`` is a recognised health-check endpoint.
+
+    Like :func:`is_fast_health_path` but tolerates an optional query
+    string. Probes from Kubernetes, GCP uptime checks, and external
+    monitoring services often append a query suffix (``?source=k8s``,
+    ``?check=ready``) to differentiate themselves in access logs; the
+    strict matcher rejects those even though the underlying path is a
+    valid health endpoint. This variant strips the query before
+    comparing against ``FAST_HEALTH_PATHS``.
+
+    Examples:
+        >>> match_health_request_path("/health")
+        True
+        >>> match_health_request_path("/health?source=k8s")
+        True
+        >>> match_health_request_path("/api/health/?check=ready")
+        True
+        >>> match_health_request_path("/users")
+        False
+    """
+    if "?" in path:
+        path = path.split("?", 1)[0]
+    return path in FAST_HEALTH_PATHS
+
+
 async def _drain_http_body(
     receive: Callable[[], Awaitable[Dict[str, Any]]],
 ) -> None:


### PR DESCRIPTION
## Summary

Add `match_health_request_path(path: str) -> bool` to `lex/lex_app/fast_health.py`. It mirrors the existing `is_fast_health_path` but tolerates an optional query suffix (`?source=k8s`, `?check=ready`) — query strings that real probes (k8s, GCP uptime, monitoring tools) routinely append to identify themselves in access logs.

The strict `is_fast_health_path` is left untouched. Callers opt into query tolerance by picking the new helper.

## Why this PR ships without a test

This PR is the parent half of an end-to-end demonstration of the **coverage-check + Copilot test-bot** pipeline (Feature 4). The `copilot_coverage_check.yml` workflow should:

1. Detect that `lex/lex_app/fast_health.py` was modified with no paired test in the same diff
2. Open a `[copilot-task]` issue asking Copilot to write regression tests targeting branch `demo/health-path-query-tolerance`
3. Apply the `needs-tests` label here and post a failing `coverage / required` check
4. When Copilot's sub-PR merges into this branch, the gate re-runs, flips green, and unblocks merge

Watch this PR for the gate behaviour and the auto-opened coverage-task issue.

## Test plan
- [ ] `copilot_coverage_check` workflow runs and reports `status: miss`
- [ ] A `[copilot-task] Coverage tests for PR #N` issue is opened with the `coverage-task` label
- [ ] This PR gets the `needs-tests` label
- [ ] `coverage / required` posts a red check
- [ ] Copilot writes a sub-PR with `test_*_match_health_request_path.py` (or similar) under `lex/test_project/tests/<cluster>/`
- [ ] Sub-PR runs through `copilot_pr_gate` cleanly
- [ ] On sub-PR merge into this branch, parent PR's `coverage / required` flips green

🤖 Generated with [Claude Code](https://claude.com/claude-code)