### PR TITLE
Harden coverage-task issue body to force correct base branch

### DIFF
--- a/.github/workflows/copilot_coverage_check.yml
+++ b/.github/workflows/copilot_coverage_check.yml
@@ -243,13 +243,25 @@ jobs:
           cat > issue-body.md <<EOF
           # Coverage task — auto-opened by copilot_coverage_check.yml
 
+          ## ⚠️ Required base branch
+
+          Open your PR with this **exact** base:
+
+          \`\`\`
+          ${PR_HEAD_REF}
+          \`\`\`
+
+          Do **NOT** target \`lex-app-v2\`. The test must merge into the parent PR's head branch (\`${PR_HEAD_REF}\`) so it ships in the same diff as the source change. Targeting \`lex-app-v2\` directly will leave the parent PR blocked forever and may break \`lex-app-v2\` CI by shipping a test for code that doesn't exist on that branch yet.
+
+          ---
+
+          ## Task
+
           PR #${PR_NUMBER} modifies ${COUNT} source file(s) under \`lex/lex_app/\*\*\` without test coverage in the same diff:
 
           ${UNTESTED}
 
           Write regression tests for the behaviour these files now express. Follow the test-plan rules in \`lex/test_project/test-plan/\`.
-
-          **Open your PR against base \`${PR_HEAD_REF}\` — not \`lex-app-v2\`.** Targeting the parent PR's head branch ensures the test ships *with* the change instead of racing against it, and avoids recursive triggering of this workflow.
 
           End your PR body with \`Fixes #<this issue number>\`.
 


### PR DESCRIPTION
## Summary

- Restructures the coverage-task issue body in `copilot_coverage_check.yml` so the base-branch directive is the first section, in a fenced code block, with explicit positive + negative phrasing.
- Prompt-engineering hardening only — no logic change to the coverage detector or the workflow flow.

## Motivation

PR #527 (Copilot's auto-generated test PR for issue #526) targeted `lex-app-v2` directly instead of `demo/health-path-query-tolerance` (the parent PR's head branch). The previous issue body told Copilot to use the parent branch, but the directive was buried in the fourth paragraph as prose and Copilot ignored it.

Wrong base targeting breaks the coverage flow in two ways:
1. The parent PR (#525) stays blocked — its diff against `lex-app-v2` still has source-without-test.
2. The test would land on `lex-app-v2` importing a function that doesn't exist there yet, breaking CI for every subsequent PR.

## Changes

The issue body now leads with a `## ⚠️ Required base branch` section that puts the parent head ref in a fenced code block and explicitly forbids targeting `lex-app-v2` — before any task description. LLMs follow the first explicit instruction in a structured document much more reliably than buried prose.

## Test plan

- [ ] Merge this PR.
- [ ] Close + reopen the existing PR #525 (or push an empty commit) to fire a fresh `pull_request` event → `copilot_coverage_check.yml` re-runs.
- [ ] Verify the new coverage-task issue body has the base-branch section at the top.
- [ ] Verify Copilot's next test PR uses `demo/health-path-query-tolerance` as base, not `lex-app-v2`.

## Follow-up

A planned auto-retargeting workflow (`copilot_coverage_retarget.yml`) will provide deterministic enforcement for cases where prompt hardening alone isn't enough. Tracked separately.

Refs: parent PR #525, Copilot's mis-targeted PR #527, coverage-task issue #526.