### PR TITLE
Local-Copilot testing rules + /write-cluster-test prompt

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,123 @@
+---
+description: "Use when: writing, modifying, or generating tests for the lex-app framework. Activates for any file under lex/tests/, lex/test_project/tests/, or when the user asks Copilot to write a test."
+applyTo: "lex/tests/**,lex/test_project/tests/**,**/test_*.py,**/tests/**/*.py,frontend/src/__test__/**"
+---
+
+# LEX Testing Rules — Read Before Writing Tests
+
+The lex-app test suite is **release-gating**: nothing ships to PyPI unless the full backend run passes and coverage stays above the configured threshold. Tests double as living documentation. These rules exist so generated tests pass review, satisfy the coverage gate, and don't get bounced back for style fixes.
+
+When these rules conflict with prior knowledge, **these rules win**. They reflect decisions documented in [`docs/testing-methodology.md`](../../docs/testing-methodology.md) and the active migration plan in [`lex/test_project/test-plan/`](../../lex/test_project/test-plan/).
+
+---
+
+## 1. Where tests live
+
+| Layer | Path | Use for |
+| --- | --- | --- |
+| Framework unit | `lex/tests/unit/<topic>/test_*.py` | Pure logic, single-class behaviour, no DB if possible. Topic subdirs: `api/`, `audit/`, `auth/`, `calculation/`, `cli/`, `core/`, `crud/`, `grid/`, `infra/`, `serialization/`, `temporal/`. |
+| Framework integration | `lex/tests/integration/test_*.py` | Multi-component flows, bitemporal chains, audit recovery. |
+| Framework E2E | `lex/tests/e2e/test_*.py` | Full user journeys through REST `APIClient`. |
+| Project-cluster tests | `lex/test_project/tests/<topic>/test_<cluster>.py` | Cluster-based test plan (see §5). |
+| Frontend | `frontend/src/__test__/*.test.{ts,tsx}` | Vitest, jsdom env. |
+
+**Do not invent new top-level directories.** If unsure where a new test belongs, place it under `lex/tests/unit/<existing-topic>/` and ask the reviewer.
+
+## 2. Test runner
+
+- **Backend:** pytest (cutover in progress — see [`docs/ci-cd/pytest-cutover-hotfixes-2026-05-27.md`](../../docs/ci-cd/pytest-cutover-hotfixes-2026-05-27.md)). Run via `lex test <labels>` or `pytest <path>`. **Do not** use `manage.py test`.
+- **Frontend:** Vitest with `globals: true`. Use `vi.mock`/`vi.fn` in new code; `jest.mock` is aliased for legacy compat but not for new tests.
+
+## 3. Base-class selection
+
+| Need | Class |
+| --- | --- |
+| Pure functions, no DB | `SimpleTestCase` (fastest — use whenever possible) |
+| ORM, per-test transaction rollback | `TestCase` |
+| Schema editing, multi-transaction behaviour, raw connection use | `TransactionTestCase` (slowest — only when truly needed) |
+| REST endpoint testing | `APITestCase` (DRF) |
+
+Pytest tests can use plain `def test_...` functions with fixtures — prefer this for new pure-logic tests under `lex/tests/unit/`.
+
+## 4. The coverage-pairing rule (critical)
+
+The coverage gate ([`copilot_coverage_check.yml`](../workflows/copilot_coverage_check.yml)) blocks PRs that touch `lex/lex_app/**` source without a paired test in the **same diff**. A test is "paired" if it satisfies at least one of:
+
+1. **Imports the changed module** — e.g. `from lex.lex_app.fast_health import match_health_request_path`.
+2. **Has the source filename stem in its name** — e.g. changing `fast_health.py` → pair with `test_fast_health.py`.
+
+When you write a test for new code, ensure **at least one** of those is true. The detector is `.github/scripts/copilot_coverage_detect.py` — read it if you need to verify the exact logic.
+
+## 5. The test-plan workflow (cluster-aligned tests)
+
+Tests under `lex/test_project/tests/` follow the **cluster plan** in [`lex/test_project/test-plan/test-writing-plan.md`](../../lex/test_project/test-plan/test-writing-plan.md). This plan is the source of truth — **read it before writing any test under `lex/test_project/tests/`**.
+
+### Allocation rules (follow exactly — never improvise)
+
+1. **Cluster numbers are never renumbered.** They map 1:1 to coverage tracking and reports.
+2. **Sub-clusters use letters in alphabetical order.** Find the highest letter currently in use for the cluster; allocate the next free one. Example: cluster 1 has 1a–1n → next is `1o`. Cluster 6 has 6a–6f → next is `6g`.
+3. **Scenario IDs continue from the cluster's current max.** Don't restart numbering or reuse IDs.
+4. **One batch = one sub-cluster = one PR.** Keeps reviews bounded.
+5. **Don't re-slot files already in an in-flight Tier-A cluster.** Check the "in-flight" section of the test-writing-plan before allocating.
+
+### File naming
+
+- Test file: `lex/test_project/tests/<topic>/test_<cluster><letter>_<short_description>.py`
+- Test class: `TestCluster<NN><letter>_<Description>` — e.g. `TestCluster01o_ProcessAdminLazyGetattr`
+- Type letter on the batch metadata: **U** (`SimpleTestCase`, no DB), **I** (`TestCase`, per-test transaction), **E** (REST via `APIClient`).
+
+### Required batch metadata
+
+Every batch in the test-plan documents: scenario range, files covered, test classes, fixtures, file path, est. tests, est. coverage gain, prerequisite PRs. When adding a new batch, append a row that matches this shape — copy the format of the most recent batch.
+
+### Slash command
+
+For test-plan-aligned work, invoke `/write-cluster-test` in Copilot Chat. The prompt walks through the lookup-and-allocate workflow step by step and asks you to confirm the cluster/letter before scaffolding.
+
+## 6. Naming conventions (everywhere else)
+
+- **Test files:** `test_<module_stem>.py` (default outside the cluster plan).
+- **Test methods:** `test_<behaviour_under_test>` — verb-led, describes the assertion, not the setup.
+
+## 7. What NOT to do
+
+These are linter or review failures every time:
+
+- **No `print()`** for debugging — use `self.subTest()` or assertions with descriptive messages.
+- **No bare `except:` or `except: pass`** — always name the exception: `except SpecificError:`.
+- **No reliance on `.env`** — tests that depend on environment variables must `patch.dict("os.environ", {...})` explicitly. Specifically `CELERY_ACTIVE` — never assume it's set.
+- **No DB mocks for `TestCase`-style work** — integration tests must hit a real Postgres. Mocking the ORM masked a broken migration once; don't repeat it.
+- **No silent `self.skipTest()` on a 404 or unexpected status** — that hides regressions. Assert, don't skip.
+- **No duplicate assertions** — if a fact is asserted in `setUp`, don't re-assert it in every test method.
+- **No new docstring-only files.** Tests without assertions are dead weight.
+
+## 8. Docstrings (mandatory)
+
+Every new test file and every `TestCase` subclass needs a docstring. They are read by reviewers and by future contributors who treat the test suite as documentation. Minimum:
+
+```python
+"""Tests for <module>.
+
+Covers: <one-line behaviour summary>.
+Run: lex test lex.tests.unit.<topic>.test_<module> --verbosity=2 --noinput
+"""
+```
+
+## 9. If this PR is a coverage-task PR (auto-opened by the gate)
+
+Coverage-task issues are tagged `coverage-task` and are auto-opened by [`copilot_coverage_check.yml`](../workflows/copilot_coverage_check.yml). When writing a PR to close one:
+
+1. **Base branch:** target the **parent PR's head branch** (named in the issue body under "Required base branch"). **Never** target `lex-app-v2` directly — that breaks the pairing rule and the parent PR stays blocked.
+2. **Body footer:** end the PR body with `Fixes #<issue-number>` so the gate can link the test PR back to the coverage task.
+3. **Scope:** add only the missing tests. Do not refactor the source, rename files, or fix unrelated issues — that gets the PR labelled `copilot:invalid` by the gate's shape check.
+
+## 10. Reference docs (read these for full detail)
+
+- [`docs/testing-methodology.md`](../../docs/testing-methodology.md) — full methodology, base-class guide, coverage strategy, CI integration.
+- [`lex/test_project/test-plan/`](../../lex/test_project/test-plan/) — active cluster plan, naming rules, scenario IDs. **This is the source of truth for cluster allocation.**
+- [`CLAUDE.md`](../../CLAUDE.md) §15 ("Test Framework — How It Works") — runner setup, isolation rules, local-vs-CI differences.
+- [`docs/superpowers/specs/2026-05-26-copilot-test-automation-pipeline-design.md`](../../docs/superpowers/specs/2026-05-26-copilot-test-automation-pipeline-design.md) — coverage-task automation spec.
+
+## 11. When in doubt
+
+Read the docs above before writing. Don't guess at framework APIs, base-class semantics, or fixture conventions — the docs are authoritative and the tests already in `lex/tests/unit/` and `lex/test_project/tests/` are the worked examples.

--- a/.github/prompts/write-cluster-test.prompt.md
+++ b/.github/prompts/write-cluster-test.prompt.md
@@ -1,0 +1,149 @@
+---
+description: "Scaffold a test-plan-aligned pytest file following the LEX cluster naming and allocation rules. Walks the dev through the test-plan lookup and confirms cluster/letter before writing."
+mode: agent
+---
+
+# /write-cluster-test — Scaffold a cluster-aligned test
+
+You are helping write a test that follows the LEX test-plan structure in `lex/test_project/test-plan/`. **Follow these steps strictly and do not improvise.** The test-plan rules in `.github/instructions/testing.instructions.md` apply throughout.
+
+## Inputs to gather (one at a time, only if not already provided)
+
+1. The **source module/file** the user wants to test (e.g., `lex/lex_app/fast_health.py`).
+2. The **behaviour** under test (one-line description).
+3. Optional: a **specific cluster** the user already has in mind. If not provided, you'll infer it in Step 2.
+
+## Step 1 — Read the test-plan
+
+Open and read **all** of these before doing anything else:
+
+1. [`lex/test_project/test-plan/index.md`](../../lex/test_project/test-plan/index.md) — overview of all clusters.
+2. [`lex/test_project/test-plan/test-clusters.md`](../../lex/test_project/test-plan/test-clusters.md) — cluster definitions and topic mapping.
+3. [`lex/test_project/test-plan/test-writing-plan.md`](../../lex/test_project/test-plan/test-writing-plan.md) — current batch state, in-flight clusters, allocation rules.
+
+If you cannot find any of these files, **stop and tell the user**. Do not guess.
+
+## Step 2 — Identify the cluster
+
+Map the source module to a cluster using `test-clusters.md`. Common mappings:
+
+| Source area | Cluster |
+| --- | --- |
+| `lex/lex_app/__init__.py`, settings, urls, views, bootstrap | 1 |
+| `lex/lex_app/LexModel.py`, ORM models | 3, 4 |
+| Audit logging | 6 |
+| Calculation models, calculation flow | 7 |
+| Celery / async / workers | 8 |
+| Serializers, REST | 12 |
+| Model export / import | 13 |
+| List views, AG Grid | 14 |
+
+**If unsure, ask the user which cluster.** Do not pick one yourself when ambiguous.
+
+## Step 3 — Allocate the next free letter and scenario range
+
+From `test-writing-plan.md`:
+
+1. List every batch already documented for the target cluster (e.g., 1a, 1b, ..., 1n, 1o, 1p).
+2. The next free letter is the next alphabetical letter after the highest one in use. **Cluster letters are never renumbered.**
+3. Find the cluster's current maximum scenario ID. The new batch starts at `max + 1`.
+4. Check the "Pending decisions" and "in-flight Tier-A clusters" sections — if the source file is already slotted in an in-flight batch, **stop and tell the user**. Do not duplicate.
+
+## Step 4 — Determine the test type letter
+
+| Letter | Class | When |
+| --- | --- | --- |
+| **U** | `SimpleTestCase` or plain pytest function | Pure logic, no DB. **Prefer this.** |
+| **I** | `TestCase` | ORM access, per-test transaction rollback |
+| **E** | `APITestCase` + `APIClient` | REST endpoint testing |
+
+Default to **U** unless the test clearly needs DB or HTTP plumbing.
+
+## Step 5 — Pause and confirm
+
+Before scaffolding, output exactly this format and **wait for the user's confirmation**:
+
+```
+Allocating new batch:
+  Cluster:        <NN><letter>          (e.g., 7h)
+  Scenarios:      <start> – <end>       (e.g., 7.123 – 7.140)
+  Type:           U | I | E
+  Test file:      lex/test_project/tests/<topic>/test_<NN><letter>_<short>.py
+  Test classes:   TestCluster<NN><letter>_<Description>
+  Files covered: <list of source files>
+  Fixtures:       <list, or "none">
+
+Confirm? (yes / change cluster / change type)
+```
+
+If the user says no or wants changes, revise and re-confirm. **Do not proceed without explicit confirmation.**
+
+## Step 6 — Scaffold the test file
+
+Create the file at the path from Step 5 with this exact header:
+
+```python
+"""<one-line summary of what these tests cover>.
+
+Cluster <NN><letter> — scenarios <start>–<end>.
+Type: <U | I | E>.
+
+Covers: <files covered, comma-separated>.
+Run: pytest lex/test_project/tests/<topic>/test_<NN><letter>_<short>.py -v
+"""
+
+from <appropriate imports>
+
+
+class TestCluster<NN><letter>_<Description>(<SimpleTestCase | TestCase | APITestCase>):
+    """<one-line class docstring describing the cluster of scenarios>."""
+
+    def test_<behaviour_under_test>(self):
+        """Scenario <NN><letter>.<id> — <one-line scenario description>."""
+        # arrange
+        ...
+        # act
+        ...
+        # assert
+        self.assertEqual(...)
+```
+
+Apply all rules from `.github/instructions/testing.instructions.md`:
+
+- No `print()`, no bare `except:`, no `.env` reliance.
+- Mandatory docstrings on file and every test class.
+- Pairing rule: the test must import the source module OR share its filename stem so the coverage gate accepts it.
+
+## Step 7 — Append to the test-plan
+
+After writing the test file, append a row for the new batch to the appropriate cluster section in `test-writing-plan.md`. Use the same table shape as the most recent batch in that cluster. Fill in:
+
+- Scenario range
+- Type letter
+- Files covered
+- Test file path
+- Test classes
+- Fixtures
+- Tests landed: leave as `pending — to be measured after run`
+- Coverage gain: leave as `pending — to be measured after coverage run`
+- Status: ⏳ In progress
+
+## Step 8 — Suggest next steps
+
+Output:
+
+```
+Done. Suggested next actions:
+  1. Run the new tests:  pytest <file> -v
+  2. Run with coverage:  pytest --cov=lex.lex_app <file>
+  3. When green: commit with message "Add cluster <NN><letter> — <short>" and open a PR against lex-app-v2.
+  4. If this is the test PR for a coverage-task issue, change the PR base to the parent PR's head branch (not lex-app-v2) — see testing.instructions §9.
+```
+
+## What NOT to do
+
+- Do not pick a cluster letter without reading `test-writing-plan.md` first.
+- Do not skip the confirmation step in Step 5.
+- Do not invent new clusters or renumber existing ones.
+- Do not write tests for a source file already slotted in an in-flight batch — defer to that batch.
+- Do not touch source files in the same PR as the test scaffolding. Tests-only PRs unless explicitly bundled by the user.

--- a/docs/superpowers/specs/2026-05-28-copilot-local-rules-design.md
+++ b/docs/superpowers/specs/2026-05-28-copilot-local-rules-design.md
@@ -1,0 +1,95 @@
+# Copilot local-rules — testing-first MVP
+
+**Date:** 2026-05-28
+**Status:** MVP — testing scope only. Future domain rules deferred.
+
+## Problem
+
+The Copilot Coding Agent (cloud) writes tests that follow the lex-app conventions (cluster naming, base-class selection, coverage pairing) because the coverage workflow injects an explicit prompt into the agent's issue. Local IDE Copilot (Chat, inline) has no such prompt — so its test suggestions drift away from project conventions and frequently fail review.
+
+We want **local Copilot to produce work matching the cloud agent's quality**, with the test-plan followed strictly (no improvisation on cluster naming, letter allocation, or scenario IDs).
+
+## Decisions
+
+### Decision 1: Approach is **A + B** (instructions + prompt). C deferred.
+
+Three options were considered:
+
+- **A. Instructions file only.** Path-scoped instructions activate when a test file is open or the user asks Copilot about tests. Tells Copilot the rules and points at the test-plan. Cheap, but relies on Copilot remembering to read the live test-plan state.
+- **B. Prompt that scripts the workflow.** `/write-cluster-test` slash command walks Copilot through the test-plan lookup and forces a confirmation step before scaffolding. Explicit and reliable, but only runs when the dev invokes it.
+- **C. CLI / MCP tool returning canonical state.** `lex test-plan next-slot --topic <topic>` returns `{cluster, letter, scenario_range, path}` deterministically. Eliminates parse drift but requires building infrastructure.
+
+**Chosen: A + B.** Instructions cover style/convention so any Copilot interaction in a test context inherits the rules. The prompt covers the workflow-heavy path (cluster allocation) where determinism matters most. **C is deferred** — building a CLI is a separate multi-hour task and the MVP needs to ship now.
+
+### Decision 2: Scope is **testing only**
+
+Other domain instructions (calculation models, audit logging, migrations, frontend) are valuable but separate work. One PR per domain keeps reviews bounded. Testing is the highest-leverage domain because:
+
+- Every framework change needs paired tests (coverage gate).
+- Test conventions are the most cited reason for review pushback.
+- The cloud agent already writes tests in the target style — we have a working reference.
+
+### Decision 3: Files shipped in this PR
+
+1. **`.github/instructions/testing.instructions.md`** — scoped path-based instructions. `applyTo` covers `lex/tests/`, `lex/test_project/tests/`, and any `test_*.py` / `frontend/src/__test__/` files.
+2. **`.github/prompts/write-cluster-test.prompt.md`** — explicit slash command for the test-plan workflow. Forces test-plan read → cluster identification → letter/scenario allocation → confirmation → scaffold → test-plan update.
+3. **This spec doc** — captures decisions for future refinement.
+
+### Decision 4: What's deferred (refinement later)
+
+- **Other domain scoped instructions** — calculation-models, audit-logging, migrations, frontend. Worth doing; not blocking testing parity.
+- **CLI / MCP tool** for canonical test-plan state. Build only if devs report repeat parse errors on the markdown tables.
+- **Auto-retargeting workflow** for coverage-task PRs that target the wrong base branch. Tracked separately as defense-in-depth for the prompt-hardening fix in PR #528.
+- **`.github/copilot-instructions.md` changes** — left untouched. It's currently focused on MCP/kickstart guidance for downstream Lex app builders; adding domain rules there would dilute its purpose.
+
+## How the two files interact
+
+```
+Dev opens a test file in IDE
+        ↓
+testing.instructions.md auto-loads (applyTo glob match)
+        ↓
+Copilot Chat / inline suggestions have full LEX testing rules in context
+        ↓
+Dev asks "write a test for fast_health.py"
+        ↓
+   ┌────────────────────────┬─────────────────────────┐
+   │                                                  │
+Free-form chat                            Dev invokes /write-cluster-test
+(general test, no cluster ↓               ↓ (cluster allocation matters)
+allocation needed)            write-cluster-test.prompt.md runs
+   ↓                                       ↓
+Instructions guide the           Step-by-step lookup → confirm → scaffold
+output (style, pairing,                    ↓
+docstring, base-class)           Output: scaffolded file + test-plan row
+```
+
+## Success criteria
+
+- IDE Copilot produces tests that pass the coverage gate's pairing check on first try.
+- Cluster-aligned tests (when devs use `/write-cluster-test`) get the right letter, the right scenario range, and update the test-plan in the same PR.
+- No new "should have read the test-plan" review comments on Copilot-assisted test PRs.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Copilot mis-parses the test-plan markdown tables and picks a wrong letter. | The prompt forces an explicit confirmation step (Step 5) before scaffolding. Dev sees the proposed allocation and can correct it. |
+| Devs forget to invoke `/write-cluster-test` and write free-form. | Acceptable for non-cluster-aligned tests under `lex/tests/unit/`. Cluster work is the minority. If this becomes a problem, escalate to a CI check that validates batch numbering on PR open. |
+| `applyTo` glob misses some test file naming conventions. | Globs are broad on purpose: `lex/tests/**`, `lex/test_project/tests/**`, `**/test_*.py`, `**/tests/**/*.py`, `frontend/src/__test__/**`. Expand if a gap is reported. |
+| Test-plan format changes break the prompt's lookup steps. | The prompt cites the canonical files; if the format changes, update the prompt. Coupling is acceptable for a project-specific tool. |
+
+## Future work (in priority order)
+
+1. **Domain instruction files** — `calculation-models.instructions.md`, `audit-logging.instructions.md`, `migrations.instructions.md`, `frontend.instructions.md`. Each follows the same pattern as testing.
+2. **Auto-retargeting workflow** for coverage-task PRs (see follow-up note in PR #528's discussion).
+3. **CLI / MCP tool** for test-plan state lookup — only if step 1 of the prompt (markdown table parse) proves unreliable in practice.
+4. **Org-level Copilot instructions** — if other repos in the org need shared rules, lift the cross-cutting ones to the org settings UI.
+
+## References
+
+- [`.github/copilot-instructions.md`](../../../.github/copilot-instructions.md) — global Copilot file (untouched).
+- [`.github/instructions/lex-docs.instructions.md`](../../../.github/instructions/lex-docs.instructions.md) — existing scoped instructions (template followed for new file).
+- [`docs/superpowers/specs/2026-05-26-copilot-test-automation-pipeline-design.md`](2026-05-26-copilot-test-automation-pipeline-design.md) — coverage-task pipeline spec.
+- PR #528 — coverage-task issue-body hardening (related but separate work).
+- `lex/test_project/test-plan/` — authoritative source for cluster allocation rules.


### PR DESCRIPTION
## Summary

- Adds `.github/instructions/testing.instructions.md` — path-scoped Copilot rules that auto-load when devs open any test file or ask Copilot to write tests.
- Adds `.github/prompts/write-cluster-test.prompt.md` — explicit `/write-cluster-test` slash command that walks the dev through the test-plan lookup (cluster → letter → scenario range → confirm → scaffold).
- Adds the design doc capturing decisions and what was deferred.

## Motivation

The cloud Copilot Coding Agent writes tests following project conventions because the coverage workflow injects an explicit prompt into the agent's issue. Local IDE Copilot (Chat, inline) had no equivalent — so test suggestions drifted away from the cluster naming, base-class rules, and pairing requirements, and got bounced in review.

## Approach (chosen autonomously per user direction "decide everything yourself")

- **A + B (instructions + prompt). C deferred.** Pure instructions are too easy to ignore in flow; pure prompts only run when invoked. Combined: instructions handle the always-on rules; the prompt forces deterministic cluster allocation when devs need it.
- **Testing-only scope.** Other domains (calculation models, audit logging, migrations, frontend) deferred to future per-domain PRs.
- Global `.github/copilot-instructions.md` left untouched (it's focused on MCP/kickstart for downstream Lex app builders; adding domain rules there would dilute it).

Full reasoning in [`docs/superpowers/specs/2026-05-28-copilot-local-rules-design.md`](docs/superpowers/specs/2026-05-28-copilot-local-rules-design.md).

## What's deferred (future PRs)

- Other domain instructions: `calculation-models`, `audit-logging`, `migrations`, `frontend`.
- CLI / MCP tool for canonical test-plan state lookup — only if markdown-table parsing in the prompt proves unreliable.
- Auto-retargeting workflow for coverage-task PRs that target the wrong base (was the follow-up note in #528).

## Test plan

- [ ] Open any file under `lex/tests/`, `lex/test_project/tests/`, or `frontend/src/__test__/` and ask Copilot Chat to write a test. Confirm it follows the rules in `testing.instructions.md` (right base class, docstrings, pairing rule).
- [ ] In Copilot Chat, run `/write-cluster-test` and feed it a source file. Verify it reads `test-writing-plan.md` first, identifies the cluster, allocates the next free letter, pauses for confirmation, then scaffolds — instead of jumping straight to writing.
- [ ] No regression: existing instruction files (`lex-docs.instructions.md`, `lex-kickstart.instructions.md`) still load for their respective contexts.

## Refs

- PR #528 — coverage-task issue-body hardening (related work that motivated unifying local rules with cloud-agent behavior).
- `lex/test_project/test-plan/test-writing-plan.md` — authoritative source the new prompt reads at runtime.