### PR TITLE
Harden local-agent rules: research-first, cluster placement, plan-consistency

### DIFF
--- a/.claude/skills/lex-testing/SKILL.md
+++ b/.claude/skills/lex-testing/SKILL.md
@@ -21,6 +21,30 @@ This skill is the executable workflow for cluster-aligned tests.
 If the change is to a downstream Lex *project* (not this framework repo), the cluster rules do
 **not** apply — follow that project's conventions instead.
 
+## Step 0 — Research the intent first (the Golden Rule — never skip)
+
+**Before writing a single line of source or test, gather enough context to solve the problem
+correctly.** The source code is an incomplete story — it has bugs and workarounds. A test derived by
+mirroring the implementation locks those bugs in. This is the single most common failure mode here.
+Do this yourself, automatically — do not wait to be asked:
+
+1. **Read the docs that describe intent**, not just the code: [`docs/features/`](../../../docs/features/),
+   [`docs/reference/`](../../../docs/reference/), [`docs/tutorial/`](../../../docs/tutorial/). They say what the
+   framework is *trying to achieve*. Derive the behaviour you'll implement and test from that intent
+   + *"What would a customer reasonably expect?"* — not from what the code currently happens to do.
+2. **Read the public API docstrings** of the classes/functions you'll touch, and skim the existing
+   cluster tests for that topic to match established patterns.
+3. **Check for an existing mechanism before inventing one.** E.g. cross-process state already lives
+   in the cache-backed `ActiveCalculationStateStore` — don't add a process-local dict that fails
+   silently across Celery workers. Search the codebase for the capability first.
+4. **If the request is ambiguous or has more than one defensible design, STOP and ask the
+   developer** before coding — surface the trade-offs and let them choose. Use the
+   `superpowers:brainstorming` skill. A wrong assumption baked into a feature + its tests costs far
+   more than one question.
+
+Only once you understand the intent do you proceed to allocation. If a test then fails because the
+code is genuinely buggy, that is the test doing its job — record it (Step 7), don't weaken it.
+
 ## Step 1 — Read the test-plan (always, before allocating)
 
 Read these before doing anything else; if any is missing, **stop and tell the user** — do not guess:
@@ -88,35 +112,68 @@ Revise and re-confirm if the user wants changes. Don't proceed without confirmat
 
 ## Step 6 — Scaffold the test file
 
+**Location is strict:** the file goes in the cluster tree —
+`lex/test_project/tests/<cluster_slug>/test_<NN><letter>_<short>.py`. **Never** drop a feature test
+into the legacy `lex/tests/unit/`, `lex/tests/integration/`, or `lex/tests/e2e/` trees — those are
+the pre-existing audit suite and adding feature tests there bypasses the cluster plan and
+coverage-task tracking. That escape hatch is exactly what breaks plan consistency.
+
 Create the file with this header and follow every rule in `testing.instructions.md` (no `print()`,
 no bare `except:`, no `.env` reliance, real DB models — mock only external boundaries, mandatory
-docstrings):
+docstrings). The module header carries an `Intent` section (what the framework is trying to achieve
++ why a regression matters + the scenario range) and a module-level
+`pytestmark = pytest.mark.<cluster_slug>`:
 
 ```python
 """<one-line summary of what these tests cover>.
 
+Intent: <what the framework is trying to achieve here + why a regression matters>.
 Cluster <NN><letter> — scenarios <start>–<end>. Type: <U | I | E>.
 Covers: <files covered>.
-Run: python -m lex pytest lex/test_project/tests/<topic>/test_<NN><letter>_<short>.py -v
+Run: python -m lex pytest lex/test_project/tests/<cluster_slug>/test_<NN><letter>_<short>.py -v
 """
+
+import pytest
+
+pytestmark = pytest.mark.<cluster_slug>
+
+
+class TestCluster<NN><letter>_<Description>(<SimpleTestCase | TestCase | APITestCase | E2ETestCase>):
+    """Cluster <NN><letter>: <description>."""
+
+    def test_<NN>_<NN>_<behaviour>(self):
+        """
+        Scenario <X>.<Y>: <one-line description>
+        Given: <setup>
+        When: <action>
+        Then: <expected outcome — derived from docs/intent, not from the implementation>
+        """
+        ...  # every assertion carries a human-readable failure message
 ```
 
 **Coverage pairing (critical):** the test must import the changed source module OR share its
 filename stem, or the coverage gate rejects it. This is the local mirror of the cloud paradigm —
 the gate would otherwise open a `coverage-task` issue and assign Copilot. Pre-empt that here.
 
-## Step 7 — Keep the plan honest (mandatory)
+## Step 7 — Definition of Done: bring the plan into sync (mandatory)
 
-1. **Append the batch row** to the right cluster section in `test-writing-plan.md`, matching the
-   most recent batch's table shape. Set *Tests landed* and *Coverage gain* to
-   `pending — measured after run`; update them once you've run the suite, then flip *Status* to
-   ✅ Complete.
+**The task is NOT done until the test-plan on disk matches the tests you wrote.** Writing the test
+is only half the job — do all of this in the **same change**, not as optional follow-up:
+
+1. **Append/update the batch row** in the right cluster section of `test-writing-plan.md`, matching
+   the most recent batch's table shape (scenario range, type U/I/E, files covered, test file path,
+   test classes, fixtures, status). After you run the suite (Step 8), record the **real** results
+   (`Tests landed: N pass / 0 fail`, measured coverage gain) and flip *Status* to ✅ Complete.
+   Don't leave `pending` placeholders in a finished change.
 
 2. **If a test exposes a real framework bug, record it — don't weaken the test.** Per the
    `known-bugs.md` workflow: assert the *correct* behaviour, mark the test
-   `@unittest.expectedFailure`, and add a `BUG-NNN` row (description, severity, cluster, test,
-   status). The marker is dropped when the framework is fixed; the test becomes a live regression
-   gate. Never soften an assertion to make a real bug pass.
+   `@unittest.expectedFailure` (or `@pytest.mark.xfail(strict=True)` for post-cutover tests), and
+   add a `BUG-NNN` row (description, severity, cluster, test, status). The marker is dropped when
+   the framework is fixed; the test becomes a live regression gate. Never soften an assertion to
+   make a real bug pass.
+
+If the plan and the tests on disk disagree, you are not done.
 
 ## Step 8 — Run and report
 
@@ -131,8 +188,13 @@ Done. Next:
 
 ## Never
 
+- Start writing code or tests before the Step 0 research (docs for intent) — and never derive a
+  test by mirroring the implementation.
+- Put a feature test in the legacy `lex/tests/unit/`, `integration/`, or `e2e/` trees — cluster
+  tests go in `lex/test_project/tests/<cluster_slug>/`.
 - Pick a cluster letter without reading `test-writing-plan.md` first.
 - Skip the Step 5 confirmation.
 - Invent new clusters or renumber existing ones.
 - Write tests for a source file already slotted in an in-flight batch.
+- Finish without bringing `test-writing-plan.md` into sync with the tests on disk.
 - Soften an assertion to hide a real bug — record it in `known-bugs.md` instead.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -13,17 +13,28 @@ When these rules conflict with prior knowledge, **these rules win**. They reflec
 
 ---
 
+## 0. Before you write code or tests — research first (the Golden Rule)
+
+**Do not write code or tests from your first instinct, and never derive a test by mirroring the implementation.** The source code is an incomplete story — it has bugs and workarounds; a test that asserts "whatever the code does" locks those bugs in. This is the single most common failure mode here. Before writing anything:
+
+1. **Read the docs that describe intent** — [`docs/features/`](../../docs/features/), [`docs/reference/`](../../docs/reference/), [`docs/tutorial/`](../../docs/tutorial/). They say what the framework is *trying to achieve*. Derive the test from that, then *"What would a customer reasonably expect?"* (full statement: the Golden Rule in [`test-clusters.md`](../../lex/test_project/test-plan/test-clusters.md#testing-philosophy)).
+2. **Read the public API docstrings** of what you'll touch, and skim the existing cluster tests for that topic to match established patterns.
+3. **Check for an existing mechanism before inventing one.** E.g. cross-process state already lives in the cache-backed `ActiveCalculationStateStore` — don't add a process-local dict that fails silently across Celery workers. Search first.
+4. **If the request is ambiguous or has more than one defensible design, STOP and ask the developer** before coding — surface the trade-offs. A wrong assumption baked into a feature + its tests costs far more than one question. (Claude Code: use the `superpowers:brainstorming` skill.)
+
+If a test fails because the code is genuinely buggy, that is the test doing its job → §6.
+
 ## 1. Where tests live
+
+**Feature/bugfix work on framework source goes into the cluster system** — this is the active, plan-tracked, release-gating suite:
 
 | Layer | Path | Use for |
 | --- | --- | --- |
-| Framework unit | `lex/tests/unit/<topic>/test_*.py` | Pure logic, single-class behaviour, no DB if possible. Topic subdirs: `api/`, `audit/`, `auth/`, `calculation/`, `cli/`, `core/`, `crud/`, `grid/`, `infra/`, `serialization/`, `temporal/`. |
-| Framework integration | `lex/tests/integration/test_*.py` | Multi-component flows, bitemporal chains, audit recovery. |
-| Framework E2E | `lex/tests/e2e/test_*.py` | Full user journeys through REST `APIClient`. |
-| Project-cluster tests | `lex/test_project/tests/<topic>/test_<cluster>.py` | Cluster-based test plan (see §5). |
+| **Cluster tests (default for feature work)** | `lex/test_project/tests/<cluster_slug>/test_<NN><letter>_<short>.py` | Any test paired with a framework source change. Plan-tracked (see §5, §6). |
 | Frontend | `frontend/src/__test__/*.test.{ts,tsx}` | Vitest, jsdom env. |
+| Legacy framework audit | `lex/tests/unit/<topic>/`, `lex/tests/integration/`, `lex/tests/e2e/` | **Pre-existing** suite. **Do not add new feature tests here** — it bypasses the cluster plan and the coverage-task tracking. Only touch when extending an existing file in it. |
 
-**Do not invent new top-level directories.** If unsure where a new test belongs, place it under `lex/tests/unit/<existing-topic>/` and ask the reviewer.
+**Do not invent new top-level directories**, and **do not** drop a feature test into `lex/tests/unit/` to avoid cluster allocation — that is exactly the escape hatch that breaks plan consistency.
 
 ## 2. Test runner
 
@@ -52,25 +63,31 @@ When you write a test for new code, ensure **at least one** of those is true. Th
 
 **This is the local mirror of the cloud paradigm:** the cloud coverage gate opens a `coverage-task` issue and assigns Copilot to write the missing test against the parent PR's head branch. Locally, you pre-empt that by writing the paired test in the same change — so the gate stays green and no follow-up task is needed.
 
-## 5. Cluster test-plan — naming & allocation
+## 5. Cluster test-plan — strict naming & allocation
 
-Project-cluster tests under `lex/test_project/tests/` follow the plan in [`lex/test_project/test-plan/`](../../lex/test_project/test-plan/). The allocation rules are strict — **follow them, don't improvise**:
+Cluster tests follow the plan in [`lex/test_project/test-plan/`](../../lex/test_project/test-plan/) and the conventions in [`progress/conventions.md`](../../lex/test_project/test-plan/progress/conventions.md). These rules are **strict — follow them exactly, don't improvise**:
 
-- **Test files:** `test_<module_stem>.py` (default) or `test_<cluster><letter>_<short_description>.py` (when extending the cluster plan).
-- **Test classes:** `Test<Topic>` for ad-hoc tests; `TestCluster<NN><letter>_<Description>` when contributing to the cluster plan (e.g. `TestCluster01p_SettingsConstants`).
-- **Test methods:** `test_<behaviour_under_test>` — verb-led, describes the assertion, not the setup.
-- **Cluster numbers are never renumbered.** Extend a cluster with the next free **letter**; scenario IDs continue from the cluster's current max. The authoritative source is [`test-writing-plan.md`](../../lex/test_project/test-plan/test-writing-plan.md) — read it before allocating, never guess the next letter.
-- **One batch = one sub-cluster = one PR.**
+1. **Identify the cluster.** Map the source area to a cluster via [`test-clusters.md`](../../lex/test_project/test-plan/test-clusters.md) (e.g. calculation flow → cluster 7, audit → 6, CRUD/serializers → 2/12, exports → 13, AG-Grid → 14).
+2. **Allocate from `test-writing-plan.md` — never guess.** Cluster numbers are **never renumbered**. Take the **next free letter** for that cluster (read the plan to find the highest in use), and **continue scenario IDs from the cluster's current max**. If the source file is already slotted in an in-flight batch, defer to it — don't duplicate.
+3. **File:** `lex/test_project/tests/<cluster_slug>/test_<NN><letter>_<short>.py` (e.g. `test_7m_cancellation.py`).
+4. **Module header:** an `Intent` docstring section (what the framework is *trying to achieve* + why a regression matters + the scenario range), plus module-level `pytestmark = pytest.mark.<cluster_slug>`. See [`test_7k_exceptions_restrictions_xlsx.py`](../../lex/test_project/tests/calculations/test_7k_exceptions_restrictions_xlsx.py) as the gold standard.
+5. **Class:** `TestCluster<NN><letter>_<Description>` (e.g. `TestCluster07m_Cancellation`). For E-type, inherit `E2ETestCase` and declare `e2e_models`.
+6. **Methods:** `test_<NN>_<NN>_<behaviour>` with a docstring `Scenario X.Y: <one-line> / Given: … / When: … / Then: …`. Every assertion carries a human-readable failure message.
+7. **One batch = one sub-cluster = one PR.**
 
 Claude Code users: the [`lex-testing` skill](../../.claude/skills/lex-testing/SKILL.md) walks this allocation automatically.
 
-## 6. After writing tests — keep the plan honest (mandatory)
+## 6. Definition of Done — the task is not finished until the plan is consistent
 
-Writing the test is only half the job. Tests are the project's living record, so you update the plan in the **same change**:
+Writing the test is only half the job. **A feature/test task is NOT done until the test-plan on disk matches the tests you wrote.** Do all of this in the **same change**:
 
-1. **Append/update the batch row** in [`test-writing-plan.md`](../../lex/test_project/test-plan/test-writing-plan.md), under the right cluster, matching the table shape of the most recent batch. Fill scenario range, type (U/I/E), files covered, test file path, test classes, fixtures. Set *Tests landed* and *Coverage gain* to `pending — measured after run` until you have real numbers, then update them and flip *Status* to ✅ Complete.
+1. **Append/update the batch row** in [`test-writing-plan.md`](../../lex/test_project/test-plan/test-writing-plan.md), under the right cluster, matching the table shape of the most recent batch. Fill scenario range, type (U/I/E), files covered, test file path, test classes, fixtures, status.
 
-2. **If a test surfaces broken framework behaviour, record the bug — don't weaken the test.** Per the workflow in [`known-bugs.md`](../../lex/test_project/test-plan/known-bugs.md): write the test asserting the *correct* behaviour (from docs/intent), mark it `@unittest.expectedFailure`, and add a `BUG-NNN` row (description, severity, cluster, test, status). When the framework is later fixed, the marker is dropped and the test passes naturally — a permanent regression gate. **Never** soften an assertion to make a real bug "pass".
+2. **Run the tests** (`python -m lex pytest <path>`) and record the **real** results in the batch row (`Tests landed: N pass / 0 fail`, measured coverage gain) — flip *Status* to ✅ Complete. Don't leave `pending` placeholders in a finished change.
+
+3. **If a test surfaces broken framework behaviour, record the bug — don't weaken the test.** Per the workflow in [`known-bugs.md`](../../lex/test_project/test-plan/known-bugs.md): write the test asserting the *correct* behaviour (from docs/intent), mark it `@unittest.expectedFailure` (or `@pytest.mark.xfail(strict=True)`), and add a `BUG-NNN` row (description, severity, cluster, test, status). When the framework is later fixed, the marker is dropped and the test passes naturally — a permanent regression gate. **Never** soften an assertion to make a real bug "pass".
+
+If the plan and the tests on disk disagree, you are not done.
 
 ## 7. What NOT to do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,85 @@
 # AGENTS.md — lex-app
 
-Cross-tool guidance for AI coding agents (Claude Code, Copilot coding agent, Cursor, Codex)
+Cross-tool guidance for AI coding agents (Claude Code, Copilot coding/agent mode, Cursor, Codex)
 working in this repository. These are defaults, not overrides: explicit user instructions and
-`CLAUDE.md` win where they conflict.
+`CLAUDE.md` win where they conflict. **Read this file fully before starting any task** — it is the
+contract for how work is done here.
 
 `lex-app` is a Django framework shipped as a pip package. The frontend lives in a separate repo
 (`process-admin-general-client`); the docs live in `lex-app-docs`.
 
-## Three things to know before you touch anything
+## Prime directive 1 — Research before you write code
 
-1. **The docs are authoritative.** Read the relevant files under [`docs/`](docs/) before
-   implementing a feature. If your training data disagrees with the docs, the docs win. Start
-   from [`docs/index.md`](docs/index.md) when unsure which file applies.
+**Do not start implementing from your first instinct.** Framework code here has bugs, workarounds,
+and non-obvious lifecycle rules; guessing produces plausible-looking code that is wrong in
+production. Before writing feature code or tests:
 
-2. **Changing framework source means writing tests — automatically.** When you add or modify code
-   under `lex/` (the framework: `lex/lex_app/`, `lex/core/`, `lex/api/`, `lex/audit_logging/`,
-   `lex/process_admin/`, …), you write the paired tests in the **same change**, following the
-   cluster-based test-plan. This is not optional and you do not need to be asked — the CI coverage
-   gate (`copilot_coverage_check.yml`) blocks any source change that arrives without a paired test,
-   so local work mirrors what the cloud agent does. The full rules live in
-   [`.github/instructions/testing.instructions.md`](.github/instructions/testing.instructions.md)
-   and the authoritative plan is [`lex/test_project/test-plan/`](lex/test_project/test-plan/).
+1. **Read the docs that describe the intent**, not just the code: [`docs/`](docs/) — especially
+   [`docs/features/`](docs/features/), [`docs/reference/`](docs/reference/),
+   [`docs/tutorial/`](docs/tutorial/). The docs describe what the framework is *trying to achieve*;
+   the source is an incomplete story. Start at [`docs/index.md`](docs/index.md) if unsure.
+2. **Read the public API docstrings** of the classes/functions you'll touch, and skim the existing
+   tests for that area (under `lex/test_project/tests/<topic>/`) to see the established patterns.
+3. **Check for existing mechanisms before inventing new ones.** Example: cross-process state
+   already has a cache-backed home (`ActiveCalculationStateStore`); don't add a process-local dict
+   that silently fails across Celery workers. Search the codebase for the capability first.
+4. **If the request is ambiguous or has more than one defensible design, STOP and ask the
+   developer** targeted questions before coding — surface the trade-offs and let them choose. A
+   wrong assumption baked into a feature + its tests is far more expensive than one question.
+   (Claude Code: use the `superpowers:brainstorming` skill for this.)
 
-3. **Tests keep the plan honest.** After writing tests you update the batch row in
-   [`test-writing-plan.md`](lex/test_project/test-plan/test-writing-plan.md), and if a test
-   surfaces broken framework behaviour you record it in
-   [`known-bugs.md`](lex/test_project/test-plan/known-bugs.md) (assert the *correct* behaviour,
-   mark `@unittest.expectedFailure`, add a `BUG-NNN` row) rather than weakening the test.
+When your prior knowledge conflicts with the docs, **the docs win.**
+
+## Prime directive 2 — Changing framework source means writing cluster tests, automatically
+
+When you add or modify code under `lex/` (`lex/lex_app/`, `lex/core/`, `lex/api/`,
+`lex/audit_logging/`, `lex/process_admin/`, …), you write the paired tests in the **same change**,
+following the **cluster test-plan** — without being asked. The CI coverage gate
+(`copilot_coverage_check.yml`) blocks any source change that arrives without a paired test, so local
+work must mirror what the cloud agent does.
+
+**Tests are derived from intent (docs), never by mirroring the implementation you just wrote.**
+Writing a test that asserts whatever the code happens to do locks in bugs — this is the single most
+common failure here (see the Golden Rule in
+[`lex/test_project/test-plan/test-clusters.md`](lex/test_project/test-plan/test-clusters.md)).
+
+Where the tests go and how they're named is **strict** — do not improvise:
+
+- **Location:** `lex/test_project/tests/<cluster_slug>/` (the cluster system). **Not**
+  `lex/tests/unit/` — that is the legacy audit tree; do not add new feature tests there.
+- **Allocation:** map the change to a cluster, take the **next free letter** for that cluster, and
+  continue scenario IDs from the cluster's current max. The authoritative source is
+  [`test-writing-plan.md`](lex/test_project/test-plan/test-writing-plan.md) — **read it to allocate;
+  never guess the letter.**
+- **Names:** file `test_<NN><letter>_<short>.py`, class `TestCluster<NN><letter>_<Description>`,
+  module-level `pytestmark = pytest.mark.<cluster_slug>`, methods `test_<NN>_<NN>_<behaviour>` with a
+  `Scenario X.Y: … / Given / When / Then` docstring, and an `Intent` header on the file.
+
+Full rules: [`.github/instructions/testing.instructions.md`](.github/instructions/testing.instructions.md).
+Claude Code: the [`lex-testing` skill](.claude/skills/lex-testing/SKILL.md) automates the allocation.
+
+## Prime directive 3 — A task is not done until the test-plan is consistent
+
+After the feature + tests, you bring the plan into sync **in the same change** — this is part of
+finishing, not optional cleanup:
+
+1. **Append/update the batch row** in
+   [`test-writing-plan.md`](lex/test_project/test-plan/test-writing-plan.md) for the cluster: scenario
+   range, type (U/I/E), files covered, test file path, test classes, fixtures, status.
+2. **If a test surfaced broken framework behaviour**, record it in
+   [`known-bugs.md`](lex/test_project/test-plan/known-bugs.md) (assert the *correct* behaviour, mark
+   `@unittest.expectedFailure` / `@pytest.mark.xfail(strict=True)`, add a `BUG-NNN` row) — **never
+   weaken the test to make it pass.**
+3. **Run the tests** (`python -m lex pytest <path>`) and record real results in the batch row.
+
+If the plan and the tests on disk disagree, the task is not finished.
 
 ## What you'll be asked to do here
 
-- **Develop a feature in lex-app** → read docs, implement, write paired cluster tests, run them,
-  update the plan. See directive 2 above.
-- **Develop in a downstream Lex project** (not this framework repo) → follow the project's own
-  conventions and [`docs/`](docs/); the cluster test-plan rules are framework-internal and do
-  **not** apply to downstream app code.
+- **Develop a feature/bugfix in lex-app** → directives 1→2→3, in that order.
+- **Develop in a downstream Lex project** (not this framework repo) → follow that project's own
+  conventions and [`docs/`](docs/); the cluster test-plan rules are framework-internal and do **not**
+  apply to downstream app code.
 - **Run the tests** → `python -m lex pytest <path>` (or `lex test <labels>`). Never `manage.py test`.
 - **Answer a question** → the answer is usually in [`docs/`](docs/) or `lex-app-docs`. Read before
   asserting; don't guess at framework APIs.
@@ -43,8 +88,9 @@ working in this repository. These are defaults, not overrides: explicit user ins
 
 | Topic | Where |
 | --- | --- |
-| Testing rules (always read before writing a test) | [`.github/instructions/testing.instructions.md`](.github/instructions/testing.instructions.md) |
-| Authoritative test-plan (clusters, allocation, bug tracker) | [`lex/test_project/test-plan/`](lex/test_project/test-plan/) |
+| Testing rules (read before writing any test) | [`.github/instructions/testing.instructions.md`](.github/instructions/testing.instructions.md) |
+| Authoritative test-plan (clusters, allocation, Golden Rule, bug tracker) | [`lex/test_project/test-plan/`](lex/test_project/test-plan/) |
+| Test conventions (naming, run commands, quality gates) | [`lex/test_project/test-plan/progress/conventions.md`](lex/test_project/test-plan/progress/conventions.md) |
 | Framework conventions & feature docs | [`docs/`](docs/) |
 | Session history & CI/CD architecture | [`CLAUDE.md`](CLAUDE.md), [`docs/ci-cd/`](docs/ci-cd/) |
 | Claude Code skill for cluster tests | [`.claude/skills/lex-testing/SKILL.md`](.claude/skills/lex-testing/SKILL.md) |

--- a/docs/superpowers/specs/2026-05-28-copilot-local-rules-design.md
+++ b/docs/superpowers/specs/2026-05-28-copilot-local-rules-design.md
@@ -3,6 +3,26 @@
 **Date:** 2026-05-28 (revised 2026-05-29)
 **Status:** Implemented — testing scope. Other domains deferred.
 
+> **2026-05-29 hardening pass (from a live PyCharm test).** A real run — prompt *"in CalculationModel.py
+> we need a way to cancel the Calculation"*, Copilot agent mode (Opus 4.7) — exposed three gaps that
+> this revision closes:
+> 1. **The agent skipped docs research** and coded from first instinct (it added a process-global
+>    `_CancellationRegistry` dict that can't share state web→Celery-worker — the cache-backed
+>    `ActiveCalculationStateStore` already exists for exactly this). → Added an explicit
+>    **research-first / Golden-Rule** step as Prime directive 1 (AGENTS.md), §0 (instructions), and
+>    Step 0 (skill), including *stop-and-ask-the-dev when ambiguous* via `superpowers:brainstorming`.
+> 2. **The test landed in legacy `lex/tests/unit/`** and the test-plan was never updated. → Demoted
+>    the legacy tree to "do not add new feature tests here", made the cluster tree the primary/default
+>    home, and made **plan-consistency the Definition of Done** (Prime directive 3 / §6 / Step 7).
+> 3. **Strict cluster naming was not followed.** → Reinforced the strict allocation steps and added a
+>    full scaffold template (Intent header, `pytestmark`, `TestCluster<NN><letter>_`, Given/When/Then).
+>
+> **PyCharm finding (load-bearing):** JetBrains Copilot (March 2026+ plugin) autodetects `AGENTS.md`
+> and `CLAUDE.md`, but does **not** honour `.github/instructions/*.instructions.md` `applyTo` globs —
+> that mechanism is VS Code-only. So in the user's IDE **`AGENTS.md` is the load-bearing file**; the
+> path-scoped instructions file only auto-loads for the cloud agent and VS Code Copilot Chat. This is
+> why the three prime directives were pushed up into AGENTS.md rather than left in the instructions file.
+
 ## Problem
 
 The Copilot Coding Agent (cloud) writes tests that follow the lex-app conventions (cluster naming,


### PR DESCRIPTION
## Summary

A live PyCharm test (prompt: *"in CalculationModel.py we need a way to cancel the Calculation"*, Copilot agent mode, Opus 4.7) exposed three gaps in the no-trigger local-agent rules shipped in #531:

1. **No research before coding** — the agent built from first instinct, adding a process-global `_CancellationRegistry` dict that can't share cancel state web→Celery-worker, when the cache-backed `ActiveCalculationStateStore` already exists for exactly that.
2. **Test landed in the legacy tree** (`lex/tests/unit/`) instead of the plan-tracked cluster system, and the test-plan was never updated.
3. **Strict cluster naming not followed.**

This pass closes those gaps across all three artifacts.

## Changes

- **`AGENTS.md`** — restructured into three prime directives: research-before-code (read intent docs, check for existing mechanisms, stop-and-ask when ambiguous), write cluster tests automatically, and plan-consistency as the Definition of Done. AGENTS.md is the **load-bearing** file in PyCharm because JetBrains Copilot does not honour `.github/instructions/*.instructions.md` `applyTo` globs (VS Code-only).
- **`.github/instructions/testing.instructions.md`** — new research-first §0 (the Golden Rule), cluster tree made primary with the legacy `lex/tests/unit/` tree demoted to "do not add new feature tests here", strict 7-step allocation, and a "Definition of Done" §6.
- **`.claude/skills/lex-testing/SKILL.md`** — Step 0 docs-first research, explicit cluster path, scaffold template (Intent header, `pytestmark`, `TestCluster<NN><letter>_`, Given/When/Then), plan-consistency as Definition of Done.
- **design spec** — records the PyCharm finding and the hardening rationale.

Excludes the agent's experimental cancellation code and misplaced test — those are not part of the rules work.

## Test plan

- [ ] Re-run the same PyCharm prompt and confirm the agent reads intent docs first, places the test in the cluster tree, and updates `test-writing-plan.md`.
- [ ] Confirm the `lex-testing` skill auto-activates in Claude Code on a framework-source edit and walks the allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)