### PR TITLE
Unify cloud + local agent prompt contract: research-first + shared Definition of Done

### DIFF
--- a/.claude/skills/lex-testing/SKILL.md
+++ b/.claude/skills/lex-testing/SKILL.md
@@ -158,15 +158,23 @@ the gate would otherwise open a `coverage-task` issue and assign Copilot. Pre-em
 ## Step 7 — Definition of Done: bring the plan into sync (mandatory)
 
 **The task is NOT done until the test-plan on disk matches the tests you wrote.** Writing the test
-is only half the job — do all of this in the **same change**, not as optional follow-up:
+is only half the job. This mirrors the **cloud Copilot agent's required deliverables**
+(`.github/scripts/copilot_assemble_prompt.py`) so both paths stay consistent — do all of this in the
+**same change**, not as optional follow-up:
 
-1. **Append/update the batch row** in the right cluster section of `test-writing-plan.md`, matching
-   the most recent batch's table shape (scenario range, type U/I/E, files covered, test file path,
-   test classes, fixtures, status). After you run the suite (Step 8), record the **real** results
-   (`Tests landed: N pass / 0 fail`, measured coverage gain) and flip *Status* to ✅ Complete.
-   Don't leave `pending` placeholders in a finished change.
+1. **Append a row to `progress/session-log.md`** — the universal per-PR record (its header: "the
+   Copilot test-bot writes here as part of every PR"). Append-only, bottom row, never re-order.
 
-2. **If a test exposes a real framework bug, record it — don't weaken the test.** Per the
+2. **Update the cluster status / scenario range** in `test-clusters.md` for each touched
+   (sub-)cluster, and bump the matching row in `progress/dashboard.md`.
+
+3. **If the work maps to a planned batch, append/update the batch row** in `test-writing-plan.md`,
+   matching the most recent batch's table shape (scenario range, type U/I/E, files covered, test
+   file path, test classes, fixtures, status). After you run the suite (Step 8), record the **real**
+   results (`N pass / 0 fail`, measured coverage gain) in the rows above and flip *Status* to
+   ✅ Complete. Don't leave `pending` placeholders in a finished change.
+
+4. **If a test exposes a real framework bug, record it — don't weaken the test.** Per the
    `known-bugs.md` workflow: assert the *correct* behaviour, mark the test
    `@unittest.expectedFailure` (or `@pytest.mark.xfail(strict=True)` for post-cutover tests), and
    add a `BUG-NNN` row (description, severity, cluster, test, status). The marker is dropped when

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -79,13 +79,17 @@ Claude Code users: the [`lex-testing` skill](../../.claude/skills/lex-testing/SK
 
 ## 6. Definition of Done — the task is not finished until the plan is consistent
 
-Writing the test is only half the job. **A feature/test task is NOT done until the test-plan on disk matches the tests you wrote.** Do all of this in the **same change**:
+Writing the test is only half the job. **A feature/test task is NOT done until the test-plan on disk matches the tests you wrote.** This is the **same checklist the cloud Copilot agent satisfies on every PR** (see `.github/scripts/copilot_assemble_prompt.py` → "Required deliverables") — local work must match it so the two paths stay consistent. Do all of this in the **same change**:
 
-1. **Append/update the batch row** in [`test-writing-plan.md`](../../lex/test_project/test-plan/test-writing-plan.md), under the right cluster, matching the table shape of the most recent batch. Fill scenario range, type (U/I/E), files covered, test file path, test classes, fixtures, status.
+1. **Append a row to [`session-log.md`](../../lex/test_project/test-plan/progress/session-log.md)** — this is the *universal* per-PR record (its header: "the Copilot test-bot writes here as part of every PR"). Append-only: new row at the bottom, never re-order. Columns: date, session, what was done, clusters affected, tests added, tests passing.
 
-2. **Run the tests** (`python -m lex pytest <path>`) and record the **real** results in the batch row (`Tests landed: N pass / 0 fail`, measured coverage gain) — flip *Status* to ✅ Complete. Don't leave `pending` placeholders in a finished change.
+2. **Update the cluster's status / scenario range** in [`test-clusters.md`](../../lex/test_project/test-plan/test-clusters.md) for **each** (sub-)cluster you touched, and bump the matching row in [`dashboard.md`](../../lex/test_project/test-plan/progress/dashboard.md) (the high-churn per-cluster status view).
 
-3. **If a test surfaces broken framework behaviour, record the bug — don't weaken the test.** Per the workflow in [`known-bugs.md`](../../lex/test_project/test-plan/known-bugs.md): write the test asserting the *correct* behaviour (from docs/intent), mark it `@unittest.expectedFailure` (or `@pytest.mark.xfail(strict=True)`), and add a `BUG-NNN` row (description, severity, cluster, test, status). When the framework is later fixed, the marker is dropped and the test passes naturally — a permanent regression gate. **Never** soften an assertion to make a real bug "pass".
+3. **If your work maps to a planned batch, append/update the batch row** in [`test-writing-plan.md`](../../lex/test_project/test-plan/test-writing-plan.md), under the right cluster, matching the table shape of the most recent batch (scenario range, type U/I/E, files covered, test file path, test classes, fixtures, status). Ad-hoc work that isn't a planned COMPLETE-bucket batch still needs steps 1–2; this step is for batches the plan already forecasts.
+
+4. **Run the tests** (`python -m lex pytest <path>`) and record the **real** results (`N pass / 0 fail`, measured coverage gain) in the rows above — flip *Status* to ✅ Complete. Don't leave `pending` placeholders in a finished change.
+
+5. **If a test surfaces broken framework behaviour, record the bug — don't weaken the test.** Per the workflow in [`known-bugs.md`](../../lex/test_project/test-plan/known-bugs.md): write the test asserting the *correct* behaviour (from docs/intent), mark it `@unittest.expectedFailure` (or `@pytest.mark.xfail(strict=True)`), and add a `BUG-NNN` row (description, severity, cluster, test, status). When the framework is later fixed, the marker is dropped and the test passes naturally — a permanent regression gate. **Never** soften an assertion to make a real bug "pass".
 
 If the plan and the tests on disk disagree, you are not done.
 

--- a/.github/scripts/copilot_assemble_prompt.py
+++ b/.github/scripts/copilot_assemble_prompt.py
@@ -108,6 +108,17 @@ def assemble_prompt(issue: IssueInput, *, test_plan_dir: Path) -> str:
 
 ---
 
+## Research before you write code
+
+The Golden Rule above tells you *not* to mirror the implementation. This tells you what to do instead — **gather intent before writing anything**:
+
+1. **Read the docs that describe intent**, not just the code: `docs/features/`, `docs/reference/`, `docs/tutorial/`. Derive the behaviour you assert from what the framework is *trying to achieve* + what a customer would reasonably expect.
+2. **Read the public API docstrings** of the classes/functions involved, and skim the existing cluster tests for that area to match established patterns.
+3. **Check for an existing mechanism before inventing one.** Cross-process state, for example, already has a cache-backed home (`ActiveCalculationStateStore`) — don't add a process-local dict that silently fails across Celery workers. Search the repo for the capability first.
+4. **If the behaviour is genuinely ambiguous** (the docs don't settle it and there's more than one defensible contract), state your assumption explicitly in the PR description and pick the option a customer would expect — don't silently guess.
+
+---
+
 ## Test-plan conventions
 
 {conventions_md.strip()}
@@ -193,6 +204,8 @@ For each test file you create (primary + each secondary):
 - One or more new test files under `lex/test_project/tests/<slug>/test_<Nx>_<short>.py` — one per cluster involved (regression mode may have several; bug-repro and fix-and-test have exactly one).
 - `lex/test_project/test-plan/test-clusters.md` updated (status / scenario range for **each** touched (sub-)cluster).
 - One new row appended to the bottom of `lex/test_project/test-plan/progress/session-log.md` summarising all touched clusters in this PR.
+- Bump the matching per-cluster status row in `lex/test_project/test-plan/progress/dashboard.md`.
+- If your work corresponds to a planned batch in `lex/test_project/test-plan/test-writing-plan.md`, append/update that batch row (scenario range, files covered, test classes, fixtures, status) so the allocation tracker stays consistent.
 - Mode B/C only: one new BUG-NNN row in `lex/test_project/test-plan/known-bugs.md`.
 - New-cluster placement only: register the new cluster in `.github/scripts/showcase_clusters.py` and update default selectors in `pip_publish.yml` + `showcase_tests.yml`.
 - Touch nothing outside the allowed file set, except the source fix in mode `fix-and-test`.

--- a/.github/scripts/tests/test_copilot_assemble_prompt.py
+++ b/.github/scripts/tests/test_copilot_assemble_prompt.py
@@ -187,6 +187,33 @@ def test_assembled_prompt_teaches_multi_cluster_decomposition(fake_test_plan: Pa
     assert "audit_logging" in out
 
 
+def test_assembled_prompt_includes_research_first_block(fake_test_plan: Path) -> None:
+    """The PyCharm live test exposed that a Copilot agent will code from first
+    instinct (reinventing cross-process state instead of reusing the existing
+    cache-backed store) when the prompt only says 'don't mirror the code'. The
+    prompt must also tell the agent what to do FIRST: read docs for intent and
+    check for an existing mechanism before inventing one."""
+    out = assemble_prompt(_basic_issue(Mode.REGRESSION), test_plan_dir=fake_test_plan)
+    assert "Research before you write code" in out
+    # Reads docs for intent.
+    assert "docs/features/" in out
+    # The concrete anti-pattern from the live failure: reinventing existing state.
+    assert "ActiveCalculationStateStore" in out
+    # Research must come before the mode block (front-loaded, like the Golden Rule).
+    assert out.index("Research before you write code") < out.index("## Mode: regression")
+
+
+def test_assembled_prompt_lists_full_done_doc_set(fake_test_plan: Path) -> None:
+    """Definition-of-Done parity with the local AGENTS.md rules: the deliverables
+    must name the universal session-log row, the dashboard status bump, AND the
+    test-writing-plan batch row — so the cloud and local paths update the same
+    docs and don't drift."""
+    out = assemble_prompt(_basic_issue(Mode.REGRESSION), test_plan_dir=fake_test_plan)
+    assert "progress/session-log.md" in out
+    assert "progress/dashboard.md" in out
+    assert "test-writing-plan.md" in out
+
+
 def test_bug_repro_and_fix_and_test_constrained_to_single_file(fake_test_plan: Path) -> None:
     """Multi-cluster decomposition is REGRESSION-only. Bug-repro and
     fix-and-test stay single-file (a multi-file bug-repro dilutes the

--- a/.github/workflows/copilot_coverage_check.yml
+++ b/.github/workflows/copilot_coverage_check.yml
@@ -261,7 +261,23 @@ jobs:
 
           ${UNTESTED}
 
-          Write regression tests for the behaviour these files now express. Follow the test-plan rules in \`lex/test_project/test-plan/\`.
+          Write regression tests for the behaviour these files now express.
+
+          ### Research first (do not skip)
+
+          Derive what to test from **intent**, not from the code you see. Before writing:
+          - Read the docs that describe these files' intent — \`docs/features/\`, \`docs/reference/\`, \`docs/tutorial/\` — and assert what the framework is *trying to achieve* + what a customer would expect. **This is the Golden Rule** (full statement: \`lex/test_project/test-plan/test-clusters.md\` → Testing Philosophy). A test that mirrors a buggy implementation locks the bug in.
+          - Check for an existing mechanism before assuming new behaviour; skim the existing cluster tests for the area to match patterns.
+
+          ### Where the tests go (strict)
+
+          Cluster tree only: \`lex/test_project/tests/<cluster_slug>/test_<Nx>_<short>.py\`. Allocate the next free sub-cluster letter and continue scenario IDs per \`lex/test_project/test-plan/test-writing-plan.md\` — do not invent clusters or drop tests in the legacy \`lex/tests/unit/\` tree.
+
+          ### Definition of Done (same as every test PR)
+
+          - Append a row to \`lex/test_project/test-plan/progress/session-log.md\` (universal per-PR record).
+          - Update the touched cluster's status / scenario range in \`lex/test_project/test-plan/test-clusters.md\` and bump \`progress/dashboard.md\`.
+          - If a test surfaces a real framework bug, assert the correct behaviour, mark \`@unittest.expectedFailure\` / \`@pytest.mark.xfail(strict=True)\`, and add a \`BUG-NNN\` row to \`known-bugs.md\` — never weaken the assertion.
 
           End your PR body with \`Fixes #<this issue number>\`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,16 +61,25 @@ Claude Code: the [`lex-testing` skill](.claude/skills/lex-testing/SKILL.md) auto
 ## Prime directive 3 — A task is not done until the test-plan is consistent
 
 After the feature + tests, you bring the plan into sync **in the same change** — this is part of
-finishing, not optional cleanup:
+finishing, not optional cleanup. This is the **same checklist the cloud Copilot agent satisfies on
+every PR** (`.github/scripts/copilot_assemble_prompt.py` → "Required deliverables"); local work
+matches it so the two paths don't drift:
 
-1. **Append/update the batch row** in
-   [`test-writing-plan.md`](lex/test_project/test-plan/test-writing-plan.md) for the cluster: scenario
-   range, type (U/I/E), files covered, test file path, test classes, fixtures, status.
-2. **If a test surfaced broken framework behaviour**, record it in
+1. **Append a row to [`session-log.md`](lex/test_project/test-plan/progress/session-log.md)** — the
+   universal per-PR record ("the Copilot test-bot writes here as part of every PR"). Append-only,
+   bottom row, never re-order.
+2. **Update the cluster status / scenario range** in
+   [`test-clusters.md`](lex/test_project/test-plan/test-clusters.md) for each touched (sub-)cluster,
+   and bump [`dashboard.md`](lex/test_project/test-plan/progress/dashboard.md).
+3. **If the work maps to a planned batch**, append/update the batch row in
+   [`test-writing-plan.md`](lex/test_project/test-plan/test-writing-plan.md): scenario range, type
+   (U/I/E), files covered, test file path, test classes, fixtures, status.
+4. **Run the tests** (`python -m lex pytest <path>`) and record real results (`N pass / 0 fail`,
+   coverage gain) in the rows above.
+5. **If a test surfaced broken framework behaviour**, record it in
    [`known-bugs.md`](lex/test_project/test-plan/known-bugs.md) (assert the *correct* behaviour, mark
    `@unittest.expectedFailure` / `@pytest.mark.xfail(strict=True)`, add a `BUG-NNN` row) — **never
    weaken the test to make it pass.**
-3. **Run the tests** (`python -m lex pytest <path>`) and record real results in the batch row.
 
 If the plan and the tests on disk disagree, the task is not finished.
 


### PR DESCRIPTION
## Summary

Reading both Copilot pipelines end-to-end (the issue-form **test-bot path** via `assemble_prompt.py`, and the **coverage-gate path** in `copilot_coverage_check.yml`) showed they'd drifted into *two prompt systems over one test-plan*. This PR converges them on a single shared contract, fixing three gaps — the same class of gap the live PyCharm test exposed locally.

## What changed

**1. Research-first, now in the cloud prompt too.** `assemble_prompt.py` front-loaded the Golden Rule (*don't mirror the implementation*) but never said what to do **first**. Added a "Research before you write code" block — read `docs/` for intent, check for an existing mechanism before inventing (the `ActiveCalculationStateStore` anti-pattern from the live test), state assumptions when ambiguous — front-loaded ahead of the mode block.

**2. One shared Definition of Done.** The cloud required `session-log.md` + `test-clusters.md`; the local rules required a `test-writing-plan.md` batch row. Different docs → an agent satisfying one violated the other. Reconciled both onto the same checklist (`session-log.md` universal per-PR record + `test-clusters.md`/`dashboard.md` status + `test-writing-plan.md` batch row when applicable + `known-bugs.md` on bug), applied across `AGENTS.md`, `testing.instructions.md`, `SKILL.md`, and the cloud deliverables list.

**3. Enriched the weakest path (Path B).** The coverage-gate issue body was a thin two-liner with none of the Golden Rule / research-first / cluster-placement / DoD guidance the test-bot path front-loads. Enriched it to point at all four. **Kept as a text-only change** — fully rewiring Path B through `assemble_prompt.py` is a design change (the spec §7.2 deliberately defines the thin body), deferred for review.

## Tests

- Two new unit tests pin the new cloud-prompt contracts (research-first block + front-loaded ordering; full done-doc set).
- All **42** `.github/scripts/tests` pass; `copilot_coverage_check.yml` re-validated as well-formed YAML.

## Follow-ups deferred (flagged, not done)

- **Full Path B unification:** route the coverage gate through `assemble_prompt.py` (add a `coverage` mode keyed off the untested-file list) so there's one prompt builder. Higher risk — design change to a live automation.
- **Coverage-task → Copilot assignment:** `copilot_coverage_check.yml` opens the `coverage-task` issue but I found **no explicit `--assignee copilot-swe-agent` step** (the only assignment in the repo is the test-bot's). The spec's state machine implies Copilot picks it up — worth verifying it isn't relying on manual triage.

## Test plan

- [ ] Re-run a cloud test-bot task and confirm the assembled issue body contains the research-first block before the mode block.
- [ ] Trigger a coverage miss and confirm the enriched `coverage-task` body renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)