### PR TITLE
Assign Copilot to coverage-task issues so Path B advances

### DIFF
--- a/.github/workflows/copilot_coverage_check.yml
+++ b/.github/workflows/copilot_coverage_check.yml
@@ -270,11 +270,22 @@ jobs:
           *Coverage-task automation spec:* \`docs/superpowers/specs/2026-05-26-copilot-test-automation-pipeline-design.md\` §7
           EOF
 
+          # Assign Copilot so the agent actually picks the task up. Without
+          # this the issue is created but sits unassigned forever — the parent
+          # PR stays blocked on the red `coverage / required` check and a human
+          # has to chase it, defeating §7.1 ("one uniform workflow … so I don't
+          # have to manually chase contributors"). The spec's flow diagram and
+          # state machine both assume assignment ("creates issue → assigns
+          # Copilot → Copilot opens PR"). Mirrors copilot_test_bot.yml's
+          # `gh issue create … --assignee copilot-swe-agent`, and works here
+          # because this step already runs under COPILOT_PAT (a human PAT —
+          # GITHUB_TOKEN-created assignments don't reliably trigger the agent).
           ISSUE_URL=$(gh issue create \
             --repo "$GITHUB_REPOSITORY" \
             --title "[copilot-task] Coverage tests for PR #${PR_NUMBER}" \
             --body-file issue-body.md \
-            --label coverage-task)
+            --label coverage-task \
+            --assignee copilot-swe-agent)
           echo "Opened coverage-task issue: $ISSUE_URL"
 
           # Tag the parent PR. `needs-tests` is human-facing; the red


### PR DESCRIPTION
## Summary

The coverage gate (`copilot_coverage_check.yml`) opened the `coverage-task` issue but **never assigned Copilot to it**, so Path B automation stalled: the issue sat unassigned, the parent PR stayed blocked on the red `coverage / required` check, and a human had to chase it.

This adds `--assignee copilot-swe-agent` to the `gh issue create` call, mirroring `copilot_test_bot.yml` (Path A). It works here because the step already runs under `COPILOT_PAT` (a human PAT — `GITHUB_TOKEN`-created assignments don't reliably trigger the agent).

## Why this is the correct behavior

- The spec's intent (`docs/superpowers/specs/2026-05-26-copilot-test-automation-pipeline-design.md`) is "one uniform workflow … so I don't have to manually chase contributors" (§7.1) and its flow is explicitly "creates issue → assigns Copilot → Copilot opens PR" (line 73).
- §7.7 (decisions) contains **no** deliberate "don't assign" choice — the omission was a bug, not a design decision.

## Test plan

- [x] `copilot_coverage_check.yml` parses as valid YAML.
- [ ] On the next PR that touches `lex/lex_app/**` without paired tests, confirm the opened `coverage-task` issue is assigned to `copilot-swe-agent` and Copilot picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)