### PR TITLE
Require behaviour-surface enumeration before cluster allocation (all 3 agent front-ends)

### DIFF
--- a/.claude/skills/lex-testing/SKILL.md
+++ b/.claude/skills/lex-testing/SKILL.md
@@ -57,9 +57,31 @@ Read these before doing anything else; if any is missing, **stop and tell the us
 3. [`lex/test_project/test-plan/test-writing-plan.md`](../../../lex/test_project/test-plan/test-writing-plan.md) — current batch state, in-flight clusters, allocation rules.
 4. [`lex/test_project/test-plan/known-bugs.md`](../../../lex/test_project/test-plan/known-bugs.md) — bug-recording workflow.
 
-## Step 2 — Identify the cluster
+## Step 2 — Enumerate behaviour surfaces, then map each to its cluster
 
-Map the source module to a cluster using `test-clusters.md`. Common mappings:
+**First, list every externally-observable behaviour the change creates or changes** — don't reason
+about "the feature" as one thing. Each of these is a distinct surface needing its own scenario:
+
+- every new public entry point a caller can invoke (instance method, classmethod, REST endpoint,
+  management command — anything a customer or the framework dispatches),
+- every state transition or status change the change can produce,
+- every persisted or emitted side-effect (a written audit/history row, a signal or broadcast, a row
+  landing in a different terminal state),
+- every error/edge path (not-found, no-op, permission-denied, already-finished, failure-during-X).
+
+**A surface is only "covered" when a test drives it the way a real caller reaches it — end-to-end
+through the public entry point, not by exercising the private helper or in-memory data structure
+underneath it.** Testing the easy internal layer while leaving the public entry points and their
+integration paths unexercised is the single most common way a change *looks* tested but isn't. If
+your scenarios only touch the data structure and the no-op/error returns, you have not tested the
+feature — go back and add the happy-path and integration surfaces.
+
+**Then map each surface to its owning cluster — often more than one.** A single change frequently
+spans clusters: one that adds a state transition *and* a new REST endpoint *and* a new persisted
+side-effect has surfaces in three domains. Map by **what the surface is**, not where the source line
+lives — a REST surface belongs to the API-layer cluster even if the code sits on a model; a
+persisted side-effect belongs to the cluster owning that record type. Surfaces in different clusters
+become separate batches (Step 3 onward, run per cluster). Use `test-clusters.md`; common mappings:
 
 | Source area | Cluster |
 | --- | --- |
@@ -73,7 +95,9 @@ Map the source module to a cluster using `test-clusters.md`. Common mappings:
 | Model export / import | 13 |
 | List views, AG Grid | 14 |
 
-If the mapping is ambiguous, ask the user which cluster. Don't pick one blindly.
+If you can't confidently place a surface, **stop and ask the user** — don't pick one blindly. And if
+a surface genuinely cannot be exercised in the test environment, surface that explicitly — gate it
+with a documented reason (or ask), **never** silently omit it and still call the change tested.
 
 ## Step 3 — Allocate the next free letter and scenario range
 

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -67,13 +67,21 @@ When you write a test for new code, ensure **at least one** of those is true. Th
 
 Cluster tests follow the plan in [`lex/test_project/test-plan/`](../../lex/test_project/test-plan/) and the conventions in [`progress/conventions.md`](../../lex/test_project/test-plan/progress/conventions.md). These rules are **strict — follow them exactly, don't improvise**:
 
-1. **Identify the cluster.** Map the source area to a cluster via [`test-clusters.md`](../../lex/test_project/test-plan/test-clusters.md) (e.g. calculation flow → cluster 7, audit → 6, CRUD/serializers → 2/12, exports → 13, AG-Grid → 14).
-2. **Allocate from `test-writing-plan.md` — never guess.** Cluster numbers are **never renumbered**. Take the **next free letter** for that cluster (read the plan to find the highest in use), and **continue scenario IDs from the cluster's current max**. If the source file is already slotted in an in-flight batch, defer to it — don't duplicate.
-3. **File:** `lex/test_project/tests/<cluster_slug>/test_<NN><letter>_<short>.py` (e.g. `test_7m_cancellation.py`).
-4. **Module header:** an `Intent` docstring section (what the framework is *trying to achieve* + why a regression matters + the scenario range), plus module-level `pytestmark = pytest.mark.<cluster_slug>`. See [`test_7k_exceptions_restrictions_xlsx.py`](../../lex/test_project/tests/calculations/test_7k_exceptions_restrictions_xlsx.py) as the gold standard.
-5. **Class:** `TestCluster<NN><letter>_<Description>` (e.g. `TestCluster07m_Cancellation`). For E-type, inherit `E2ETestCase` and declare `e2e_models`.
-6. **Methods:** `test_<NN>_<NN>_<behaviour>` with a docstring `Scenario X.Y: <one-line> / Given: … / When: … / Then: …`. Every assertion carries a human-readable failure message.
-7. **One batch = one sub-cluster = one PR.**
+1. **First, enumerate the behaviour surfaces your change creates or changes.** Before picking any cluster, list *every externally-observable behaviour* the change introduces — don't reason about "the feature" as one thing. Each of these is a distinct surface that needs its own scenario:
+   - every new public entry point a caller can invoke (instance method, classmethod, REST endpoint, management command, anything a customer or the framework dispatches),
+   - every state transition or status change the change can produce,
+   - every persisted or emitted side-effect (a written audit/history row, a signal or broadcast, a row that lands in a different terminal state),
+   - every error/edge path (not-found, no-op, permission-denied, already-finished, failure-during-X).
+
+   **A surface is only "covered" when a test drives it the way a real caller reaches it — end-to-end through the public entry point, not by exercising the private helper or in-memory data structure underneath it.** Testing the easy internal layer while leaving the public entry points and their integration paths unexercised is the single most common way a change *looks* tested but isn't. If your scenarios only touch the data structure and the no-op/error returns, you have not tested the feature — go back and add the happy-path and integration surfaces.
+
+2. **Map each surface to its owning cluster — this is often more than one cluster.** A single change frequently spans clusters: a behaviour that adds, say, a state transition *and* a new REST endpoint *and* a new persisted side-effect has surfaces in three different domains. Map each surface to its cluster via [`test-clusters.md`](../../lex/test_project/test-plan/test-clusters.md) by **what the surface is**, not where the source line lives — a REST surface belongs to the API-layer cluster even if the code lives on a model; a persisted side-effect belongs to the cluster that owns that record type. Put each surface in the cluster that owns its domain; do **not** bundle an out-of-domain surface into whichever cluster is most convenient. Surfaces in different clusters become separate batches/PRs (see step 8). If you can't confidently place a surface, that's a §0.4 *stop-and-ask*. And if a surface genuinely cannot be exercised in the test environment, that is a decision to surface explicitly — gate it with a documented reason (or ask), **never** silently omit it and still call the change tested.
+3. **Allocate from `test-writing-plan.md` — never guess.** Cluster numbers are **never renumbered**. Take the **next free letter** for that cluster (read the plan to find the highest in use), and **continue scenario IDs from the cluster's current max**. If the source file is already slotted in an in-flight batch, defer to it — don't duplicate.
+4. **File:** `lex/test_project/tests/<cluster_slug>/test_<NN><letter>_<short>.py` (e.g. `test_7m_cancellation.py`).
+5. **Module header:** an `Intent` docstring section (what the framework is *trying to achieve* + why a regression matters + the scenario range), plus module-level `pytestmark = pytest.mark.<cluster_slug>`. See [`test_7k_exceptions_restrictions_xlsx.py`](../../lex/test_project/tests/calculations/test_7k_exceptions_restrictions_xlsx.py) as the gold standard.
+6. **Class:** `TestCluster<NN><letter>_<Description>` (e.g. `TestCluster07m_Cancellation`). For E-type, inherit `E2ETestCase` and declare `e2e_models`.
+7. **Methods:** `test_<NN>_<NN>_<behaviour>` with a docstring `Scenario X.Y: <one-line> / Given: … / When: … / Then: …`. Every assertion carries a human-readable failure message.
+8. **One batch = one sub-cluster = one PR.** When a change's surfaces span multiple clusters (step 2), each cluster gets its own batch — don't collapse cross-domain surfaces into a single batch to save a PR.
 
 Claude Code users: the [`lex-testing` skill](../../.claude/skills/lex-testing/SKILL.md) walks this allocation automatically.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,10 +47,21 @@ Where the tests go and how they're named is **strict** — do not improvise:
 
 - **Location:** `lex/test_project/tests/<cluster_slug>/` (the cluster system). **Not**
   `lex/tests/unit/` — that is the legacy audit tree; do not add new feature tests there.
-- **Allocation:** map the change to a cluster, take the **next free letter** for that cluster, and
-  continue scenario IDs from the cluster's current max. The authoritative source is
+- **Surfaces:** first enumerate *every externally-observable behaviour* the change creates — each
+  new public entry point (method, classmethod, REST endpoint, management command), state transition,
+  persisted/emitted side-effect, and error/edge path. A surface is only *covered* when a test drives
+  it **end-to-end through the public entry point**, not via the helper or in-memory data structure
+  underneath. Exercising only the easy internal layer (and the no-op/error returns) is the single
+  most common way a change *looks* tested but isn't.
+- **Allocation:** map **each surface** to its owning cluster by *what the surface is*, not where the
+  source line lives (a REST surface belongs to the API cluster even if the code sits on a model) —
+  often more than one cluster, and surfaces in different clusters become separate batches. Take the
+  **next free letter** for each cluster and continue scenario IDs from its current max. The
+  authoritative source is
   [`test-writing-plan.md`](lex/test_project/test-plan/test-writing-plan.md) — **read it to allocate;
-  never guess the letter.**
+  never guess the letter.** If you can't confidently place a surface, or it genuinely can't be
+  exercised in the test environment, **stop and ask** — never silently omit it and still call the
+  change tested.
 - **Names:** file `test_<NN><letter>_<short>.py`, class `TestCluster<NN><letter>_<Description>`,
   module-level `pytestmark = pytest.mark.<cluster_slug>`, methods `test_<NN>_<NN>_<behaviour>` with a
   `Scenario X.Y: … / Given / When / Then` docstring, and an `Intent` header on the file.


### PR DESCRIPTION
Supersedes #538 (the ruleset blocks pushing follow-up commits to a branch with an open PR, so this rebuilds it on a fresh branch with the `AGENTS.md` sync included).

## Summary

The cloud Copilot test-bot and the local `lex-testing` skill previously mapped a change to **one** cluster and tested whichever internal layer was easiest — leaving public entry points and integration paths unexercised (a change that *looks* tested but isn't). This adds a **surface-enumeration step ahead of cluster allocation** across **all three** agent front-ends, kept in sync per their mirror contract:

- **`AGENTS.md` Prime Directive 2** — the cross-tool front door Copilot/Cursor/Codex read natively.
- **`.github/instructions/testing.instructions.md` §5** — read by GitHub Copilot via `applyTo` globs.
- **`.claude/skills/lex-testing/SKILL.md` Step 2** — invoked by Claude Code.

## What the rule requires

- Enumerate **every externally-observable surface**: public entry points (method, classmethod, REST endpoint, management command), state transitions, persisted/emitted side-effects, error/edge paths.
- A surface is only **"covered" when a test drives it end-to-end through the public entry point** — not via the helper/data structure underneath.
- **Map each surface to its owning cluster by what it is, not where the code lives** — often more than one cluster, which become separate batches.
- Unplaceable or un-exercisable surfaces are **stop-and-ask**, never silently omitted while still calling the change tested.

Domain-neutral by design — no background-task/celery example, since that path is the held-out evaluation case.

## Test plan

- [ ] Docs/prompt change only. Verify `AGENTS.md` Prime Directive 2, `testing.instructions.md` §5, and SKILL Step 2 read coherently and stay consistent.