### PR TITLE
Teach surface enumeration to the cloud prompt + add execution-path rule

### DIFF
--- a/.claude/skills/lex-testing/SKILL.md
+++ b/.claude/skills/lex-testing/SKILL.md
@@ -61,10 +61,18 @@ Read these before doing anything else; if any is missing, **stop and tell the us
 ## Step 2 — Enumerate behaviour surfaces, then map each to its cluster
 
 **First, list every externally-observable behaviour the change creates or changes** — don't reason
-about "the feature" as one thing. Each of these is a distinct surface needing its own scenario:
+about "the feature" as one thing. (The authoritative statement is
+[`conventions.md` → "Enumerate Behaviour Surfaces Before Allocating Clusters"](../../../lex/test_project/test-plan/progress/conventions.md)
+— the single source the cloud and local agents share; this step mirrors it.) Each of these is a
+distinct surface needing its own scenario:
 
 - every new public entry point a caller can invoke (instance method, classmethod, REST endpoint,
   management command — anything a customer or the framework dispatches),
+- **every distinct execution path the same operation can take** — one logical operation may run by
+  more than one route depending on configuration, runtime mode, or how the work is dispatched, and
+  those routes can have entirely different machinery and ways of being stopped. Each route is its
+  own surface; a test driving one route tells you nothing about the others. Cover each route
+  independently — don't assume one generalises to the rest,
 - every state transition or status change the change can produce,
 - every persisted or emitted side-effect (a written audit/history row, a signal or broadcast, a row
   landing in a different terminal state),

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -67,8 +67,9 @@ When you write a test for new code, ensure **at least one** of those is true. Th
 
 Cluster tests follow the plan in [`lex/test_project/test-plan/`](../../lex/test_project/test-plan/) and the conventions in [`progress/conventions.md`](../../lex/test_project/test-plan/progress/conventions.md). These rules are **strict — follow them exactly, don't improvise**:
 
-1. **First, enumerate the behaviour surfaces your change creates or changes.** Before picking any cluster, list *every externally-observable behaviour* the change introduces — don't reason about "the feature" as one thing. Each of these is a distinct surface that needs its own scenario:
+1. **First, enumerate the behaviour surfaces your change creates or changes.** Before picking any cluster, list *every externally-observable behaviour* the change introduces — don't reason about "the feature" as one thing. (The authoritative statement of this rule lives in [`progress/conventions.md` → "Enumerate Behaviour Surfaces Before Allocating Clusters"](../../lex/test_project/test-plan/progress/conventions.md) — the one source the cloud and local agents share; this section mirrors it.) Each of these is a distinct surface that needs its own scenario:
    - every new public entry point a caller can invoke (instance method, classmethod, REST endpoint, management command, anything a customer or the framework dispatches),
+   - **every distinct execution path the same operation can take** — one logical operation may run by more than one route depending on configuration, runtime mode, or how the work is dispatched, and those routes can have entirely different machinery and ways of being stopped. Each route is its own surface; a test that drives one route tells you nothing about the others. Cover each route independently — don't assume one generalises to the rest,
    - every state transition or status change the change can produce,
    - every persisted or emitted side-effect (a written audit/history row, a signal or broadcast, a row that lands in a different terminal state),
    - every error/edge path (not-found, no-op, permission-denied, already-finished, failure-during-X).

--- a/.github/scripts/copilot_assemble_prompt.py
+++ b/.github/scripts/copilot_assemble_prompt.py
@@ -161,21 +161,18 @@ The Golden Rule above tells you *not* to mirror the implementation. This tells y
 
 ---
 
-## Cluster decomposition — one feature may need tests in multiple clusters
+## Surfaces and clusters — one feature may need tests in multiple clusters
 
-A feature's contract often spans clusters. The cluster hint names the **primary** cluster (the feature's headline behaviour). Your job is to identify **secondary** clusters whose contracts the feature also touches, and add a test file in each.
+**The authoritative rule is in the *Test-plan conventions* above — "Enumerate Behaviour Surfaces Before Allocating Clusters." Apply it; it is the single source this prompt and every local agent share.** This section only says how it maps onto a Copilot PR:
 
-**How to decide (regression mode):**
-
-1. **Primary cluster** — owns the feature's headline behaviour. The "selling point" test goes here. This is what the user hinted at (or what cluster routing below picks if no hint).
-2. **Secondary clusters** — for every observable contract the feature is responsible for that lives in a *different* cluster, add a separate test file in that cluster's folder. Typical cross-cluster contracts:
+1. **Enumerate the surfaces first.** Per the conventions rule, list every externally-observable behaviour the change introduces — each public entry point, **each distinct execution path the same operation can take** (one operation may run by more than one route — cover each route, don't assume one generalises to the others), each state transition, each persisted/emitted side-effect, each error/edge path. A surface counts as covered only when a test drives it end-to-end through the public entry point.
+2. **Map each surface to its owning cluster.** The cluster hint names the **primary** cluster (the headline surface). Every surface that lives in a *different* cluster is a **secondary** cluster that gets its own test file. Map by *what the surface is*, not where the source line lives:
    - Produces audit-log entries → test in `audit_logging/`.
    - Drives calculation state transitions → test in `calculations/`.
    - Must respect permission rules → test in `permissions/`.
    - Emits WebSocket signals → test in `signals_ws/`.
    - Goes through the REST/serializer surface → test in `api_layer/` or `serializers/`.
-   Read the **Behaviour** and **Reproducer** fields below carefully; each contractual guarantee the user lists is a candidate for its own cross-cluster test file.
-3. State the decomposition in the PR description, one line per file: *"Placed `tests/<slug>/test_<Nx>_<short>.py` under cluster N because …"*
+3. State the decomposition in the PR description, one line per file: *"Placed `tests/<slug>/test_<Nx>_<short>.py` under cluster N because …"*. If a surface genuinely cannot be exercised here, say so explicitly in the PR body — never silently drop it.
 
 **Mode-specific scope:**
 

--- a/.github/scripts/tests/test_copilot_assemble_prompt.py
+++ b/.github/scripts/tests/test_copilot_assemble_prompt.py
@@ -179,12 +179,27 @@ def test_assembled_prompt_teaches_multi_cluster_decomposition(fake_test_plan: Pa
     least one concrete cross-cluster example so Copilot doesn't default
     to single-file."""
     out = assemble_prompt(_basic_issue(Mode.REGRESSION), test_plan_dir=fake_test_plan)
-    # Heading: the decomposition section is its own block, not buried.
-    assert "Cluster decomposition" in out
+    # Heading: the surfaces-and-clusters section is its own block, not buried.
+    assert "Surfaces and clusters" in out
     # Concept: primary vs secondary clusters.
     assert "primary" in out.lower() and "secondary" in out.lower()
     # Concrete cross-cluster example: audit log is the canonical case.
     assert "audit_logging" in out
+
+
+def test_assembled_prompt_teaches_execution_path_surfaces(fake_test_plan: Path) -> None:
+    """The held-out cancellation eval exposed that an agent enumerates the
+    *entry-point* surfaces (method / endpoint / command) but misses that one
+    operation can run by more than one execution route — each route being its
+    own surface with its own machinery. The prompt must teach this dimension,
+    and it must do so **domain-neutrally**: it names the abstract category
+    (execution path / route, varying by configuration/runtime-mode/dispatch),
+    never a concrete subsystem, so the agent derives the specific routes itself
+    instead of being handed the answer for the eval feature."""
+    out = assemble_prompt(_basic_issue(Mode.REGRESSION), test_plan_dir=fake_test_plan)
+    assert "execution path" in out.lower()
+    # The principle: covering one route says nothing about the others.
+    assert "one generalises to the others" in out or "don't assume one generalises" in out
 
 
 def test_assembled_prompt_includes_research_first_block(fake_test_plan: Path) -> None:

--- a/.github/scripts/tests/test_prompt_surface_parity.py
+++ b/.github/scripts/tests/test_prompt_surface_parity.py
@@ -1,0 +1,100 @@
+"""Drift guard: every agent front-end must share ONE surface-enumeration rule.
+
+There are four prompt surfaces that tell an agent how to decompose a change into
+test surfaces and clusters:
+
+  1. `lex/test_project/test-plan/progress/conventions.md` — the **canonical**
+     source. The cloud Copilot prompt inlines this file verbatim
+     (see `copilot_assemble_prompt.assemble_prompt`), so whatever lands here is
+     what the cloud agent reads.
+  2. `.github/instructions/testing.instructions.md` — VS Code Copilot / cloud IDE.
+  3. `.claude/skills/lex-testing/SKILL.md` — Claude Code skill.
+  4. `AGENTS.md` — JetBrains Copilot / Cursor / Codex (load-bearing in PyCharm).
+
+These drifted once: the cloud assembler taught a weaker "primary/secondary"
+decomposition while the local surfaces taught full surface enumeration, and none
+of them taught the *execution-path* dimension — which is why an agent enumerated
+the entry points of a feature but missed that one operation can run by more than
+one route, each route its own surface. This test pins that the shared rule — and
+specifically its execution-path clause — is present in all four, so the cloud and
+local paths can never silently diverge again.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CANONICAL = REPO_ROOT / "lex" / "test_project" / "test-plan" / "progress" / "conventions.md"
+
+SURFACES = {
+    "conventions.md (canonical)": CANONICAL,
+    "testing.instructions.md": REPO_ROOT / ".github" / "instructions" / "testing.instructions.md",
+    "lex-testing SKILL.md": REPO_ROOT / ".claude" / "skills" / "lex-testing" / "SKILL.md",
+    "AGENTS.md": REPO_ROOT / "AGENTS.md",
+}
+
+
+def test_canonical_source_owns_the_surface_rule() -> None:
+    """conventions.md is the single source the cloud prompt inlines. It must
+    carry the rule's canonical heading and the execution-path clause."""
+    text = CANONICAL.read_text()
+    assert "Enumerate Behaviour Surfaces Before Allocating Clusters" in text, (
+        "conventions.md must own the canonical surface-enumeration section — the "
+        "cloud Copilot prompt inlines this file, so the rule must live here."
+    )
+    assert "execution path" in text.lower(), (
+        "The canonical rule must teach the execution-path dimension (one operation, "
+        "multiple routes). This is the clause that makes an agent derive the "
+        "multi-route surface without being handed a concrete example."
+    )
+
+
+@pytest.mark.parametrize("name", list(SURFACES))
+def test_every_surface_carries_the_execution_path_rule(name: str) -> None:
+    """All four agent front-ends must teach the execution-path surface dimension.
+    If any one drops or never gained it, cloud and local agents drift — exactly
+    the failure this guard exists to prevent."""
+    path = SURFACES[name]
+    text = path.read_text().lower()
+    assert "execution path" in text, (
+        f"{name} is missing the execution-path surface rule. Every prompt surface "
+        f"must teach it (one operation may run by more than one route; each route is "
+        f"its own surface). Update {path.relative_to(REPO_ROOT)} to match the "
+        f"canonical rule in conventions.md."
+    )
+
+
+@pytest.mark.parametrize("name", [n for n in SURFACES if n != "conventions.md (canonical)"])
+def test_local_surfaces_point_at_the_canonical_source(name: str) -> None:
+    """Each local surface must name conventions.md as the authoritative source, so
+    future edits have one obvious home and reviewers know the satellites mirror it."""
+    text = SURFACES[name].read_text()
+    assert "conventions.md" in text, (
+        f"{name} must reference conventions.md as the canonical source of the "
+        f"surface rule, so the four surfaces stay anchored to one source of truth."
+    )
+
+
+def test_execution_path_rule_stays_domain_neutral() -> None:
+    """The whole point is that the agent *derives* the concrete routes itself. The
+    canonical rule must describe routes by abstract category (configuration /
+    runtime mode / dispatch) and must NOT name the held-out eval's concrete
+    cancellation mechanics — naming them would hand the agent the answer and leak
+    the evaluation domain."""
+    # Collapse whitespace so line-wrapping in the markdown can't break the match.
+    text = " ".join(CANONICAL.read_text().lower().split())
+    # The section states routes vary by abstract category, not a named subsystem.
+    assert "configuration, runtime mode, or how the work is dispatched" in text
+    # Guard against re-introducing concrete cancellation/dispatch giveaways into
+    # the *rule statement*. (These tokens may legitimately appear elsewhere in the
+    # repo — this only checks the canonical conventions rule file.)
+    for leak in ("revoke", "terminate=true", "setasyncexc", "cooperative cancellation"):
+        assert leak not in text, (
+            f"The canonical surface rule leaked a concrete eval-domain mechanic "
+            f"({leak!r}). Keep the rule domain-neutral — name the category, not the "
+            f"answer, so the agent figures out the routes itself."
+        )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,17 @@ Where the tests go and how they're named is **strict** — do not improvise:
 - **Location:** `lex/test_project/tests/<cluster_slug>/` (the cluster system). **Not**
   `lex/tests/unit/` — that is the legacy audit tree; do not add new feature tests there.
 - **Surfaces:** first enumerate *every externally-observable behaviour* the change creates — each
-  new public entry point (method, classmethod, REST endpoint, management command), state transition,
-  persisted/emitted side-effect, and error/edge path. A surface is only *covered* when a test drives
-  it **end-to-end through the public entry point**, not via the helper or in-memory data structure
-  underneath. Exercising only the easy internal layer (and the no-op/error returns) is the single
-  most common way a change *looks* tested but isn't.
+  new public entry point (method, classmethod, REST endpoint, management command), **each distinct
+  execution path the same operation can take** (one operation may run by more than one route
+  depending on configuration, runtime mode, or how the work is dispatched — those routes can have
+  entirely different machinery and ways of being stopped, so each is its own surface and covering one
+  tells you nothing about the others), state transition, persisted/emitted side-effect, and
+  error/edge path. A surface is only *covered* when a test drives it **end-to-end through the public
+  entry point**, not via the helper or in-memory data structure underneath. Exercising only the easy
+  internal layer (and the no-op/error returns) is the single most common way a change *looks* tested
+  but isn't. The authoritative statement of this rule lives in
+  [`conventions.md` → "Enumerate Behaviour Surfaces Before Allocating Clusters"](lex/test_project/test-plan/progress/conventions.md)
+  — the one source the cloud and local agents share.
 - **Allocation:** map **each surface** to its owning cluster by *what the surface is*, not where the
   source line lives (a REST surface belongs to the API cluster even if the code sits on a model) —
   often more than one cluster, and surfaces in different clusters become separate batches. Take the

--- a/lex/test_project/test-plan/progress/conventions.md
+++ b/lex/test_project/test-plan/progress/conventions.md
@@ -44,6 +44,50 @@ markers are not bulk-converted.
 
 ---
 
+## Enumerate Behaviour Surfaces Before Allocating Clusters
+
+> **Canonical source.** This is the one authoritative statement of the surface rule.
+> Every agent front-end — the cloud Copilot prompt (which inlines this file), the IDE
+> instructions, `AGENTS.md`, and the `lex-testing` skill — derives the rule from here.
+> Change it here and nowhere else, so the cloud and local paths can never drift.
+
+Before picking any cluster, list *every externally-observable behaviour* the change
+introduces or alters — **don't reason about "the feature" as one thing.** Each of these is
+a distinct **surface** that needs its own scenario:
+
+- every public entry point a caller can invoke — instance method, classmethod, REST
+  endpoint, management command, anything a customer or the framework dispatches;
+- **every distinct execution path the same operation can take.** One logical operation may
+  run by more than one route depending on configuration, runtime mode, or how the work is
+  dispatched — and those routes can have entirely different machinery, failure modes, and
+  ways of being stopped. Each route is its own surface: a test that drives one route tells
+  you *nothing* about the others. Enumerate every route the operation can take and cover
+  each independently — do not assume the behaviour of one generalises to the rest;
+- every state transition or status change the change can produce;
+- every persisted or emitted side-effect — a written audit/history row, a signal or
+  broadcast, a record that lands in a different terminal state;
+- every error/edge path — not-found, no-op, permission-denied, already-finished,
+  failure-during-X.
+
+**A surface is only "covered" when a test drives it the way a real caller reaches it —
+end-to-end through the public entry point, not by exercising the private helper or
+in-memory data structure underneath it.** Testing the easy internal layer while leaving the
+public entry points and their integration paths unexercised is the single most common way a
+change *looks* tested but isn't. If your scenarios only touch the data structure and the
+no-op/error returns, you have not tested the feature — go back and add the happy-path and
+integration surfaces.
+
+**Map each surface to its owning cluster — often more than one.** A single change
+frequently spans clusters. Map each surface by *what the surface is*, not where the source
+line lives: a REST surface belongs to the API-layer cluster even if the code sits on a
+model; a persisted side-effect belongs to the cluster that owns that record type. Surfaces
+in different clusters become separate batches. If you can't confidently place a surface, or
+a surface genuinely cannot be exercised in the test environment, **say so explicitly** —
+gate it with a documented reason or stop and ask the developer — **never** silently omit it
+and still call the change tested.
+
+---
+
 ## User Experience: Making Tests Readable
 
 Tests are documentation. A new developer reading a test should understand:


### PR DESCRIPTION
## Summary

The cloud Copilot assembler had **drifted** from the three local agent surfaces. The cloud prompt taught a weaker primary/secondary "cluster decomposition", while `testing.instructions.md`, `AGENTS.md`, and the `lex-testing` skill taught full behaviour-surface enumeration. And **none** of the four taught the *execution-path* dimension — which is exactly why an agent could enumerate a feature's entry points (method / endpoint / command) yet miss that one operation can run by **more than one route**, each route being its own surface with its own machinery.

This PR closes both gaps and makes the drift structurally impossible to repeat:

- **Single canonical source.** `lex/test_project/test-plan/progress/conventions.md` now owns the authoritative *"Enumerate Behaviour Surfaces Before Allocating Clusters"* rule. The cloud prompt already inlines this file verbatim, so the cloud agent now reads the same bytes as the local agents.
- **New, domain-neutral execution-path clause.** *One operation may run by more than one route depending on configuration, runtime mode, or how the work is dispatched; each route is its own surface and covering one tells you nothing about the others.* The wording names the **category, not the answer** — no concrete subsystem is mentioned — so the agent derives the specific routes itself instead of being handed them.
- **Satellites defer to the source.** The assembler's hand-written block now points at the inlined rule; the three local surfaces gain the execution-path clause **and** a pointer naming `conventions.md` as authoritative.
- **Drift guard.** New `test_prompt_surface_parity.py` fails CI if any of the four surfaces drops the execution-path rule, if a local surface stops pointing at the canonical source, or if the canonical rule ever leaks a concrete eval mechanic (`revoke`, `SetAsyncExc`, …).

End-to-end check: assembling the cloud prompt against the real test-plan produces a body that carries the canonical section + execution-path clause at ~26.8 KB (well under the 60 KB issue-body cap).

## Test plan

- [x] `pytest .github/scripts/tests/` — 64 passed
- [x] Updated the decomposition test for the renamed "Surfaces and clusters" heading + added an execution-path assertion
- [x] Added `test_prompt_surface_parity.py` (canonical-source ownership, 4-surface parity, local→canonical pointers, domain-neutrality / no eval leak)
- [x] Verified the rule reaches the assembled cloud prompt and stays under the size cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)