### PR TITLE
fix(coverage-gate): widen source scope to every framework app, not just lex_app

### DIFF
--- a/.github/scripts/copilot_coverage_detect.py
+++ b/.github/scripts/copilot_coverage_detect.py
@@ -18,14 +18,17 @@ Outputs JSON on stdout::
 
     {
       "status": "pass" | "miss",
-      "untested": ["lex/lex_app/foo.py", ...],
-      "matched": {"lex/lex_app/bar.py": "lex/test_project/tests/.../test_x.py"},
+      "untested": ["lex/core/foo.py", ...],
+      "matched": {"lex/api/bar.py": "lex/test_project/tests/.../test_x.py"},
       "skipped_allowlist": [...]
     }
 
 Inputs are paths to two files holding the PR's changed-file lists, one
-per line, produced by ``gh pr diff`` upstream. We split into source-list
-(``added``/``modified`` under ``lex/lex_app/``) and test-list (any path
+per line, produced by ``gh pr diff`` upstream. We split into a source-list
+(``added``/``modified`` ``.py`` files inside any framework package under
+``lex/`` — ``lex/lex_app/``, ``lex/core/``, ``lex/api/``,
+``lex/audit_logging/``, ``lex/process_admin/``, … — excluding the test
+trees, docs, and other non-source packages) and a test-list (any path
 matching ``lex/test_project/tests/**/test_*.py``).
 
 Pure-Python, no third-party deps — runs on a stock GitHub runner.
@@ -41,11 +44,30 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
-# Mirrors §7.3 of the spec — files where coverage is not meaningful.
-_SOURCE_PREFIX = "lex/lex_app/"
+# Framework source lives in app/packages directly under ``lex/`` —
+# ``lex/lex_app/``, ``lex/core/``, ``lex/api/``, ``lex/audit_logging/``,
+# ``lex/process_admin/`` and any future app. Rather than enumerate apps
+# (a new app would silently escape the coverage gate until someone
+# remembered to add it), we treat *every* package under ``lex/`` as
+# source and subtract the trees where coverage is not meaningful.
+_SOURCE_ROOT = "lex/"
+
+# Packages under ``lex/`` that are NOT testable framework source: the
+# test trees themselves, docs, frontend, static assets, vendored data.
+_EXCLUDED_PACKAGES = frozenset(
+    {
+        "test_project",  # the cluster test tree itself
+        "tests",         # legacy audit test tree
+        "docs",
+        "react",
+        "assets",
+        "legacy_data",
+        "bin",
+    }
+)
+
 _TEST_TREE = "lex/test_project/tests/"
 _ALLOWLIST_NAMES = ("__init__.py", "apps.py")
-_ALLOWLIST_PREFIXES_UNDER_SOURCE = ("migrations/",)
 _ALLOWLIST_NAME_STARTSWITH = ("settings",)  # settings.py, settings_dev.py, settings_local.py
 
 
@@ -69,13 +91,28 @@ class DetectionResult:
         )
 
 
+def _package_of(path: str) -> str | None:
+    """``lex/core/foo/bar.py`` → ``core``.
+
+    Returns ``None`` for paths outside ``lex/`` and for loose top-level
+    files directly under ``lex/`` (e.g. ``lex/runtime_config.py``) — those
+    are one-off scripts, not app code, and are deliberately out of scope.
+    """
+    if not path.startswith(_SOURCE_ROOT):
+        return None
+    rel = path[len(_SOURCE_ROOT):]
+    if "/" not in rel:
+        return None  # loose file directly under lex/, not a package member
+    return rel.split("/", 1)[0]
+
+
 def _is_allowlisted(path: str) -> bool:
-    if not path.startswith(_SOURCE_PREFIX):
+    pkg = _package_of(path)
+    if pkg is None or pkg in _EXCLUDED_PACKAGES:
         return False
-    rel = path[len(_SOURCE_PREFIX):]
-    if any(rel.startswith(p) for p in _ALLOWLIST_PREFIXES_UNDER_SOURCE):
+    if "/migrations/" in path:
         return True
-    name = rel.rsplit("/", 1)[-1]
+    name = path.rsplit("/", 1)[-1]
     if name in _ALLOWLIST_NAMES:
         return True
     if name.endswith(".py") and any(name.startswith(p) for p in _ALLOWLIST_NAME_STARTSWITH):
@@ -84,11 +121,12 @@ def _is_allowlisted(path: str) -> bool:
 
 
 def _is_source_file(path: str) -> bool:
-    if not path.startswith(_SOURCE_PREFIX):
-        return False
     if not path.endswith(".py"):
         return False
-    # Don't treat test files committed inside the app tree as source.
+    pkg = _package_of(path)
+    if pkg is None or pkg in _EXCLUDED_PACKAGES:
+        return False
+    # Don't treat test files committed inside an app tree as source.
     name = path.rsplit("/", 1)[-1]
     if name.startswith("test_"):
         return False

--- a/.github/scripts/tests/test_copilot_coverage_detect.py
+++ b/.github/scripts/tests/test_copilot_coverage_detect.py
@@ -1,0 +1,144 @@
+"""Tests for copilot_coverage_detect — source-file scope + match rule.
+
+The coverage gate originally only watched ``lex/lex_app/**``, so a change
+to any other framework app (``lex/core/``, ``lex/api/``,
+``lex/audit_logging/``, ``lex/process_admin/``, …) shipped with NO test
+enforcement. These tests pin the widened scope: every package under
+``lex/`` is source EXCEPT the test trees, docs, and other non-source
+packages, and loose top-level ``lex/*.py`` scripts are out of scope.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make .github/scripts importable when pytest runs from repo root.
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import copilot_coverage_detect as ccd  # noqa: E402
+
+
+# ── _is_source_file: which changed files demand a test ──────────────
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "lex/lex_app/views.py",
+        "lex/core/models.py",
+        "lex/api/serializers/foo.py",
+        "lex/audit_logging/mixins.py",
+        "lex/process_admin/utils/model_structure.py",
+        "lex/authentication/backends.py",
+    ],
+)
+def test_app_package_files_are_source(path: str) -> None:
+    """A .py file inside ANY framework app package is source — not just
+    lex_app. This is the whole point of the widened scope."""
+    assert ccd._is_source_file(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # Loose top-level scripts directly under lex/ are out of scope.
+        "lex/runtime_config.py",
+        "lex/backfill_history_sql.py",
+        "lex/proxy.py",
+        # Non-source packages under lex/.
+        "lex/test_project/tests/calculations/test_7a_foo.py",
+        "lex/tests/unit/api/test_views.py",
+        "lex/docs/index.py",
+        "lex/react/app.py",
+        "lex/assets/gen.py",
+        "lex/legacy_data/loader.py",
+        # Test files committed inside an app tree are not source.
+        "lex/core/tests/test_models.py",
+        # Non-python files.
+        "lex/core/templates/foo.html",
+        # Outside lex/ entirely.
+        ".github/scripts/copilot_coverage_detect.py",
+        "docs/index.md",
+    ],
+)
+def test_non_source_paths_are_excluded(path: str) -> None:
+    assert ccd._is_source_file(path) is False
+
+
+# ── _is_allowlisted: meaningless-coverage files, across all apps ────
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "lex/lex_app/__init__.py",
+        "lex/core/__init__.py",
+        "lex/api/apps.py",
+        "lex/lex_app/settings.py",
+        "lex/lex_app/settings_dev.py",
+        "lex/core/migrations/0001_initial.py",
+        "lex/audit_logging/migrations/0007_x.py",
+    ],
+)
+def test_allowlist_applies_across_apps(path: str) -> None:
+    assert ccd._is_allowlisted(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "lex/core/models.py",
+        "lex/api/views.py",
+        # A loose top-level __init__ / file is not in a package → not allowlisted.
+        "lex/__init__.py",
+    ],
+)
+def test_allowlist_does_not_swallow_real_source(path: str) -> None:
+    assert ccd._is_allowlisted(path) is False
+
+
+# ── _package_of: the loose-file boundary ────────────────────────────
+
+def test_package_of_returns_none_for_loose_top_level_file() -> None:
+    assert ccd._package_of("lex/runtime_config.py") is None
+
+
+def test_package_of_returns_none_outside_lex() -> None:
+    assert ccd._package_of("docs/index.md") is None
+
+
+def test_package_of_returns_first_segment() -> None:
+    assert ccd._package_of("lex/core/foo/bar.py") == "core"
+
+
+# ── detect(): end-to-end miss / pass over a mixed diff ──────────────
+
+def test_detect_flags_untested_source_in_a_non_lex_app_package(tmp_path: Path) -> None:
+    """A change under lex/core/ with no matching test is a MISS — the
+    exact case the old single-prefix heuristic let through."""
+    result = ccd.detect(["lex/core/widget.py"], repo_root=tmp_path)
+    assert result.status == "miss"
+    assert "lex/core/widget.py" in result.untested
+
+
+def test_detect_passes_when_test_references_source_stem(tmp_path: Path) -> None:
+    test_path = tmp_path / "lex" / "test_project" / "tests" / "core" / "test_9a_widget.py"
+    test_path.parent.mkdir(parents=True, exist_ok=True)
+    test_path.write_text("def test_widget_behaviour():\n    widget()\n")
+    changed = [
+        "lex/core/widget.py",
+        "lex/test_project/tests/core/test_9a_widget.py",
+    ]
+    result = ccd.detect(changed, repo_root=tmp_path)
+    assert result.status == "pass"
+    assert result.matched["lex/core/widget.py"].endswith("test_9a_widget.py")
+
+
+def test_detect_ignores_loose_top_level_scripts(tmp_path: Path) -> None:
+    """Loose lex/*.py scripts never demand a test, so a diff containing
+    only them passes."""
+    result = ccd.detect(["lex/sanitize_v2_migrations.py"], repo_root=tmp_path)
+    assert result.status == "pass"
+    assert result.untested == []

--- a/.github/workflows/copilot_coverage_check.yml
+++ b/.github/workflows/copilot_coverage_check.yml
@@ -2,7 +2,10 @@
 #  Copilot PR Coverage Check (Feature 4).
 #
 #  Implements the supervisor's task #4: every PR that lands code under
-#  lex/lex_app/** must also ship tests for that code. If the heuristic
+#  a framework app (lex/lex_app/**, lex/core/**, lex/api/**,
+#  lex/audit_logging/**, lex/process_admin/**, … — every package under
+#  lex/ except the test trees, docs, and other non-source dirs) must
+#  also ship tests for that code. If the heuristic
 #  can't pair source changes with test changes in the same diff, the
 #  workflow opens a coverage-task issue for Copilot, labels the PR
 #  `needs-tests`, and posts a failing `coverage / required` check that
@@ -128,14 +131,20 @@ jobs:
         id: triage
         run: |
           set -euo pipefail
-          # If the diff contains nothing under lex/lex_app/** the
-          # detector will return pass anyway, but short-circuiting
-          # here saves a Python startup and makes intent visible.
-          if ! grep -q '^lex/lex_app/' changed.txt; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::No source changes under lex/lex_app/** — coverage check is a no-op."
-          else
+          # If the diff touches no framework source the detector will
+          # return pass anyway, but short-circuiting here saves a Python
+          # startup and makes intent visible. Mirror the detector's
+          # scope: any file inside a package under lex/ (a second path
+          # segment exists, so loose lex/*.py scripts are excluded) that
+          # is NOT one of the non-source packages. This is an exclude
+          # list on purpose — an include list would let a NEW app slip
+          # the gate until someone updated this grep.
+          if grep -E '^lex/[^/]+/' changed.txt \
+               | grep -qvE '^lex/(test_project|tests|docs|react|assets|legacy_data|bin)/'; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No framework source changes under lex/<app>/** — coverage check is a no-op."
           fi
 
       - name: Run Phase 1 detection
@@ -181,7 +190,7 @@ jobs:
             -F status='completed' \
             -F conclusion='success' \
             -F output[title]='Coverage check passed' \
-            -F output[summary]='Every changed source file under lex/lex_app/** has a matching test in this PR.'
+            -F output[summary]='Every changed source file under lex/<app>/** has a matching test in this PR.'
 
       - name: Short-circuit pass when skip guards / triage matched
         # When the workflow skips for legitimate reasons (no source
@@ -192,7 +201,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          REASON: ${{ steps.escape.outputs.skip == 'true' && 'opted out via [skip-coverage-check]' || 'no source changes under lex/lex_app/**' }}
+          REASON: ${{ steps.escape.outputs.skip == 'true' && 'opted out via [skip-coverage-check]' || 'no framework source changes under lex/<app>/**' }}
         run: |
           set -euo pipefail
           gh api repos/"$GITHUB_REPOSITORY"/check-runs \
@@ -257,7 +266,7 @@ jobs:
 
           ## Task
 
-          PR #${PR_NUMBER} modifies ${COUNT} source file(s) under \`lex/lex_app/\*\*\` without test coverage in the same diff:
+          PR #${PR_NUMBER} modifies ${COUNT} framework source file(s) under \`lex/<app>/\*\*\` without test coverage in the same diff:
 
           ${UNTESTED}
 


### PR DESCRIPTION
## Summary

The Phase 1 coverage heuristic keyed off a single `lex/lex_app/` prefix, so changes to **any other framework app** (`lex/core/`, `lex/api/`, `lex/audit_logging/`, `lex/process_admin/`, …) shipped with **no paired-test enforcement at all**.

- Replace the single-prefix check in `copilot_coverage_detect.py` with a package-aware **exclude list**: every package under `lex/` is source *except* the test trees (`test_project/`, `tests/`), `docs/`, `react/`, `assets/`, `legacy_data/`, `bin/`. Loose top-level `lex/*.py` scripts stay out of scope.
- An exclude list (vs enumerating apps) means a **new app is covered automatically** instead of silently escaping the gate.
- The workflow's short-circuit `grep` now mirrors the same exclude list for the same reason — an include-list there would have re-introduced the bug at the workflow layer.
- Updated the user-facing strings (`lex/lex_app/**` → `lex/<app>/**`).
- Added unit tests (`test_copilot_coverage_detect.py`) covering the widened scope.

## Test plan

- [x] `python -m pytest .github/scripts/tests/` → 99 passed (35 new)
- [ ] Confirm the `coverage / required` check behaves on a PR touching `lex/core/`
