### PR TITLE
fix(ci): close the Feature-4 coverage-task loop in the PR gate

### DIFF
--- a/.github/scripts/copilot_discover_mode.py
+++ b/.github/scripts/copilot_discover_mode.py
@@ -1,12 +1,19 @@
 """Resolve the source issue + mode for a Copilot-authored PR.
 
-The PR-gate workflow needs two things from a Copilot PR:
+The PR-gate workflow needs three things from a Copilot PR:
 
 * the **mode** (``regression`` / ``bug-repro`` / ``fix-and-test``), so it
   knows which checks to apply;
 * the **source issue number** (the user-filed issue that carries the
-  ``copilot:<mode>`` label), so it can post comments back to the right
-  place when things go wrong.
+  ``copilot:<mode>`` label, or the auto-opened ``coverage-task`` issue),
+  so it can post comments back to the right place when things go wrong;
+* the **kind** of task (``test-bot`` vs ``coverage-task``), so the gate
+  knows whether the PR was opened in response to a maintainer's
+  test-request (test-bot path) or the Feature-4 coverage gate. A
+  coverage-task PR needs extra handling — its base branch must be the
+  parent feature branch, not ``lex-app-v2`` — and its originating issue
+  carries the ``coverage-task`` label instead of a ``copilot:<mode>`` one,
+  so it is mapped to ``regression`` (test-only, multi-file, auto-merge).
 
 The previous inline-bash resolver only matched ``Fixes #N`` in the PR
 body. Copilot's coding agent doesn't reliably emit that line — it links
@@ -25,7 +32,10 @@ Resolver chain (first match wins):
 
 For each candidate we then walk:
 
-* if it has a ``copilot:<mode>`` label → it's the source issue, done;
+* if it has a ``copilot:<mode>`` label → it's the source issue, done
+  (kind ``test-bot``);
+* else if it has the ``coverage-task`` label → it's a Feature-4 coverage
+  task, done (mode ``regression``, kind ``coverage-task``);
 * else if its body says ``Assembled from issue #M`` → fetch #M and try
   the label check on that.
 
@@ -39,8 +49,8 @@ Usage::
         --repo owner/name --pr 520 \\
         > $GITHUB_OUTPUT
 
-prints two ``key=value`` lines on success, exits non-zero with a
-human-readable explanation on failure.
+prints three ``key=value`` lines (``mode``, ``issue``, ``kind``) on
+success, exits non-zero with a human-readable explanation on failure.
 """
 
 from __future__ import annotations
@@ -54,6 +64,11 @@ from typing import Optional
 
 
 _MODE_LABEL_RE = re.compile(r"^copilot:(regression|bug-repro|fix-and-test)$")
+# Feature-4 coverage-task issues carry this label instead of a
+# copilot:<mode> one. They are treated as regression PRs (test-only,
+# multi-file allowed, auto-merge) but flagged with kind="coverage-task"
+# so the gate can retarget the PR's base onto the parent feature branch.
+_COVERAGE_TASK_LABEL = "coverage-task"
 _CLOSE_KEYWORD_RE = re.compile(
     r"(?i)(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+#(\d+)"
 )
@@ -90,13 +105,29 @@ def _issue_view(repo: str, number: int) -> Optional[dict]:
     return json.loads(raw)
 
 
-def _mode_from_labels(labels: list[dict]) -> Optional[str]:
-    """Return ``regression`` / ``bug-repro`` / ``fix-and-test`` or ``None``."""
+def _mode_and_kind_from_labels(
+    labels: list[dict],
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve an issue's labels to ``(mode, kind)``.
+
+    * a ``copilot:<mode>`` label → ``(<mode>, "test-bot")``;
+    * the ``coverage-task`` label → ``("regression", "coverage-task")``
+      (the coverage gate's PRs are test-only/multi-file/auto-merge, i.e.
+      the regression contract);
+    * neither → ``(None, None)``.
+
+    A ``copilot:<mode>`` label wins over ``coverage-task`` on the off
+    chance both are present, so an explicitly-moded issue is never
+    silently downgraded to regression.
+    """
     for label in labels:
         m = _MODE_LABEL_RE.match(label.get("name", ""))
         if m:
-            return m.group(1)
-    return None
+            return m.group(1), "test-bot"
+    for label in labels:
+        if label.get("name", "") == _COVERAGE_TASK_LABEL:
+            return "regression", "coverage-task"
+    return None, None
 
 
 def _closing_issue_references(repo: str, pr: int) -> list[int]:
@@ -134,12 +165,14 @@ def _candidates_from_pr_body(body: str) -> list[int]:
     return seen
 
 
-def resolve(repo: str, pr: int) -> tuple[str, int]:
-    """Return ``(mode, source_issue_number)``.
+def resolve(repo: str, pr: int) -> tuple[str, int, str]:
+    """Return ``(mode, source_issue_number, kind)``.
 
-    Walks the resolver chain documented in the module docstring. Raises
-    ``RuntimeError`` with a human-readable message if no candidate yields
-    a ``copilot:<mode>`` label, even after dereferencing task issues.
+    ``kind`` is ``"test-bot"`` for maintainer test-request issues and
+    ``"coverage-task"`` for Feature-4 coverage tasks. Walks the resolver
+    chain documented in the module docstring. Raises ``RuntimeError`` with
+    a human-readable message if no candidate yields a ``copilot:<mode>``
+    or ``coverage-task`` label, even after dereferencing task issues.
     """
     # Step 1 — gather candidates from every available signal.
     candidates: list[int] = list(_closing_issue_references(repo, pr))
@@ -172,12 +205,12 @@ def resolve(repo: str, pr: int) -> tuple[str, int]:
             if issue is None:
                 break
 
-            mode = _mode_from_labels(issue.get("labels") or [])
+            mode, kind = _mode_and_kind_from_labels(issue.get("labels") or [])
             if mode:
-                return mode, cand
+                return mode, cand, kind
 
-            # No mode label. If the body declares it was assembled from a
-            # parent, hop to that and retry.
+            # No mode / coverage-task label. If the body declares it was
+            # assembled from a parent, hop to that and retry.
             m = _ASSEMBLED_FROM_RE.search(issue.get("body") or "")
             if not m:
                 break
@@ -188,8 +221,9 @@ def resolve(repo: str, pr: int) -> tuple[str, int]:
 
     raise RuntimeError(
         f"None of the candidate issues ({candidates}) carry a copilot:<mode> "
-        "label, and none dereference to a source issue that does. The PR is "
-        "either not Copilot-triggered or the source issue lost its label."
+        "or coverage-task label, and none dereference to a source issue that "
+        "does. The PR is either not Copilot-triggered or the source issue lost "
+        "its label."
     )
 
 
@@ -200,7 +234,7 @@ def _cli() -> int:
     args = p.parse_args()
 
     try:
-        mode, issue = resolve(args.repo, args.pr)
+        mode, issue, kind = resolve(args.repo, args.pr)
     except RuntimeError as exc:
         print(f"::error::{exc}", file=sys.stderr)
         return 1
@@ -208,6 +242,7 @@ def _cli() -> int:
     # GitHub Actions step output format.
     print(f"mode={mode}")
     print(f"issue={issue}")
+    print(f"kind={kind}")
     return 0
 
 

--- a/.github/scripts/copilot_validate_pr_shape.py
+++ b/.github/scripts/copilot_validate_pr_shape.py
@@ -57,7 +57,25 @@ def _is_allowed_for_test_only(path: str) -> bool:
     return any(path == p or path.startswith(p) for p in ALLOWED_TEST_ONLY_PREFIXES)
 
 
-def validate_pr_shape(*, mode: str, files: list[PRFile], pr_body: str) -> ValidationResult:
+def validate_pr_shape(
+    *,
+    mode: str,
+    files: list[PRFile],
+    pr_body: str,
+    linked_issue: int | None = None,
+) -> ValidationResult:
+    """Validate a Copilot PR's file set, naming, and body markers.
+
+    ``linked_issue`` — when the caller (the PR gate) has already resolved
+    the originating issue via the PR's verified closing-issue link
+    (GitHub's Development sidebar / ``closingIssuesReferences``), the
+    literal ``Fixes #N`` line in the body is redundant and not required.
+    Copilot's coding agent routinely links the issue via the sidebar
+    *instead of* writing ``Fixes #N`` (see ``copilot_discover_mode.py``),
+    so requiring the text would reject otherwise-valid PRs. When
+    ``linked_issue`` is ``None`` (e.g. local/manual validation with no
+    resolved link) the body must still carry ``Fixes #N``.
+    """
     if mode not in VALID_MODES:
         raise ValueError(f"unknown mode {mode!r}; valid: {VALID_MODES}")
 
@@ -141,8 +159,10 @@ def validate_pr_shape(*, mode: str, files: list[PRFile], pr_body: str) -> Valida
                         f"source file `{f.path}` not listed under `{SOURCE_CHANGES_HEADING}`"
                     )
 
-    # 7. PR body links the originating issue.
-    if not FIXES_LINK_RE.search(pr_body or ""):
+    # 7. PR body links the originating issue. A verified closing-issue
+    #    link (passed as linked_issue by the gate) satisfies this without
+    #    the literal text — Copilot links via the Development sidebar.
+    if linked_issue is None and not FIXES_LINK_RE.search(pr_body or ""):
         errors.append("PR body must contain `Fixes #N` (the originating issue)")
 
     return ValidationResult(ok=not errors, errors=errors)
@@ -154,6 +174,12 @@ def _cli() -> int:
     parser.add_argument("--files-json", required=True, type=Path,
                         help='JSON: [{"path":..., "additions":N, "deletions":N}, ...]')
     parser.add_argument("--body-file", required=True, type=Path)
+    parser.add_argument(
+        "--linked-issue", type=int, default=None,
+        help="Originating issue number, if the gate already verified the "
+             "PR's closing-issue link. When set, the body's `Fixes #N` line "
+             "is not required.",
+    )
     args = parser.parse_args()
 
     raw = json.loads(args.files_json.read_text())
@@ -162,7 +188,9 @@ def _cli() -> int:
         for r in raw
     ]
     body = args.body_file.read_text()
-    result = validate_pr_shape(mode=args.mode, files=files, pr_body=body)
+    result = validate_pr_shape(
+        mode=args.mode, files=files, pr_body=body, linked_issue=args.linked_issue
+    )
     if result.ok:
         print("OK")
         return 0

--- a/.github/scripts/tests/test_copilot_discover_mode.py
+++ b/.github/scripts/tests/test_copilot_discover_mode.py
@@ -1,0 +1,60 @@
+"""Tests for copilot_discover_mode — label → (mode, kind) resolution.
+
+The full ``resolve()`` chain shells out to ``gh`` (closingIssuesReferences,
+issue views), so these tests pin the pure label-resolution helper that
+decides what a candidate issue *is*: a maintainer test-request
+(``copilot:<mode>`` → kind ``test-bot``) or a Feature-4 coverage task
+(``coverage-task`` → mode ``regression``, kind ``coverage-task``).
+
+A regression here is exactly the bug this change fixes: a coverage-task
+issue carries no ``copilot:<mode>`` label, so the old resolver failed
+mode-discovery and the gate rejected every coverage-task PR as
+``copilot:invalid`` — leaving the parent PR blocked forever.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from copilot_discover_mode import _mode_and_kind_from_labels  # noqa: E402
+
+
+def _labels(*names: str) -> list[dict]:
+    return [{"name": n} for n in names]
+
+
+def test_copilot_mode_label_maps_to_test_bot() -> None:
+    for mode in ("regression", "bug-repro", "fix-and-test"):
+        m, kind = _mode_and_kind_from_labels(_labels(f"copilot:{mode}"))
+        assert (m, kind) == (mode, "test-bot")
+
+
+def test_coverage_task_label_maps_to_regression_coverage_task() -> None:
+    m, kind = _mode_and_kind_from_labels(_labels("coverage-task"))
+    assert (m, kind) == ("regression", "coverage-task")
+
+
+def test_unrelated_labels_resolve_to_none() -> None:
+    m, kind = _mode_and_kind_from_labels(_labels("needs-tests", "bug"))
+    assert (m, kind) == (None, None)
+
+
+def test_empty_labels_resolve_to_none() -> None:
+    assert _mode_and_kind_from_labels([]) == (None, None)
+
+
+def test_explicit_mode_wins_over_coverage_task() -> None:
+    """If both are present, the explicit mode must not be downgraded.
+
+    A test-bot issue that somehow also picked up `coverage-task` should
+    still be treated as its real mode (and kind test-bot), never silently
+    forced to regression.
+    """
+    m, kind = _mode_and_kind_from_labels(
+        _labels("coverage-task", "copilot:bug-repro")
+    )
+    assert (m, kind) == ("bug-repro", "test-bot")

--- a/.github/scripts/tests/test_copilot_validate_pr_shape.py
+++ b/.github/scripts/tests/test_copilot_validate_pr_shape.py
@@ -217,3 +217,60 @@ def test_missing_fixes_link_fails_bug_repro() -> None:
 def test_unknown_mode_raises() -> None:
     with pytest.raises(ValueError):
         validate_pr_shape(mode="banana", files=[], pr_body="")
+
+
+# ----- linked-issue (coverage-task / sidebar-link) ----------------
+
+def test_linked_issue_satisfies_fixes_link_without_body_text() -> None:
+    """A gate-verified closing-issue link replaces the literal `Fixes #N`.
+
+    Copilot's coding agent routinely links the originating issue via the
+    Development sidebar instead of writing `Fixes #N` in the body. The
+    gate resolves that link (copilot_discover_mode.py) and passes the
+    issue number as linked_issue — the body text is then not required.
+    """
+    files = _files(
+        ("lex/test_project/tests/signals_ws/test_9e_thing.py", 80),
+        ("lex/test_project/test-plan/test-clusters.md", 3),
+        ("lex/test_project/test-plan/progress/session-log.md", 1),
+    )
+    pr_body = "Adds coverage for the consumer/signal sync. No Fixes line here."
+    result = validate_pr_shape(
+        mode="regression", files=files, pr_body=pr_body, linked_issue=556
+    )
+    assert result.ok, result.errors
+
+
+def test_missing_fixes_link_still_fails_when_no_linked_issue() -> None:
+    """Without a resolved link, the body must still carry `Fixes #N`."""
+    files = _files(
+        ("lex/test_project/tests/signals_ws/test_9e_thing.py", 80),
+        ("lex/test_project/test-plan/test-clusters.md", 3),
+        ("lex/test_project/test-plan/progress/session-log.md", 1),
+    )
+    result = validate_pr_shape(
+        mode="regression", files=files, pr_body="No link.", linked_issue=None
+    )
+    assert not result.ok
+    assert any("Fixes #" in e for e in result.errors)
+
+
+def test_coverage_task_regression_pr_passes_shape() -> None:
+    """A Feature-4 coverage-task PR is shaped exactly like a regression PR.
+
+    It maps to mode=regression (test-only, multi-file allowed) and links
+    its coverage-task issue via the sidebar — so with linked_issue set it
+    must pass shape validation end-to-end.
+    """
+    files = _files(
+        ("lex/test_project/tests/signals_ws/test_9e_consumer_signal_sync.py", 251),
+        ("lex/test_project/test-plan/test-clusters.md", 16),
+        ("lex/test_project/test-plan/progress/session-log.md", 1),
+        ("lex/test_project/test-plan/progress/dashboard.md", 3),
+        ("lex/test_project/test-plan/test-writing-plan.md", 15),
+    )
+    pr_body = "Adds cluster 9e coverage for the PR #555 source files."
+    result = validate_pr_shape(
+        mode="regression", files=files, pr_body=pr_body, linked_issue=556
+    )
+    assert result.ok, result.errors

--- a/.github/workflows/copilot_pr_gate.yml
+++ b/.github/workflows/copilot_pr_gate.yml
@@ -7,11 +7,20 @@
 #       closingIssuesReferences (Development sidebar), then close-
 #       keyword refs in the body, then bare #N; dereferences task
 #       issues to the source issue via "Assembled from issue #M".
-#       Reads the source issue's copilot:<mode> label.
-#    2. Static PR-shape check via copilot_validate_pr_shape.py.
+#       Reads the source issue's copilot:<mode> label, OR the
+#       coverage-task label (Feature 4) which maps to mode=regression
+#       with kind=coverage-task.
+#    1b. Coverage-task PRs only: retarget the PR's base from lex-app-v2
+#       onto the parent feature branch (Copilot ignores the base-branch
+#       instruction in the issue body), so the test ships in the parent
+#       PR's diff and its `coverage / required` check re-runs green.
+#    2. Static PR-shape check via copilot_validate_pr_shape.py. The
+#       resolved issue is passed as --linked-issue so a sidebar-only
+#       link satisfies the "Fixes #N" requirement.
 #    3. Run the new test in isolation. Mode-B strips
 #       @expectedFailure on a temp copy and asserts FAILURE.
-#    4. Apply auto-merge (modes A/B) or needs-human-review (mode C).
+#    4. Apply auto-merge (modes A/B + coverage-task) or
+#       needs-human-review (mode C).
 #
 #  Any failure → label PR copilot:invalid + comment + exit non-zero
 #  (the comment lists what failed; merge labels are not applied).
@@ -136,6 +145,43 @@ jobs:
           gh pr edit    "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "copilot:invalid"
           exit 1
 
+      # ── 1b. Retarget coverage-task PRs onto the parent branch ──
+      # Feature-4 coverage tasks must merge into the *parent feature
+      # branch*, not lex-app-v2, so the new test ships in the same diff
+      # as the source change and the parent PR's `coverage / required`
+      # check re-runs green (see the coverage-check spec §7.2). Copilot's
+      # coding agent bases its PR on the repo default branch regardless of
+      # the explicit instruction in the coverage-task issue body, so we
+      # correct the base here deterministically rather than relying on the
+      # agent. The parent PR head SHA is the merge-base of both branches
+      # (both branched off lex-app-v2), so GitHub's three-dot PR diff stays
+      # test-only after the retarget — no source is reverted. No-op when
+      # the PR already targets the parent branch (Copilot complied) or when
+      # this isn't a coverage-task PR.
+      - name: Retarget coverage-task PR onto parent branch
+        if: steps.mode.outputs.kind == 'coverage-task' && github.event.pull_request.base.ref == 'lex-app-v2'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COVERAGE_ISSUE: ${{ steps.mode.outputs.issue }}
+        run: |
+          set -euo pipefail
+          # The coverage-task issue body carries `*Parent PR:* #N`. Resolve
+          # that PR's head branch and make it this PR's base.
+          ISSUE_BODY=$(gh issue view "$COVERAGE_ISSUE" --repo "$GITHUB_REPOSITORY" --json body --jq .body)
+          PARENT_PR=$(printf '%s' "$ISSUE_BODY" | grep -oE 'Parent PR:\*? +#[0-9]+' | grep -oE '[0-9]+' | head -n1)
+          if [[ -z "${PARENT_PR:-}" ]]; then
+            echo "::error::could not find 'Parent PR: #N' in coverage-task issue #${COVERAGE_ISSUE} body — cannot retarget."
+            exit 1
+          fi
+          PARENT_BRANCH=$(gh pr view "$PARENT_PR" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
+          if [[ -z "${PARENT_BRANCH:-}" || "$PARENT_BRANCH" == "lex-app-v2" ]]; then
+            echo "::error::parent PR #${PARENT_PR} head branch resolved to '${PARENT_BRANCH:-<empty>}' — refusing to retarget."
+            exit 1
+          fi
+          echo "Retargeting PR #${PR_NUMBER} base lex-app-v2 → ${PARENT_BRANCH} (parent PR #${PARENT_PR})."
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --base "$PARENT_BRANCH"
+
       # ── 2. PR-shape gate ───────────────────────────────────────
       - name: Build files JSON + body file
         id: files
@@ -160,7 +206,8 @@ jobs:
           python .github/scripts/copilot_validate_pr_shape.py \
             --mode "${{ steps.mode.outputs.mode }}" \
             --files-json files.json \
-            --body-file body.txt | tee shape.out
+            --body-file body.txt \
+            --linked-issue "${{ steps.mode.outputs.issue }}" | tee shape.out
 
       - name: On shape failure, label + comment
         # Scope to the shape step only. Previously this used a bare


### PR DESCRIPTION
## Summary

Two independent bugs broke the Feature-4 coverage loop, leaving every coverage-task PR stuck at `copilot:invalid` and the parent feature PR blocked on `needs-tests` forever.

**Bug B — gate didn't understand coverage-task PRs.** Mode discovery hard-failed on coverage-task issues because they carry the `coverage-task` label, not a `copilot:<mode>` label. The shape validator separately required a literal `Fixes #N` line in the body, but Copilot links the originating issue via the Development sidebar instead (the very reason `copilot_discover_mode.py` exists).

**Bug A — Copilot targets the wrong base branch.** GitHub's Copilot coding agent always bases its PR on the repo default branch (`lex-app-v2`), ignoring the issue-text instruction to target the parent feature branch. The gate now retargets deterministically.

## What changed

- `copilot_discover_mode.py`: resolves `(mode, issue, kind)`. A `coverage-task` label maps to `(regression, coverage-task)`; `copilot:<mode>` still wins if both are present.
- `copilot_validate_pr_shape.py`: `validate_pr_shape` accepts `linked_issue`; a gate-verified closing-issue link satisfies rule #7 without the literal `Fixes #N`.
- `copilot_pr_gate.yml`: new step retargets a `kind=coverage-task` PR from `lex-app-v2` onto the parent feature branch (parsed from the coverage-task issue's `Parent PR: #N`), with guards refusing to retarget onto `lex-app-v2`. Shape validation now passes `--linked-issue`.

## Test plan

- [x] 107 script tests pass (`.github/scripts/tests/`), including 5 new discover-mode tests + 3 new shape-validator tests
- [x] `discover_mode` on PR #557 resolves `mode=regression / issue=556 / kind=coverage-task`
- [x] Retarget parse resolves #556 → parent PR #555 → `feat/cancel-audit-status-cancelled`
- [ ] After merge, existing stuck PRs (#557/#554/#551) need a re-trigger (close/reopen or push) — they won't retroactively reprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)