### PR TITLE
docs(agents): add Prime directive 4 — offer a PR on completion

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,3 +38,22 @@ kickstart_workflow OR kickstart_run  →  [work]  →  finalize_workflow
 ```
 
 See the tool descriptions for step details. Steps (0–12) are optional guidance — the kickstart → finalize pattern is mandatory.
+
+## Finishing work — offer a pull request
+
+When you believe a feature or bugfix is **complete and verified** — the code is written, its tests
+have been run, and they pass — **ask the developer whether to open a pull request.** Do not open one
+without being asked, and do not offer while the work is partial or any test is failing (keep going or
+report the blocker instead).
+
+If the developer says yes:
+
+1. Create a **new branch** with a meaningful, descriptive name (`feat/…`, `fix/…`). Never push
+   directly to the default `lex-app-v2` branch — the repository ruleset blocks direct pushes, so all
+   work must land via a branch + PR.
+2. Push the branch (`git push -u`) and open the PR with `gh pr create`: a concise title (< 70 chars)
+   and a body covering **what changed and why** plus a short test-plan / verification checklist.
+3. Return the PR URL.
+
+If the developer says no, leave the commits in place and continue. (Full agent workflow:
+[`AGENTS.md`](../AGENTS.md) → Prime directive 4.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,9 +107,34 @@ matches it so the two paths don't drift:
 
 If the plan and the tests on disk disagree, the task is not finished.
 
+## Prime directive 4 — When everything is complete and verified, offer a pull request
+
+Once the feature/bugfix, its cluster tests, **and** the test-plan are all consistent (directives 2–3)
+and the tests actually pass, **ask the developer whether to open a pull request** before touching any
+branch. Do **not** open a PR unsolicited.
+
+- **Only offer when the work is genuinely finished** — never mid-task, and never while tests are
+  failing or the change is partial. If it isn't done, keep going or report the blocker instead.
+- This is the **local agent's** completion step. It is unrelated to the cloud GitHub Copilot coding
+  agent that produces docs PRs in `lex-app-docs`.
+
+If the developer says **yes**:
+
+1. Create a **new branch** with a **meaningful, descriptive name** (`feat/…`, `fix/…`, e.g.
+   `feat/instant-cancel-calculations`, `fix/coverage-gate-all-apps`). **Never push to the default
+   `lex-app-v2` branch directly** — the repository ruleset blocks direct pushes, so every change lands
+   via a branch + PR.
+2. Move the completed commits onto that branch and push it with `git push -u`.
+3. Open the PR with `gh pr create`: a concise title (< 70 chars) and a body covering **what changed
+   and why**, plus a short test-plan / verification checklist (the same evidence directives 2–3
+   already produced).
+4. Return the PR URL.
+
+If the developer says **no**, leave the commits as they are and continue.
+
 ## What you'll be asked to do here
 
-- **Develop a feature/bugfix in lex-app** → directives 1→2→3, in that order.
+- **Develop a feature/bugfix in lex-app** → directives 1→2→3→4, in that order.
 - **Develop in a downstream Lex project** (not this framework repo) → follow that project's own
   conventions and [`docs/`](docs/); the cluster test-plan rules are framework-internal and do **not**
   apply to downstream app code.


### PR DESCRIPTION
## Summary

Documents the **local agent's** completion step so it stops being tribal knowledge: once a feature/bugfix and its tests are consistent and passing, the agent should ask the developer whether to open a PR — never unsolicited, never mid-task, never while tests fail.

- `AGENTS.md`: new **Prime directive 4** (offer a PR when everything is complete and verified), threaded into the `1→2→3→4` workflow list. Explicitly distinguishes the local agent's completion step from the cloud Copilot docs agent.
- `.github/copilot-instructions.md`: mirrors the same "finishing work — offer a pull request" guidance.

Both reinforce the existing rule: never push to `lex-app-v2` directly (ruleset blocks it) — land via a descriptive `feat/…`/`fix/…` branch + `gh pr create`, then return the URL.

## Test plan

- [x] Docs-only change — no code, no tests affected
- [x] Cross-references between the two files verified (AGENTS.md ↔ copilot-instructions.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)