### PR TITLE
ci(release): two-phase pre-release validation before publish

### DIFF
--- a/.github/workflows/copilot_publish_after_merge.yml
+++ b/.github/workflows/copilot_publish_after_merge.yml
@@ -4,13 +4,18 @@
 #  Fires when a Copilot PR with both `auto-merge` and
 #  `publish-on-merge` labels gets merged. Bumps the rc suffix on
 #  the latest release tag and creates a GitHub release; the
-#  existing `pip_publish.yml` (release: created) takes over from
+#  existing `pip_publish.yml` (release: released) takes over from
 #  there to publish to PyPI.
 #
-#  NOTE: the release is created NON-DRAFT on purpose. GitHub's
-#  `release` event family does not fire for draft creations — a
-#  draft sits silent until a maintainer manually flips it to
-#  published, which fires `published`/`released` (NOT `created`).
+#  NOTE: the release is created NON-DRAFT and NON-pre-release on
+#  purpose. A full release published without a prior draft fires
+#  `release: released`, which is exactly what pip_publish.yml now
+#  listens on — so this auto-cut path publishes in one shot (it does
+#  not use the manual two-phase pre-release validation flow; the gate
+#  inside pip_publish.yml still blocks a red build).
+#  Drafts and pre-releases would NOT fire `released`: a draft sits
+#  silent until promoted, and a pre-release fires `prereleased`
+#  (handled by validate_release.yml, which publishes nothing).
 #  Earlier versions of this file used `--draft` and the publish
 #  chain never ran. See pip_publish.yml's trigger comment.
 #

--- a/.github/workflows/frontend_build.yml
+++ b/.github/workflows/frontend_build.yml
@@ -21,7 +21,15 @@ name: Frontend Build
 
 on:
   release:
-    types: [published]
+    # `released`, NOT `published`: this build commits + pushes a fresh
+    # frontend bundle, so it must run only for REAL releases — never for
+    # the pre-release validation phase (see validate_release.yml). The
+    # `published` activity fires for pre-releases too, which would build
+    # and push a bundle during validation and then NOT re-fire when the
+    # pre-release is promoted to a full release. `released` fires only
+    # for full releases and for promotion (un-checking "pre-release"),
+    # which is exactly when a shipped bundle should be produced.
+    types: [released]
   workflow_dispatch:
     inputs:
       frontend_branch:

--- a/.github/workflows/pip_publish.yml
+++ b/.github/workflows/pip_publish.yml
@@ -25,14 +25,30 @@
 #  → 2.0.0rc124). The version in pyproject.toml is dynamic — it reads
 #  from lex/_version.py which this workflow writes before building.
 #
-#  Trigger: `release: created`. Fires when a non-draft release is
-#  created directly. GitHub does NOT fire any `release` event for
-#  draft creations — a draft sits silent until a maintainer flips
-#  it to published, which then fires `published`/`released`. We
-#  deliberately listen only on `created` so a release ships to PyPI
-#  exactly once, at the moment it becomes a real (non-draft) release.
-#  Upstream callers (e.g. copilot_publish_after_merge.yml) therefore
-#  must NOT use `--draft` when creating releases programmatically.
+#  Trigger: `release: released`. This is the PUBLISH half of a
+#  two-phase release. It fires ONLY when a release is published as a
+#  full (non-pre-release) release — which happens either by creating
+#  a full release directly, or by editing an existing PRE-RELEASE to
+#  uncheck "pre-release" (promotion). Crucially, promotion keeps the
+#  SAME tag, so a version validated as a pre-release ships to PyPI
+#  under that exact same version name.
+#
+#  The VALIDATE half lives in validate_release.yml, which fires on
+#  `release: prereleased` and runs the same gate WITHOUT publishing.
+#  The intended operator flow:
+#    1. Cut vX.Y.ZrcN as a PRE-RELEASE  → validate_release.yml runs
+#       the gate, publishes nothing. If it fails, re-push and re-cut;
+#       the tag is never "spent" on a publish.
+#    2. When green, edit the release and UNCHECK "pre-release"      →
+#       `released` fires on the same tag → this workflow publishes.
+#
+#  Why `released` and not `created`: `created` fires for pre-releases
+#  too, so it could not separate validate from publish. `released`
+#  never fires for pre-releases or drafts, so a pre-release validation
+#  pass can never accidentally publish. Programmatic callers
+#  (e.g. copilot_publish_after_merge.yml) that want to publish in one
+#  shot create a NON-draft, NON-pre-release release, which fires
+#  `released` directly — still a single publish.
 #
 #  Required secrets:
 #   - PYPI_API_TOKEN               (PyPI API token with upload permission)
@@ -52,12 +68,12 @@ name: Publish to PyPI
 
 on:
   release:
-    # `created` fires when a non-draft release is created (either
-    # directly, or by flipping a draft to published — both count as
-    # the moment the release becomes real). Drafts emit no release
-    # event at all, so this is a single-shot trigger per release.
-    # See header for the upstream contract this enforces.
-    types: [created]
+    # `released` fires only for FULL (non-pre-release, non-draft)
+    # releases — either created directly, or promoted from a
+    # pre-release by unchecking "pre-release" (same tag). Pre-releases
+    # fire `prereleased` instead and are handled by validate_release.yml
+    # (gate only, no publish). See header for the two-phase contract.
+    types: [released]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -138,10 +154,9 @@ jobs:
           if [[ -n "${{ inputs.version }}" ]]; then
             VERSION="${{ inputs.version }}"
           else
-            # For release events (including drafts triggered via `created`),
-            # GITHUB_REF_NAME points at the default branch, not the tag — the
-            # tag is not a real git ref until the release is published. Read
-            # the requested tag from the release payload instead.
+            # Read the tag straight from the release payload. On a
+            # `released` event the tag is real, but the payload value is
+            # authoritative regardless (and works for promoted pre-releases).
             # Strip leading 'v': v2.0.0rc124 → 2.0.0rc124.
             TAG="${{ github.event.release.tag_name }}"
             VERSION="${TAG#v}"

--- a/.github/workflows/validate_release.yml
+++ b/.github/workflows/validate_release.yml
@@ -1,0 +1,70 @@
+# ──────────────────────────────────────────────────────────────────────
+#  Validate a release candidate — the VALIDATE half of the two-phase
+#  release. Runs the full release gate WITHOUT publishing anything.
+#
+#  Why this exists:
+#    GitHub release tags are unique. If the gate ran on the publish
+#    event and failed, the tag is already "spent" — re-shipping the
+#    same version means deleting the release + tag and recreating it.
+#    This workflow lets a maintainer validate a candidate first, fix
+#    and re-validate as many times as needed under the SAME version
+#    name, and only then promote it to a real release that publishes.
+#
+#  Two-phase flow:
+#    1. Cut vX.Y.ZrcN as a PRE-RELEASE.
+#         → GitHub fires `release: prereleased`
+#         → THIS workflow runs the gate (tests + customer email),
+#           publishes NOTHING.
+#         → If red: push a fix, delete & re-cut the same pre-release
+#           tag, validate again. Nothing was ever published.
+#    2. When green, edit the release and UNCHECK "pre-release".
+#         → GitHub fires `release: released` (SAME tag)
+#         → pip_publish.yml takes over and publishes to PyPI.
+#
+#  IMPORTANT — why this is a separate file, not a branch inside
+#  pip_publish.yml:
+#    custom-image.yml and update_docs.yml both trigger on
+#    `workflow_run: ["Publish to PyPI"]` with conclusion == success.
+#    The workflow_run payload cannot tell a "validate" run apart from
+#    a "publish" run of the same workflow, so folding validation into
+#    pip_publish.yml would falsely fire the Docker build and the docs
+#    dispatch on every pre-release. Keeping validation under a
+#    different workflow NAME means those downstream legs only ever see
+#    real publishes.
+#
+#  The gate itself (showcase_tests.yml) is shared with pip_publish.yml,
+#  so a candidate is validated against exactly the same suite that will
+#  gate the eventual publish.
+#
+#  Required secrets: inherited by showcase_tests.yml — see that file.
+# ──────────────────────────────────────────────────────────────────────
+
+name: Validate Release Candidate
+
+on:
+  release:
+    # Fires only when a PRE-RELEASE is published. Full releases fire
+    # `released` and are handled by pip_publish.yml instead.
+    types: [prereleased]
+  workflow_dispatch:
+    inputs:
+      clusters:
+        description: >-
+          Cluster selector fed to the gate (same syntax as
+          run_showcase_suite.py --only). Defaults to all 13 clusters.
+        required: false
+        type: string
+        default: >-
+          init,crud_api,api_layer,calculations,validation_hooks,celery_async,history,audit_logging,permissions,signals_ws,serializers,exports,queries
+
+jobs:
+  # Run the same release gate pip_publish.yml uses, but stop there —
+  # there is no publish job, so nothing reaches PyPI.
+  validate:
+    name: "Release Candidate Gate: Tests + Customer Email"
+    uses: ./.github/workflows/showcase_tests.yml
+    secrets: inherit
+    with:
+      clusters: ${{ inputs.clusters || github.event.inputs.clusters || 'init,crud_api,api_layer,calculations,validation_hooks,celery_async,history,audit_logging,permissions,signals_ws,serializers,exports,queries' }}
+      # Distinguish this from a real release run in the email subject.
+      run_kind: prerelease


### PR DESCRIPTION
## Problem

GitHub release tags are unique. `pip_publish.yml` fired on `release: created` and published immediately, so a **failed gate left the tag spent** — re-shipping the same version meant deleting the release + tag and recreating it by hand.

## Fix — split validate from publish across the same tag

| Phase | Event | Workflow | Effect |
|---|---|---|---|
| **Validate** | `prereleased` (cut release with "pre-release" checked) | **`validate_release.yml`** (new) | runs the gate (tests + customer email) — **publishes nothing** |
| **Publish** | `released` (uncheck "pre-release" → promote, *same tag*) | `pip_publish.yml` | runs the gate + **publishes to PyPI** |

**Operator flow:** cut `vX.Y.ZrcN` as a **pre-release** → gate runs, nothing ships. If red, push a fix and re-cut the same pre-release tag (never spent). If green, **edit the release and uncheck "pre-release"** → `released` fires on the *same tag* → publishes.

## What changed

- **`pip_publish.yml`**: trigger `created` → `released`. Publishes only for full releases / promotions.
- **`validate_release.yml`** (new): trigger `prereleased`, runs the shared gate, no publish. Deliberately a *separate workflow name* — the downstream `workflow_run: ["Publish to PyPI"]` legs (`custom-image.yml`, `update_docs.yml`) can't tell a validate run from a publish run, so folding it into `pip_publish.yml` would falsely fire the Docker build + docs dispatch on every pre-release.
- **`frontend_build.yml`**: trigger `published` → `released`. `published` fires on pre-releases too (would build+commit a bundle during validation) and does **not** re-fire on promotion. `released` builds the shipped bundle only at the real release moment.
- **`copilot_publish_after_merge.yml`**: comments only — its non-draft/non-pre-release auto-cut fires `released`, so the one-shot auto-publish path is unchanged.

## Test plan

- [x] All four workflow YAMLs parse (`yaml.safe_load`)
- [x] Confirmed `released` fires for both direct full-release creation and pre-release promotion (so auto-cut + manual both publish)
- [x] Confirmed no other workflow keys off `release:` in a way this regresses (grepped: only `frontend_build` used `published`, now addressed)
- [ ] Smoke test: cut a throwaway pre-release tag → expect only `validate_release` runs; promote it → expect `pip_publish` + Docker + docs + frontend build

🤖 Generated with [Claude Code](https://claude.com/claude-code)