### PR TITLE
fix(tests): 2i cancel endpoint — e2e_unpatch={mark_in_progress}

### DIFF
--- a/lex/test_project/tests/crud_api/test_2i_cancel_endpoint.py
+++ b/lex/test_project/tests/crud_api/test_2i_cancel_endpoint.py
@@ -53,6 +53,15 @@ class TestCluster02i_CancelCalculationEndpoint(E2ETestCase):
     """Cluster 2i: PATCH ``cancel=true`` cancel-endpoint contract."""
 
     e2e_models = ALL_MODELS
+    # ``E2ETestCase`` patches ``mark_in_progress`` to a no-op by default
+    # (keeps unrelated happy-path tests deterministic). We need the real
+    # implementation here so the state-store entry actually lands and
+    # ``set_task_id`` can attach the Celery task handle the cancel
+    # endpoint reads. Without this, 2.93 / 2.96 fall through to
+    # ``sync_calculation_not_cancellable`` because ``cancel()`` sees no
+    # registered task_id and returns HTTP 409. (Same fix as cluster 7n
+    # in Session 68.)
+    e2e_unpatch = {"mark_in_progress"}
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Failure (CI)
```
test_02_93_patch_cancel_true_on_in_progress_celery_calc_returns_202
  AssertionError: 409 != 202 — response body said
    'cancellable': False, 'reason': 'sync_calculation_not_cancellable'
test_02_96_cancel_does_not_apply_sibling_fields_from_body
  AssertionError: 409 != 202
```
## Root cause
`TestCluster02i_CancelCalculationEndpoint` inherits `E2ETestCase`, which **patches `ActiveCalculationStateStore.mark_in_progress` to a no-op by default** (keeps unrelated happy-path tests deterministic). So in setUp:
```python
ActiveCalculationStateStore.mark_in_progress(...)   # patched no-op
ActiveCalculationStateStore.set_task_id(record_id, 'task-rest-1')
```
`set_task_id` requires the `_state_map` entry to already exist (its body is `entry = _state_map.get(record_id); if isinstance(entry, dict): entry['task_id'] = ...`). With no-op `mark_in_progress`, no entry exists → `set_task_id` silently no-ops → when the PATCH triggers `CalculationModel.cancel()` the `task_id = entry.get('task_id') or None` lookup returns None → falls into `sync_calculation_not_cancellable` return → HTTP 409.
2.94 and 2.95 accidentally pass because their preconditions happen to match the buggy state (terminal-state row and sync-no-task-id row both legitimately return 409).
## Fix
```python
class TestCluster02i_CancelCalculationEndpoint(E2ETestCase):
    e2e_models = ALL_MODELS
    e2e_unpatch = {"mark_in_progress"}
```
Same fix that was applied in Session 68 to `TestCluster07n_Cancellation` + `TestCluster07n_InProcessCancellationLandsAborted` when those classes migrated from `django.test.TestCase` → `E2ETestCase`. Cluster 2i is the same shape and missed that step.
## Local verification
Blocked by a separate pre-existing local-env issue (`Converter 'model' is already registered` during URL-conf load on the test client's first request) that doesn't affect CI — all four 2i tests hit that blocker before they reach the cancel-handler assertion. CI runs reproduce the original failure and will run green with this patch.