### PR TITLE
ci(release): opt-in gate_selftest cluster to test prerelease red path

### DIFF
--- a/.github/scripts/showcase_clusters.py
+++ b/.github/scripts/showcase_clusters.py
@@ -481,6 +481,32 @@ CLUSTERS: tuple[Cluster, ...] = (
         ),
         test_descriptions=QUERIES_TESTS,
     ),
+    Cluster(
+        # CI self-test cluster — NOT a product feature. It is registered
+        # here only so the runner will execute it when explicitly selected
+        # (`run_showcase_suite.py --only ...,gate_selftest`); it is left
+        # OUT of every default cluster selector, so normal releases never
+        # run it (exactly like `stress`). Its single test always fails on
+        # purpose, to drive the Prerelease Gate's red → auto-cleanup path.
+        key="gate_selftest",
+        label="CI self-test (intentionally fails)",
+        short_description=(
+            "Internal release-pipeline self-test — not a product feature."
+        ),
+        what_it_proves=(
+            "Nothing about the product. It exists purely to exercise the "
+            "prerelease gate's failure path on demand."
+        ),
+        what_it_means_if_broken=(
+            "This cluster is designed to fail whenever it runs. If it shows "
+            "up red in a real release gate, it was included by mistake — it "
+            "is not a product regression."
+        ),
+        why_it_matters=(
+            "Lets us verify the prerelease gate deletes a failed "
+            "prerelease and its tag without breaking a genuine test."
+        ),
+    ),
 )
 
 

--- a/.github/workflows/prerelease_gate.yml
+++ b/.github/workflows/prerelease_gate.yml
@@ -53,12 +53,42 @@ on:
 
 jobs:
   # ── Run the authoritative release gate against the prerelease commit. ──
+  # ── Pick the cluster selector. Normally the standard 13 clusters; if
+  #    you put [gate-selftest] in the prerelease title or notes, the
+  #    always-failing `gate_selftest` cluster is appended so you can prove
+  #    the RED → cleanup path on purpose (see cleanup-on-red below). ──────
+  select-clusters:
+    name: "Pick cluster selector"
+    runs-on: ubuntu-latest
+    outputs:
+      clusters: ${{ steps.pick.outputs.clusters }}
+    steps:
+      - id: pick
+        env:
+          NAME: ${{ github.event.release.name }}
+          BODY: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+          BASE="init,crud_api,api_layer,calculations,validation_hooks,celery_async,history,audit_logging,permissions,signals_ws,serializers,exports,queries"
+          # Opt-in self-test: a prerelease whose title OR notes contain the
+          # literal [gate-selftest] appends the gate_selftest cluster, which
+          # always fails — turning the gate red so cleanup-on-red deletes the
+          # prerelease + tag. Normal prereleases run only the standard 13.
+          if printf '%s\n%s' "$NAME" "$BODY" | grep -qF '[gate-selftest]'; then
+            echo "clusters=${BASE},gate_selftest" >> "$GITHUB_OUTPUT"
+            echo "[gate-selftest] marker found — appending the always-failing gate_selftest cluster."
+          else
+            echo "clusters=${BASE}" >> "$GITHUB_OUTPUT"
+            echo "No [gate-selftest] marker — running the standard 13 clusters."
+          fi
+
   gate:
     name: "Release Gate: Tests + Customer Email"
+    needs: select-clusters
     uses: ./.github/workflows/showcase_tests.yml
     secrets: inherit
     with:
-      clusters: init,crud_api,api_layer,calculations,validation_hooks,celery_async,history,audit_logging,permissions,signals_ws,serializers,exports,queries
+      clusters: ${{ needs.select-clusters.outputs.clusters }}
       # The prerelease gate is the release-day status update, same as the
       # pip_publish gate, so the stakeholder email is sent as a release run.
       run_kind: release

--- a/lex/test_project/tests/gate_selftest/test_gate_selftest.py
+++ b/lex/test_project/tests/gate_selftest/test_gate_selftest.py
@@ -1,0 +1,32 @@
+"""CI self-test cluster — intentionally and always fails.
+
+This cluster exists ONLY to exercise the Prerelease Gate's RED path
+(``.github/workflows/prerelease_gate.yml``): when it is included in a
+gate run, the gate goes red and the ``cleanup-on-red`` job deletes the
+prerelease and its tag. That is the whole point — it lets you prove the
+auto-cleanup works without having to break a real test.
+
+It is **excluded from the default release cluster selector**, so normal
+releases never run it. The runner only executes a cluster folder when its
+key is passed via ``run_showcase_suite.py --only``, and the prerelease
+gate only appends ``gate_selftest`` when you opt in by putting
+``[gate-selftest]`` in the prerelease title or notes. The filename has no
+numeric ``test_<N>x_`` prefix on purpose, so copilot_pr_gate's new-test
+detection never picks it up either.
+
+If you ever see this failure in a real release gate, someone included
+``[gate-selftest]`` (or selected the cluster) by mistake — it is not a
+product regression.
+"""
+
+from django.test import SimpleTestCase
+
+
+class TestGateSelfTest(SimpleTestCase):
+    def test_gate_selftest_always_fails(self):
+        self.fail(
+            "Intentional failure: the gate_selftest cluster is a CI "
+            "self-test for the Prerelease Gate red path. Seeing this means "
+            "the failing cluster was deliberately included — the gate is "
+            "expected to go red and auto-delete the prerelease + tag."
+        )


### PR DESCRIPTION
## Summary
Adds an **opt-in, always-failing** test cluster (`gate_selftest`) so we can prove the Prerelease Gate's **RED → auto-cleanup** path (delete the prerelease *and* its tag) on demand — without breaking a real product test.

This builds on #570 (the PAT-free Prerelease Gate). It does **not** touch any of the publish chain (`pip_publish.yml`, `frontend_build.yml`, `custom-image.yml`, `showcase_tests.yml`).

## How it works
- `lex/test_project/tests/gate_selftest/test_gate_selftest.py` — a `SimpleTestCase` that always `self.fail()`s. The filename has **no numeric prefix** on purpose, so `copilot_pr_gate`'s new-test detection never picks it up.
- Registered as a `Cluster` in `showcase_clusters.py`. It is **excluded from the default 13-cluster release selector**, so normal releases never run it.
- `prerelease_gate.yml` grows a `select-clusters` job: if the prerelease **title or notes** contain the literal `[gate-selftest]`, it appends `gate_selftest` to the cluster list; otherwise it runs the standard 13.

## How to use it
1. Cut a **prerelease** (tick "Set as a pre-release") with `[gate-selftest]` somewhere in the title or notes.
2. The gate runs the standard clusters **plus** `gate_selftest`, which always fails → the gate goes RED.
3. `cleanup-on-red` deletes the prerelease and its tag via `GITHUB_TOKEN` (no PAT). The version name is freed to re-cut.
4. Omit `[gate-selftest]` for any real release — the cluster never runs.

## Safety notes
- Report builder iterates `manifest["clusters"]` (only what ran), so a registered-but-unrun cluster produces no phantom row.
- The runner always selects via an explicit `--only` list, so the extra registered cluster has no effect unless explicitly appended.

## Test plan
- [ ] Cut a throwaway prerelease with `[gate-selftest]` in the notes and confirm the gate goes red and the prerelease + tag are auto-deleted.
- [ ] Cut a normal prerelease (no marker) and confirm `gate_selftest` does **not** run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)