### PR TITLE
feat(calculations): operator visibility & stuck-calculation recovery

### DIFF
--- a/lex/core/models/CalculationModel.py
+++ b/lex/core/models/CalculationModel.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from contextvars import ContextVar
 from copy import deepcopy
+from typing import Optional
 
 from django.db import models
 from django.db import transaction
@@ -499,6 +500,229 @@ class CalculationModel(LexModel):
             "revoked_tasks": revoked,
             "descendants_cancelled": descendants_cancelled,
         }
+
+    # ------------------------------------------------------------------
+    # Operator visibility & stuck-calculation recovery
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def list_in_progress(cls) -> list:
+        """Return a structured report of every active calculation.
+
+        Public surface for the operator dashboard / CLI / REST endpoint.
+        Each item exposes only the fields a human or external tool needs;
+        internal bookkeeping (the monotonic clock reading, the raw entry
+        shape) stays hidden.
+
+        The returned list is sorted oldest-first — that is the order an
+        operator wants when triaging a backlog.
+
+        Each item::
+
+            {
+                "record_id":      str,        # "<model_name>_<pk>"
+                "record":         str,        # human-readable __str__
+                "model_label":    str,        # "<app_label>.<model_name>"
+                "calculation_id": str,        # "" if none
+                "task_id":        str | None, # None for sync / unknown
+                "started_at":     str,        # UTC ISO-8601
+                "age_seconds":    float,
+                "cancellable":    bool,       # True iff a Celery task_id is known
+            }
+        """
+        from lex.core.signals.ActiveCalculationStateStore import (
+            ActiveCalculationStateStore,
+        )
+
+        return [
+            cls._public_entry(entry)
+            for entry in ActiveCalculationStateStore.list_active()
+        ]
+
+    @classmethod
+    def find_stuck(cls, older_than_seconds: float) -> list:
+        """Return active calculations older than ``older_than_seconds``.
+
+        Same shape as :meth:`list_in_progress`. ``older_than_seconds``
+        must be ``>= 0``; negative values raise ``ValueError`` (delegated
+        to the underlying store, which has the same contract).
+
+        Threshold semantics are inclusive: passing ``0`` returns every
+        active calculation; ``300`` returns calculations that have been
+        running at least five minutes.
+        """
+        from lex.core.signals.ActiveCalculationStateStore import (
+            ActiveCalculationStateStore,
+        )
+
+        return [
+            cls._public_entry(entry)
+            for entry in ActiveCalculationStateStore.list_active(
+                older_than_seconds=older_than_seconds,
+            )
+        ]
+
+    @classmethod
+    def cancel_stuck(
+        cls,
+        older_than_seconds: float,
+        *,
+        reason: str = "Calculation exceeded stuck-calculation threshold",
+    ) -> dict:
+        """Cancel every calculation older than ``older_than_seconds``.
+
+        Reuses the per-record :meth:`cancel` machinery (Celery revoke +
+        ``CANCELLED`` persistence + audit) for each candidate, so the
+        terminal state, audit row, and websocket broadcast are identical
+        to a single user-initiated cancel — operators do not need a
+        parallel code path that has to be kept in sync.
+
+        Calculations dispatched synchronously (no ``task_id``) cannot be
+        revoked in this design (mirroring :meth:`cancel`); they are
+        reported back as ``skipped`` rather than cancelled, so the caller
+        can decide what to do (e.g. surface them to a human, restart the
+        worker process).
+
+        Returns::
+
+            {
+                "threshold_seconds":     float,
+                "candidates":            int,    # how many were stuck
+                "cancelled":             int,    # successfully cancelled
+                "skipped_not_cancellable": int,  # sync calcs / no task_id
+                "errors":                int,    # exceptions during cancel
+                "results": [
+                    {"record_id": str, "outcome": "cancelled" | "skipped" | "error",
+                     "status": str, "detail": str | None},
+                    ...
+                ],
+            }
+
+        ``recursive=True`` is implied by reusing :meth:`cancel`: any
+        descendant sharing the parent's ``calculation_id`` is revoked
+        with the parent. Each parent therefore appears only once in
+        ``results``; descendants do not get a second top-level row.
+        """
+        from django.apps import apps
+
+        stuck = cls.find_stuck(older_than_seconds)
+        results = []
+        cancelled = 0
+        skipped = 0
+        errors = 0
+
+        # Cancelling a parent revokes its descendants too (the recursive
+        # walk in cancel()). Skip any record_id we have already collapsed
+        # under a parent's calculation_id so we do not call cancel() twice
+        # on the same row in the same sweep.
+        already_handled: set = set()
+
+        for entry in stuck:
+            record_id = entry["record_id"]
+            if record_id in already_handled:
+                continue
+
+            instance = cls._resolve_instance_for_entry(entry, apps)
+            if instance is None:
+                results.append(
+                    {
+                        "record_id": record_id,
+                        "outcome": "error",
+                        "status": None,
+                        "detail": "could_not_resolve_instance",
+                    }
+                )
+                errors += 1
+                already_handled.add(record_id)
+                continue
+
+            try:
+                report = cls.cancel(instance, recursive=True, reason=reason)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.exception(
+                    "cancel_stuck: cancel() raised for %s", record_id
+                )
+                results.append(
+                    {
+                        "record_id": record_id,
+                        "outcome": "error",
+                        "status": getattr(instance, "is_calculated", None),
+                        "detail": str(exc),
+                    }
+                )
+                errors += 1
+                already_handled.add(record_id)
+                continue
+
+            outcome = "cancelled" if report.get("cancelled") else "skipped"
+            if outcome == "cancelled":
+                cancelled += 1
+            else:
+                skipped += 1
+
+            results.append(
+                {
+                    "record_id": record_id,
+                    "outcome": outcome,
+                    "status": report.get("status"),
+                    "detail": report.get("reason"),
+                }
+            )
+
+            already_handled.add(record_id)
+            # Mark every descendant the cancel walk just collapsed so we
+            # don't try to cancel them as standalone targets in this sweep.
+            calc_id = entry.get("calculation_id") or ""
+            if calc_id:
+                for other in stuck:
+                    if other.get("calculation_id") == calc_id:
+                        already_handled.add(other["record_id"])
+
+        return {
+            "threshold_seconds": float(older_than_seconds),
+            "candidates": len(stuck),
+            "cancelled": cancelled,
+            "skipped_not_cancellable": skipped,
+            "errors": errors,
+            "results": results,
+        }
+
+    @staticmethod
+    def _public_entry(entry: dict) -> dict:
+        """Project a raw store entry into the public report shape."""
+        task_id = entry.get("task_id") or None
+        return {
+            "record_id": entry.get("record_id", ""),
+            "record": entry.get("record", entry.get("record_id", "")),
+            "model_label": entry.get("model_label", ""),
+            "calculation_id": entry.get("calculation_id", ""),
+            "task_id": task_id,
+            "started_at": entry.get("started_at_iso", ""),
+            "age_seconds": float(entry.get("age_seconds", 0.0)),
+            "cancellable": bool(task_id),
+        }
+
+    @classmethod
+    def _resolve_instance_for_entry(cls, entry: dict, apps) -> "Optional[CalculationModel]":
+        """Resolve a store entry back to its model instance.
+
+        Mirrors :meth:`_persist_cancelled_by_entry`'s lookup but returns
+        the live row instead of writing to it, so :meth:`cancel_stuck`
+        can dispatch to the existing :meth:`cancel` machinery.
+        """
+        model_label = entry.get("model_label") or ""
+        record_pk = entry.get("record_pk") or ""
+        if not model_label or "." not in model_label or not record_pk:
+            return None
+        app_label, model_name = model_label.split(".", 1)
+        try:
+            model_class = apps.get_model(app_label, model_name)
+        except Exception:
+            return None
+        try:
+            return model_class._default_manager.filter(pk=record_pk).first()
+        except Exception:
+            return None
 
     @staticmethod
     def _revoke_celery_task(task_id: str) -> None:

--- a/lex/core/signals/ActiveCalculationStateStore.py
+++ b/lex/core/signals/ActiveCalculationStateStore.py
@@ -1,5 +1,7 @@
 import logging
 import threading
+import time
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -56,6 +58,14 @@ class ActiveCalculationStateStore:
         Preserves any previously-stored ``task_id`` for the same
         ``record_id`` so a re-entrant ``calculate_hook`` invocation does
         not lose the Celery task handle needed for cancellation.
+
+        On first registration, stamps ``started_at_monotonic`` (a
+        ``time.monotonic()`` reading used for safe age math — wall-clock
+        time can jump backwards) and ``started_at_iso`` (a UTC ISO-8601
+        string for display in the operator UI / API report). A re-entrant
+        registration of the same ``record_id`` keeps the original start
+        timestamps so the visible "running time" reflects when the
+        calculation actually began, not when its hook was last touched.
         """
         if not record_id:
             return
@@ -64,6 +74,11 @@ class ActiveCalculationStateStore:
             existing = cls._state_map.get(record_id, {}) if isinstance(
                 cls._state_map.get(record_id), dict
             ) else {}
+            now_monotonic = existing.get("started_at_monotonic")
+            now_iso = existing.get("started_at_iso")
+            if not isinstance(now_monotonic, float):
+                now_monotonic = time.monotonic()
+                now_iso = datetime.now(timezone.utc).isoformat()
             cls._state_map[record_id] = {
                 "record_id": record_id,
                 "record": record or record_id,
@@ -71,6 +86,8 @@ class ActiveCalculationStateStore:
                 "model_label": model_label or "",
                 "record_pk": str(record_pk) if record_pk is not None else "",
                 "task_id": existing.get("task_id", ""),
+                "started_at_monotonic": now_monotonic,
+                "started_at_iso": now_iso or datetime.now(timezone.utc).isoformat(),
             }
 
     # ------------------------------------------------------------------
@@ -118,6 +135,58 @@ class ActiveCalculationStateStore:
                 if isinstance(entry, dict)
                 and entry.get("calculation_id") == calculation_id
             ]
+
+    @classmethod
+    def list_active(
+        cls,
+        *,
+        older_than_seconds: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return every active entry, optionally filtered by age.
+
+        Each returned dict carries the stored fields plus a freshly
+        computed ``age_seconds`` (non-negative float) so callers do not
+        need to know about the monotonic clock. Entries are sorted
+        oldest-first — the natural order for an operator looking for
+        stuck work.
+
+        ``older_than_seconds``:
+            * ``None`` (default) — return every entry.
+            * ``>= 0`` — return only entries whose ``age_seconds`` is
+              **greater than or equal to** the threshold. ``0`` therefore
+              still returns everything; ``60`` returns calculations that
+              have been running at least a minute.
+            * Negative values raise ``ValueError`` — a negative threshold
+              is almost always a bug at the call site (e.g. an
+              uninitialised setting) and silently returning the whole
+              store would mask it.
+        """
+        if older_than_seconds is not None and older_than_seconds < 0:
+            raise ValueError(
+                f"older_than_seconds must be >= 0, got {older_than_seconds!r}"
+            )
+
+        now = time.monotonic()
+        with cls._lock:
+            entries = [
+                dict(e) for e in cls._state_map.values() if isinstance(e, dict)
+            ]
+
+        enriched: List[Dict[str, Any]] = []
+        for entry in entries:
+            started = entry.get("started_at_monotonic")
+            if isinstance(started, (int, float)):
+                age = max(0.0, float(now - started))
+            else:
+                # Legacy entry written before started_at tracking was added —
+                # treat as age=0 rather than crashing the operator endpoint.
+                age = 0.0
+            entry["age_seconds"] = age
+            if older_than_seconds is None or age >= older_than_seconds:
+                enriched.append(entry)
+
+        enriched.sort(key=lambda e: e.get("age_seconds", 0.0), reverse=True)
+        return enriched
 
     @classmethod
     def clear(cls, record_id: str) -> None:
@@ -324,4 +393,3 @@ class ActiveCalculationStateStore:
             ):
                 return model_class
         return None
-


### PR DESCRIPTION
## What

Adds operator visibility and stuck-calculation recovery to the `CalculationModel` state machine.

Three new public classmethods, plus the start-time tracking they need:

| Surface | What it does |
| --- | --- |
| `CalculationModel.list_in_progress()` | Structured report of every active calculation (record id, started_at, age, cancellable). |
| `CalculationModel.find_stuck(older_than_seconds)` | Same shape, age-filtered. Inclusive threshold (`>=`). |
| `CalculationModel.cancel_stuck(older_than_seconds, *, reason=...)` | Bulk operator recovery. Reuses per-record `cancel()` for each candidate. Returns `{candidates, cancelled, skipped_not_cancellable, errors, results[]}`. Deduplicates descendants under a parent's `calculation_id`. |

`ActiveCalculationStateStore` gains:
- `started_at_monotonic` (for safe age math — wall-clock can jump) + `started_at_iso` (for display) stamped on first `mark_in_progress`, preserved on re-entrant calls.
- `list_active(*, older_than_seconds=None)` returning enriched entries with computed `age_seconds`, sorted oldest-first. Negative thresholds raise `ValueError`.

## Why

The store already tracked active calculations and `cancel()` already revoked a single one — but there was no public API to ask **"what's been running too long?"** or to bulk-recover wedged work, and **start times weren't tracked at all**. This is a real operational gap for the abort/recovery surface.

Reuses the existing store + `cancel()` machinery rather than introducing a parallel registry (per `AGENTS.md` prime directive 1.3 — "check for an existing mechanism before inventing one").

## Test plan

> **Note — tests intentionally omitted from this PR.** Per the developer's instruction, tests are *not* included so the cloud Copilot coverage agent (`copilot_coverage_check.yml`) can detect the missing pairings on `lex/core/models/CalculationModel.py` and `lex/core/signals/ActiveCalculationStateStore.py` and produce the cluster tests itself. This PR is the controlled experiment for that pipeline.

Local smoke-test confirmed the pure-logic surfaces on `ActiveCalculationStateStore`:

```
all       : [('m_1', 120s, 'task-abc'), ('m_2', 0s, '')]
>= 60     : ['m_1']
>= 0      : ['m_1', 'm_2']
preserve_started: True | task_id_kept: task-abc
rejects negative: older_than_seconds must be >= 0, got -1
```

Behavior surfaces the cluster suite should cover (Cluster 7 — Calculation State Machine):

1. `mark_in_progress` stamps `started_at_monotonic` + `started_at_iso` on first call.
2. Re-entrant `mark_in_progress` preserves the original start time + existing `task_id`.
3. `list_active()` with no filter returns every entry, oldest-first.
4. `list_active(older_than_seconds=N)` filters inclusively (`age >= N`).
5. `list_active(older_than_seconds=0)` returns everything (boundary).
6. `list_active(older_than_seconds=-1)` raises `ValueError`.
7. Legacy entries without `started_at_monotonic` get `age_seconds == 0.0` (graceful).
8. `CalculationModel.list_in_progress()` projects the public report shape (incl. `cancellable=True iff task_id`).
9. `CalculationModel.find_stuck(N)` delegates filtering to the store.
10. `cancel_stuck(N)` happy path: revokes Celery-backed entries.
11. `cancel_stuck` skips sync calculations (no `task_id`) → `skipped_not_cancellable`.
12. `cancel_stuck` deduplicates descendants sharing a `calculation_id` (one parent ⇒ one row).
13. `cancel_stuck` reports `errors` when an entry can't be resolved to a model row.
14. `cancel_stuck` aggregate counters (`candidates / cancelled / skipped_not_cancellable / errors`) match `len(results)`.

## Verification checklist

- [x] `python -m py_compile` passes on both touched files.
- [x] AST parse clean on both touched files.
- [x] Pure-logic smoke test of new state-store API behaves as specified.
- [ ] Cluster tests — **deliberately deferred to the cloud coverage agent** (see note above).

