### PR TITLE
Add heartbeat-based Celery worker-recovery subsystem

### DIFF
--- a/docs/celery-worker-recovery/README.md
+++ b/docs/celery-worker-recovery/README.md
@@ -1,0 +1,188 @@
+# Celery Worker Recovery
+
+A heartbeat-based safety net that detects abruptly-killed Celery workers and
+recovers their in-flight tasks, so a long-running calculation never gets stuck
+`IN_PROGRESS` forever.
+
+## The problem
+
+When a Celery worker dies cleanly, Celery handles the fallout. But our workers
+do not always die cleanly. In the cluster they run as KEDA-scaled pods that can
+be **SIGKILLed, OOM-killed, or evicted** out from under a running task. When
+that happens mid-calculation, the calculation row is left at `IN_PROGRESS` and
+any caller blocked on `AsyncResult(task_id).get()` waits forever. Nothing ever
+flips it to a terminal state.
+
+This subsystem closes that gap. Each worker re-stamps a short-lived Redis
+"heartbeat" key while a task runs. A dedicated supervisor watches for tasks
+that are still tracked as in-flight but whose heartbeat has expired — that
+divergence is the unambiguous fingerprint of a dead worker — and either
+re-runs the task or finalizes it as a terminal failure.
+
+Code lives in `lex/lex_app/celery_recovery/`.
+
+## Why heartbeats and not `visibility_timeout`
+
+Celery's Redis transport has its own redelivery mechanism (`visibility_timeout`):
+if a task isn't acked within that window, the broker re-delivers it. We have
+**deliberately disabled that**. The Celery settings set
+`visibility_timeout=float("inf")` together with `task_acks_late=True` and
+`task_reject_on_worker_lost=True`. That combination neutralizes Celery's native
+Redis redelivery on purpose (so long calculations are never silently
+re-delivered and double-run by the broker).
+
+The consequence: recovery **cannot** rely on `visibility_timeout`, and you
+should **not** change it back. This subsystem is layered on top instead, using
+heartbeats as an independent, explicit liveness signal. Treat
+`visibility_timeout=inf` as a fixed design constraint.
+
+## How it works, end to end
+
+1. **Worker heartbeat thread.** When a task starts (`task_prerun`), the worker
+   registers it in Redis and spins up a small daemon thread that re-stamps the
+   task's heartbeat key every `LEX_TASK_HEARTBEAT_INTERVAL` seconds. The
+   heartbeat key has a TTL of `interval * LEX_TASK_HB_TTL_MULTIPLIER`, so a
+   couple of missed refreshes let it expire. On `task_postrun` the thread stops
+   and the task is deregistered. (See `heartbeat.py`.)
+
+2. **Redis keys.** For each tracked task the registry keeps three keys
+   (namespaced per instance, see `redis_keys.py`):
+   - an **index set** of every tracked `task_id`;
+   - a **payload key** (`lex:recover:task:<id>`) holding the base64-pickled
+     re-dispatch payload plus a `retries` count;
+   - a **heartbeat key** (`lex:recover:hb:<id>`) — the short-TTL liveness marker.
+
+   Everything in the registry is best-effort: if Redis is unreachable, every
+   call degrades to a silent no-op. (See `registry.py`.)
+
+3. **Supervisor scan.** `scan_and_recover()` enumerates the index set and, for
+   each task, checks whether the heartbeat key still exists. A task that is
+   still in the index but whose heartbeat has expired is **dead**.
+
+4. **Same-`task_id` requeue.** For a dead task within budget, the supervisor
+   re-dispatches the **same** `task_id` onto its original queue. Reusing the id
+   matters: a parent blocked on `AsyncResult(task_id).get()` will receive the
+   eventual result of the re-run. The re-dispatched message is itself what
+   creates KEDA queue pressure to bring a fresh worker up.
+
+5. **Bounded budget → terminal ABORTED.** Each requeue increments `retries`.
+   Once `retries` reaches `LEX_TASK_MAX_RETRIES`, the supervisor stops retrying,
+   writes a `MaxRequeueExceeded` FAILURE to the result backend (so the waiter
+   unblocks instead of hanging), flips the stuck calculation row to `ABORTED`,
+   and deregisters the task. (See `supervisor.py`, `exceptions.py`.)
+
+## Deployment
+
+The supervisor must be **always-on**, because a dead worker can only be detected
+by a process that is still alive. In the cluster, neither the workers nor the
+backend can host it reliably:
+
+- Celery **workers** run as a KEDA **ScaledJob** — they scale to zero when idle.
+- The **backend** runs as a KEDA **ScaledObject** scaled 0..1 — it also scales
+  to zero.
+
+So the supervisor gets its own dedicated **singleton Deployment**. The reference
+manifest is
+[`k8s/recovery-supervisor-deployment.yaml`](k8s/recovery-supervisor-deployment.yaml)
+(`replicas: 1`, `strategy: Recreate`, `terminationGracePeriodSeconds: 30`). It
+is a reference template that gets adapted into the lex-instance Helm chart.
+
+**Critical:** the supervisor pod must point at the **same Redis instance and DB
+index** the workers use, and share the same `INSTANCE_RESOURCE_IDENTIFIER`. If
+it talks to a different Redis it sees an empty registry and silently recovers
+nothing. Wire its `envFrom` to the same ConfigMap/Secret the backend and worker
+pods already consume.
+
+### Ways to run it
+
+- **Console script** (preferred — what the manifest uses):
+  ```
+  lex-recovery-supervisor              # always-on loop
+  lex-recovery-supervisor --once       # single pass, then exit
+  lex-recovery-supervisor --interval 5
+  ```
+  Exposed via `[project.scripts]`; bootstraps Django then forwards to the
+  management command (see `entrypoint.py`).
+
+- **Management command** (same loop, via the lex CLI / Django):
+  ```
+  lex run_recovery_supervisor
+  lex run_recovery_supervisor --once          # single sweep (cron / debugging)
+  lex run_recovery_supervisor --interval 10
+  ```
+  `--interval` overrides `LEX_TASK_SUPERVISOR_SCAN_INTERVAL`; `--once` runs one
+  `scan_and_recover()` pass and exits.
+
+The command handles SIGTERM/SIGINT gracefully: it finishes the in-flight sweep,
+then exits. On an unexpected crash it exits non-zero so Kubernetes restarts the
+pod.
+
+> A Celery-beat fallback also exists: the `sweep_dead_workers` task is scheduled
+> as `lex-celery-recovery-sweep` (with `expires` set so the queue can't backlog).
+> The dedicated singleton is preferred — the beat path would spawn a worker every
+> interval just to poll.
+
+## Configuration knobs
+
+| Setting | Default | Controls |
+|---|---|---|
+| `LEX_TASK_RECOVERY_ENABLED` | `true` | Master switch. Disables all signal handlers, the heartbeat thread, and the supervisor sweep. |
+| `LEX_TASK_HEARTBEAT_INTERVAL` | `5` (s) | How often the worker re-stamps its heartbeat key. |
+| `LEX_TASK_HB_TTL_MULTIPLIER` | `3` | Heartbeat key TTL = interval × multiplier. Higher = more tolerance for a slow/paused worker before it's declared dead. |
+| `LEX_TASK_SUPERVISOR_SCAN_INTERVAL` | `10` (s) | How often the supervisor scans for dead tasks (also the beat schedule period). |
+| `LEX_TASK_MAX_RETRIES` | `4` | Requeue budget per task before giving up and finalizing `ABORTED`. |
+| `LEX_TASK_REQUEUE_GRACE_SECONDS` | `60` (s) | Grace TTL granted to a heartbeat just before a requeue, so the re-run can start before the next scan re-detects it. Also the per-task recovery-lock TTL. |
+| `LEX_TASK_PAYLOAD_TTL_SECONDS` | `86400` (24h) | How long a re-dispatch payload survives in Redis. Refreshed while the task is alive (see edge case C). |
+
+`LEX_TASK_REQUEUE_GRACE_SECONDS` and `LEX_TASK_PAYLOAD_TTL_SECONDS` are read with
+their defaults in code; set them as environment variables to override.
+
+## Edge-case behavior
+
+**A. Cancelled calculation → finalized CANCELLED, never requeued.** Before
+requeuing a dead task the supervisor checks the cluster-wide cancellation marker
+for that calculation. If the user had cancelled it, the supervisor finalizes the
+stuck rows as `CANCELLED` (not `ABORTED`), deregisters the task, and does **not**
+requeue — re-running work the user asked to stop would be wrong.
+
+**B. Multi-supervisor double-act safety.** Before acting on a dead task the
+supervisor takes a per-task Redis lock (`SET ... NX EX`). Only the replica that
+wins the lock acts; others skip the task this window. So even if two supervisors
+run, the same dead task is never requeued or finalized twice in one pass.
+(Running >1 replica is safe but unnecessary — the manifest keeps it at 1.)
+
+**C. Long-running tasks outliving the payload TTL.** The payload key defaults to
+a 24h TTL, but some calculations run longer. Each heartbeat refresh also bumps
+the payload key's expiry (only the expiry, never the value), so a task that is
+still alive keeps a recoverable payload for as long as it runs.
+
+**D. Broker outage during requeue must not burn the budget.** The requeue is
+deliberately split around the dispatch. First `grant_grace` re-stamps the
+heartbeat to a short TTL (delays re-detection only). Then `send_task` actually
+re-dispatches — and may raise if the broker is down. Only **after** a successful
+dispatch does `persist_payload` commit the incremented `retries`. So a failed
+dispatch consumes only the grace window, not a retry slot; the next pass retries
+cleanly.
+
+**E. Revoke fast-path.** When a task is revoked (typically a user cancellation),
+the `task_revoked` handler stops its heartbeat thread and deregisters it
+immediately by request id. That removes it from the registry before the
+supervisor could ever observe an expired heartbeat, so a revoked task can never
+be mistaken for a dead worker and requeued.
+
+## Enabling and disabling
+
+Recovery does real work only when **both** `CELERY_ACTIVE` is true **and**
+`LEX_TASK_RECOVERY_ENABLED` is true. `enable(app)` (wired from the Celery app
+module) connects the heartbeat signal handlers only under those conditions, and
+it is idempotent.
+
+When recovery is disabled — or whenever Redis is simply unreachable — every
+registry operation is a best-effort no-op and `is_alive()` fails safe (it never
+declares a task dead when it can't read Redis). That means **local, synchronous,
+and CI runs are completely unaffected**: no heartbeat threads, no requeues, no
+surprises. Set `LEX_TASK_RECOVERY_ENABLED=false` to turn the whole subsystem off
+in environments where no real Redis-backed Celery is running.
+
+The `sweep_dead_workers` task is itself excluded from tracking, so the recovery
+machinery never tries to recover its own sweeps.

--- a/docs/celery-worker-recovery/k8s/recovery-supervisor-deployment.yaml
+++ b/docs/celery-worker-recovery/k8s/recovery-supervisor-deployment.yaml
@@ -1,0 +1,159 @@
+# =============================================================================
+# Celery worker-recovery supervisor — reference Kubernetes Deployment
+# =============================================================================
+#
+# WHAT THIS IS
+#   A single, always-on companion process that runs the worker-recovery sweep
+#   loop (lex/lex_app/celery_recovery/supervisor.py::run_forever). Every scan
+#   interval it looks for tasks whose worker died (expired Redis heartbeat) and
+#   either re-dispatches them (within the retry budget) or finalizes them as
+#   ABORTED. The re-dispatch puts a message on the queue KEDA watches, which is
+#   what brings a fresh worker up to actually run the recovered task.
+#
+# WHY IT'S A STANDALONE SINGLETON (and can't live in the backend or workers)
+#   In the cluster the Celery workers run as a KEDA ScaledJob and the backend
+#   runs as a KEDA ScaledObject scaled 0..1 — BOTH scale to zero when idle. The
+#   recovery loop must be always-on (a dead worker can only be detected by a
+#   process that is still alive), so it cannot reliably live in either of those.
+#   This Deployment hosts it as its own always-on pod.
+#
+#   replicas: 1 because the supervisor is a singleton. The recovery code does
+#   hold a per-task Redis lock (try_acquire_recovery_lock), so running >1 is
+#   SAFE but unnecessary — keep it at 1.
+#
+# CRITICAL: REDIS DB INDEX MUST MATCH THE WORKERS
+#   Heartbeats, the task registry, and the broker all live in Redis. This pod
+#   MUST point at the SAME Redis instance AND the same DB index the workers use
+#   (the broker URL in settings.py uses redis .../1, the results/heartbeat
+#   client uses .../2 — see CELERY_BROKER_URL and the recovery Redis client).
+#   If this pod talks to a different Redis or DB index it will see an empty
+#   registry and silently recover nothing. Reuse the worker's Redis env exactly.
+#
+# WHERE THIS GETS USED
+#   This is a REFERENCE TEMPLATE. It is adapted into the LEX_TERRAFORM_MODULES
+#   lex-instance Helm chart (modules/lex-instance/chart/templates/). The
+#   envFrom configMap/secret names below are placeholders — wire them to the
+#   same ConfigMap/Secret the backend and worker pods already consume so all
+#   three share identical Redis + Postgres connection settings.
+#
+# HEALTH / RESTART
+#   No HTTP healthcheck is needed: this is a headless polling loop with no
+#   server. If the process crashes the Deployment restarts the pod (and the
+#   management command exits non-zero on an unexpected failure precisely so K8s
+#   restarts it). On normal pod termination K8s sends SIGTERM; the command
+#   installs a SIGTERM/SIGINT handler that calls supervisor.stop_forever() so
+#   the loop finishes its current pass and exits cleanly within the grace
+#   period below.
+# =============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recovery-supervisor
+  labels:
+    app.kubernetes.io/name: recovery-supervisor
+    app.kubernetes.io/component: celery-worker-recovery
+    app.kubernetes.io/part-of: lex-instance
+spec:
+  # Singleton: exactly one supervisor process cluster-wide.
+  replicas: 1
+  # Recreate (not RollingUpdate): never run two supervisors at once during a
+  # rollout. The new pod only starts after the old one is fully terminated.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: recovery-supervisor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: recovery-supervisor
+        app.kubernetes.io/component: celery-worker-recovery
+        app.kubernetes.io/part-of: lex-instance
+    spec:
+      # Give the SIGTERM handler time to finish the in-flight sweep before the
+      # kubelet escalates to SIGKILL.
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: recovery-supervisor
+          # Same image the backend / workers run (it ships the lex-app package
+          # and therefore the lex-recovery-supervisor console script).
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          # Console-script form (preferred — added to [project.scripts] in
+          # pyproject.toml as lex-recovery-supervisor).
+          command: ["lex-recovery-supervisor"]
+          # Alternative if you prefer the lex CLI / Django management path:
+          #   command: ["python", "-m", "lex", "run_recovery_supervisor"]
+          # Both run the same `run_recovery_supervisor` management command.
+          # Optional args: ["--interval", "10"]  (defaults to the
+          # LEX_TASK_SUPERVISOR_SCAN_INTERVAL setting).
+          envFrom:
+            # Reuse the SAME ConfigMap + Secret the backend and worker pods
+            # consume so Redis + Postgres connection settings are identical.
+            # Replace these names with the chart's actual resource names.
+            - configMapRef:
+                name: lex-instance-config       # PLACEHOLDER — shared app config
+            - secretRef:
+                name: lex-instance-secrets       # PLACEHOLDER — shared app secrets
+          env:
+            # ----- Recovery must be active for the supervisor to do work -----
+            - name: CELERY_ACTIVE
+              value: "TRUE"
+            - name: LEX_TASK_RECOVERY_ENABLED
+              value: "true"
+            # ----- Deployment target (non-local enables deployed behavior) ---
+            - name: DEPLOYMENT_TARGET
+              value: "{{ .Values.deploymentTarget | default \"kubernetes\" }}"
+            - name: DEPLOYMENT_ENVIRONMENT
+              value: "{{ .Values.deploymentEnvironment }}"
+            # ----- Cluster / queue identity (must match the workers) ---------
+            # CELERY_TASK_DEFAULT_QUEUE and the Redis/Celery key prefix both
+            # derive from INSTANCE_RESOURCE_IDENTIFIER in settings.py — it MUST
+            # match the workers or recovery re-dispatches onto the wrong queue.
+            - name: INSTANCE_RESOURCE_IDENTIFIER
+              value: "{{ .Values.instanceResourceIdentifier }}"
+            # ----- Redis (broker + heartbeat/registry) — MUST match workers --
+            # settings.py builds the broker/result URLs from these. The DB
+            # index is baked into settings (.../1 broker, .../2 results); just
+            # ensure HOST/credentials point at the workers' Redis.
+            - name: REDIS_HOST
+              value: "{{ .Values.redis.host }}"            # PLACEHOLDER
+            - name: REDIS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: lex-instance-secrets               # PLACEHOLDER
+                  key: REDIS_USERNAME
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: lex-instance-secrets               # PLACEHOLDER
+                  key: REDIS_PASSWORD
+            # ----- Postgres (finalizing stuck calculation rows) --------------
+            - name: DATABASE_DEPLOYMENT_TARGET
+              value: "default"
+            - name: DATABASE_DOMAIN
+              value: "{{ .Values.database.domain }}"        # PLACEHOLDER
+            - name: DATABASE_NAME
+              value: "{{ .Values.database.name }}"          # PLACEHOLDER
+            - name: POSTGRES_USERNAME
+              value: "{{ .Values.database.username | default \"django\" }}"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: lex-instance-secrets                # PLACEHOLDER
+                  key: POSTGRES_PASSWORD
+            # ----- Optional recovery tuning (defaults shown) -----------------
+            # - name: LEX_TASK_SUPERVISOR_SCAN_INTERVAL
+            #   value: "10"
+            # - name: LEX_TASK_MAX_RETRIES
+            #   value: "4"
+            # - name: LEX_TASK_REQUEUE_GRACE_SECONDS
+            #   value: "60"
+          resources:
+            # Light polling loop — modest footprint.
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"

--- a/docs/celery-worker-recovery/plan.md
+++ b/docs/celery-worker-recovery/plan.md
@@ -1,0 +1,972 @@
+---
+title: "Celery Worker Recovery — Bounded Requeue on Worker Death"
+status: IMPLEMENTED — Phases 1–7 landed 2026-05-20; integration smoke harness (cluster 8s) landed 2026-05-20; customer-shaped end-to-end recovery suite (cluster 8t, 6 scenarios) landed 2026-05-20 following the test-plan §9 Golden Rule (real `CeleryCalc` models, real `@lex_shared_task` path, assertions on `is_calculated`) and verified green against a live Redis broker (36/36 tests in 11.9 s)
+owner: hazem
+created: 2026-05-20
+last-updated: 2026-05-20
+related-files:
+  - lex/lex_app/celery.py
+  - lex/lex_app/celery_tasks.py
+  - lex/lex_app/settings.py
+  - lex/lex_app/celery_recovery/
+  - docs/features/processing/worker recovery.md
+  - docs/ci-cd/celery-worker-recovery.md
+---
+
+# Celery Worker Recovery — Bounded Requeue on Worker Death
+
+## 0. TL;DR for the next agent
+
+We need a recovery mechanism on top of the existing Celery setup that:
+
+1. **Detects** when a worker dies mid-task using a *heartbeat*, **not** `visibility_timeout`. `visibility_timeout` is currently `float("inf")` and must not be relied on as the recovery signal.
+2. **Requeues** the dead worker's in-flight task back to the broker, **preserving the original `task_id`** so the parent's `result.get()` keeps blocking on the same result row.
+3. **Caps** requeue attempts at a configurable max (default 4). On the (max+1)-th would-be requeue, the supervisor writes a `FAILURE` to the result backend so the parent thread blocked inside `WaitForTasks.wait_for_completion()` raises and the parent calculation is marked `ERROR`.
+4. **Reuses the existing callback path** — when the requeued task finally executes (or fails through the supervisor), `CallbackTask.on_success` / `on_failure` runs as today and `is_calculated` is updated on the `CalculationModel`.
+
+Implementation status as of 2026-05-20: **Phases 1–7 are landed**. The recovery package lives at `lex/lex_app/celery_recovery/`, the supervisor runs from Celery beat under the schedule key `lex-celery-recovery-sweep`, and 28 unit tests in `lex/test_project/tests/celery_async/test_8r_worker_recovery.py` cover the heartbeat, supervisor, decorator surface, and failure-injection paths. The remaining open item is an integration smoke run against a real Redis + Postgres broker (see Phase 4 progress entry).
+
+Customer-facing docs: [`docs/features/processing/worker recovery.md`](../features/processing/worker%20recovery.md).
+Operator / DevOps docs: [`docs/ci-cd/celery-worker-recovery.md`](../ci-cd/celery-worker-recovery.md).
+
+---
+
+## 1. Problem statement
+
+### Observed symptoms (infra only — not reproducible locally)
+
+- A worker pod can deadlock on a single task. Parent's `result.get()` never returns.
+- When a worker dies (OOM, SIGKILL, evicted pod) we have no way to talk to it and no way to know which task it had.
+- The framework already sets `task_acks_late=True` and `task_reject_on_worker_lost=True`, which would normally cause Celery to redeliver the lost task. But the Redis transport uses `visibility_timeout` as the sweep for orphaned `unacked` entries, and we have `visibility_timeout=float("inf")` in `CELERY_BROKER_TRANSPORT_OPTIONS` (`lex/lex_app/settings.py:398-405`). With `inf`, the orphaned entry sits in Redis's `unacked` hash forever and the task is never redelivered.
+
+### Why we can't just lower `visibility_timeout`
+
+Per project decision: `visibility_timeout` is a blunt instrument — it's queue-wide, it forces every long-running task to be smaller than the sweep window, and on Redis transport a redelivery from `visibility_timeout` doesn't carry retry-count state so we can't bound it cleanly. We want a heartbeat-based mechanism that operates per-task and is independent of how long the task takes to run.
+
+We will keep `visibility_timeout=float("inf")` as is (long-stop), and layer our own bounded recovery on top.
+
+### What "worker dies" means in this design
+
+Anything that prevents the worker from running its task body to completion *or* from sending `on_failure` to the result backend:
+
+- Pod evicted / OOM-killed / `SIGKILL`
+- Node lost
+- Network partition between worker and Redis (long enough for heartbeat TTL to elapse)
+- Process hangs in C code or a runaway loop with no GIL release
+
+A *normal* exception inside the task body is **not** in scope — that already flows through `CallbackTask.on_failure` (`lex/lex_app/celery_tasks.py:126`). We must not double-handle those.
+
+---
+
+## 2. User story (from product owner)
+
+> A `CalculationModel` runs in the backend thread and, inside a `WaitForTasks` block, spawns 5 child calculations (each decorated with `@lex_shared_task`). Four finish; one is still pending. The main thread blocks on that pending one.
+>
+> - If the task fails normally → `on_failure` fires as today.
+> - If the worker dies for an unexpected reason → the task should be requeued, up to a configurable max (4–5 attempts). If still not done after max attempts, the supervisor must inject a failure so the main calculation fails with a clear exception.
+
+---
+
+## 3. Constraints and non-goals
+
+### Constraints
+
+- **No reliance on `visibility_timeout`** for recovery detection.
+- **Same `task_id` on requeue.** The parent is holding an `AsyncResult` keyed by the original task_id; replacing it breaks the join.
+- **Bounded retries.** Default 4, configurable per-deployment and per-task.
+- **Result backend is Postgres** (`db+postgresql`, see `lex/lex_app/settings.py:381-385`). Failure injection writes to `celery_taskmeta`.
+- **`task_acks_late=True` stays on.** We rely on Celery still holding the task in `unacked` so we can re-publish from the original payload.
+- **Pickle serializer stays on.** We will pass `CalculationModel` instances and richer kwargs through requeue without conversion.
+- **One worker = one in-flight task at any time** (concurrency=1 + prefetch=1 + post-task pod shutdown in `lex/lex_app/celery.py:49-86`). This simplifies bookkeeping — there is only one active `task_id` per worker hostname at a time.
+- The new module must keep working when `CELERY_ACTIVE=false` (no broker connection attempted, no supervisor running). Tests must not require Redis to be installed.
+
+### Non-goals (for this round)
+
+- Replacing the result backend.
+- Removing `visibility_timeout=float("inf")` (left as a long-stop).
+- Cross-region / multi-broker failover.
+- Auto-scaling worker pool sizing.
+- Replacing Flower or building a new dashboard.
+
+---
+
+## 4. Design overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Backend (web) process                                                │
+│                                                                       │
+│  CalculationModel.calculate()                                         │
+│    with WaitForTasks():                                               │
+│        child.save()  → calc_and_save.delay(...)  ───────────┐         │
+│                                                              │         │
+│    WaitForTasks.__exit__ → wait_for_completion()             │         │
+│        for r in results: r.get()  (blocks on Postgres row)   │         │
+└──────────────────────────────────────────────────────────────┼─────────┘
+                                                               │
+                                                               ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  Redis (broker only)                                                  │
+│   queue:<queue_name>      (LIST) — pending tasks                      │
+│   unacked / unacked_index  — in-flight, reserved by worker            │
+│                                                                       │
+│   lex:wrk:<hostname>       (STRING, TTL ~3×hb) — worker liveness     │
+│   lex:task:<task_id>       (HASH) — task tracking                     │
+│      worker, attempt, max_retries, task_name, queue,                  │
+│      args_b64, kwargs_b64, parent_task_id, last_hb_iso                │
+│   lex:task:<task_id>:lock  (STRING, TTL 30s) — supervisor lease       │
+└──────────────────────────────────────────────────────────────────────┘
+        ▲                                                ▲
+        │ heartbeat writes                               │ scans for stale
+        │                                                │
+┌───────┴────────────────────────────┐         ┌─────────┴───────────────┐
+│  Worker process                     │         │  Supervisor process     │
+│                                     │         │  (Celery beat task OR   │
+│  task_prerun  → register task        │         │   standalone CLI)        │
+│  HeartbeatThread (every 5s):         │         │                          │
+│      SET lex:wrk:<host>  EX 15       │         │  Every 10s:              │
+│      HSET lex:task:<id>  last_hb     │         │   for each lex:task:*:   │
+│  task_postrun → unregister task      │         │     if last_hb stale:    │
+│  worker_shutting_down → del wrk key  │         │       acquire lock       │
+└─────────────────────────────────────┘         │       decide requeue/fail│
+                                                 │       publish or mark    │
+                                                 └─────────────────────────┘
+                                                              │
+                                                              ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  Postgres (result backend)                                            │
+│   celery_taskmeta: task_id → STATUS, RESULT                           │
+│   On max-retries-exceeded: supervisor writes FAILURE here              │
+│   → parent's r.get(propagate=True) raises → parent calc → ERROR        │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Why heartbeat *per task* (and not just per worker)
+
+We do have one task per worker today, but conceptually the bookkeeping is per-task because:
+
+- The supervisor needs the original args/kwargs/queue *of the task* in order to re-publish it.
+- The attempt counter is a property of the task, not the worker.
+- A worker can be alive but stuck (rare, but possible — Python hung in C code with GIL held). A per-task heartbeat refreshed *from inside the task* would catch this; a worker-only heartbeat would not.
+
+We'll do both keys. `lex:wrk:<host>` is for operator visibility (`KEYS lex:wrk:*` shows live workers). `lex:task:<id>` is the source of truth for recovery decisions.
+
+---
+
+## 5. Component breakdown
+
+### 5.1 Heartbeat writer (worker-side)
+
+Lives in the worker process. A daemon thread started on `worker_ready` and stopped on `worker_shutting_down`.
+
+Responsibilities:
+
+- Every `LEX_TASK_HEARTBEAT_INTERVAL` seconds (default 5):
+  - `SET lex:wrk:<hostname> "1" EX <ttl>` where ttl = interval × `LEX_TASK_HB_TTL_MULTIPLIER` (default 3 → 15s).
+  - For each task currently in `_in_flight_tasks` (in practice 0 or 1): `HSET lex:task:<task_id> last_hb_iso=<now>` and `EXPIRE lex:task:<task_id> <ttl>`.
+- If Redis is unreachable: log at WARNING and keep trying. Do not crash the worker.
+
+### 5.2 Task lifecycle hooks (worker-side)
+
+Connect to Celery signals in the same module.
+
+- `task_prerun`: register the task. If `attempt` is in headers, read it (this is a requeue); else attempt=0. Write the `lex:task:<id>` hash with full payload so a future requeue can re-publish without help from Redis's `unacked` store. Add `task_id` to a thread-local `_in_flight_tasks` set so heartbeat refreshes it.
+- `task_postrun`: unregister the task. Delete `lex:task:<id>`. Remove from `_in_flight_tasks`. This is the success-or-handled-exception path — supervisor does not act on tasks that have a postrun.
+- `worker_ready`: start the heartbeat thread.
+- `worker_shutting_down`: stop the heartbeat thread, delete `lex:wrk:<hostname>`. (Do **not** delete in-flight `lex:task:*` keys on graceful shutdown — the supervisor will pick them up and requeue, because the task didn't postrun.)
+
+### 5.3 Supervisor (sweeper)
+
+Stateless. Can be invoked from:
+
+- (Preferred for v1) A periodic Celery beat task `lex.celery_recovery.tasks.sweep_dead_workers`, scheduled every `LEX_TASK_SUPERVISOR_SCAN_INTERVAL` seconds (default 10).
+- (Optional fallback) A `lex celery supervisor` CLI subcommand for environments without beat.
+
+Algorithm per scan:
+
+```
+for key in SCAN MATCH "lex:task:*" (filter out :lock):
+    data = HGETALL key
+    last_hb = ISO-parse(data["last_hb_iso"])
+    if now - last_hb < stale_threshold:
+        continue  # still alive
+    task_id = key.split(":")[-1]
+    lock_key = f"lex:task:{task_id}:lock"
+    if not SET lock_key "<sup_id>" NX EX 30:
+        continue  # another supervisor instance is handling it
+
+    attempt = int(data["attempt"])
+    max_retries = int(data["max_retries"])
+    if attempt + 1 > max_retries:
+        write_failure_to_backend(task_id, MaxRequeueExceeded(...))
+        cleanup_redis_for_task(task_id)
+    else:
+        republish_task(task_id, data, attempt + 1)
+        # Do NOT delete lex:task:<id> — task_prerun on next worker will overwrite
+
+    DEL lock_key
+```
+
+Key implementation notes:
+
+- `republish_task` calls `app.send_task(name, args, kwargs, task_id=task_id, queue=queue, headers={"lex_attempt": attempt+1})`. The new header lets `task_prerun` read the carried attempt. Belt-and-braces: also write `attempt=attempt+1` into the Redis hash before sending, so even without headers we recover the right value on next `task_prerun`.
+- Before re-publishing, attempt to clean Celery's `unacked` and `unacked_index` entries for the old delivery. Implementation: `HDEL unacked <delivery_tag>` and `ZREM unacked_index <delivery_tag>`. The delivery_tag is stored when the worker first received the task; we save it in `lex:task:<id>` during `task_prerun` (Celery's `task.request.delivery_info` carries it).
+- `write_failure_to_backend` uses `app.backend.mark_as_failure(task_id, exc, traceback=tb_str)`. We define a dedicated exception class `WorkerLost(Exception)` (or reuse Celery's `celery.exceptions.WorkerLostError` — see open question O-3).
+- All Redis ops are wrapped in a small client class with retry on connection error. If Redis is fully down, the supervisor skips the sweep and logs; recovery resumes when Redis comes back.
+
+### 5.4 Result-backend failure injection
+
+The parent thread is sitting in:
+
+```python
+# lex/lex_app/celery_tasks.py:415-432 (WaitForTasks.wait_for_completion)
+for result in self.dispatched_results:
+    with allow_join_result():
+        result.get()    # ← blocks on Postgres row
+```
+
+`result.get(propagate=True)` (the default) re-raises whatever exception was stored in the result backend. So `app.backend.mark_as_failure(task_id, WorkerLost(...), traceback="...")` is enough to wake the parent and propagate.
+
+We must verify with a unit test that `result.get()` does raise the exception class we pick (Postgres backend pickles it).
+
+### 5.5 Settings additions
+
+In `lex/lex_app/settings.py`:
+
+```python
+# Worker-recovery knobs
+LEX_TASK_HEARTBEAT_INTERVAL = int(os.getenv("LEX_TASK_HEARTBEAT_INTERVAL", "5"))      # seconds
+LEX_TASK_HB_TTL_MULTIPLIER  = int(os.getenv("LEX_TASK_HB_TTL_MULTIPLIER", "3"))       # ttl = interval * mult
+LEX_TASK_SUPERVISOR_SCAN_INTERVAL = int(os.getenv("LEX_TASK_SUPERVISOR_SCAN_INTERVAL", "10"))
+LEX_TASK_MAX_RETRIES = int(os.getenv("LEX_TASK_MAX_RETRIES", "4"))                    # requeues, not total runs
+LEX_TASK_RECOVERY_ENABLED = os.getenv("LEX_TASK_RECOVERY_ENABLED", "true").lower() == "true"
+```
+
+`LEX_TASK_RECOVERY_ENABLED=false` must short-circuit the heartbeat thread, signal handlers, and beat task. Used for local dev and CI.
+
+Per-task override: read `@lex_shared_task(max_retries=N)` if present; falls back to `LEX_TASK_MAX_RETRIES`. We will extend `lex_shared_task` to accept `max_retries`.
+
+---
+
+## 6. Module layout
+
+Create a new module `lex/lex_app/celery_recovery/`:
+
+```
+lex/lex_app/celery_recovery/
+    __init__.py              — public API surface, env-gated startup
+    redis_keys.py            — key formatters (single source of truth for the namespace)
+    heartbeat.py             — HeartbeatThread + signal handlers (task_prerun, postrun, worker_ready)
+    supervisor.py            — sweep_once(), republish_task(), write_failure_to_backend()
+    tasks.py                 — @shared_task sweep_dead_workers (the beat job)
+    exceptions.py            — WorkerLost, MaxRequeueExceeded
+```
+
+`__init__.py` reads `LEX_TASK_RECOVERY_ENABLED` and only connects signal handlers if true.
+
+Beat schedule registration (likely in `lex/lex_app/settings.py` near `CELERY_BEAT_SCHEDULER`):
+
+```python
+if LEX_TASK_RECOVERY_ENABLED:
+    CELERY_BEAT_SCHEDULE = {
+        **CELERY_BEAT_SCHEDULE,  # if any
+        "lex-celery-recovery-sweep": {
+            "task": "lex.celery_recovery.tasks.sweep_dead_workers",
+            "schedule": LEX_TASK_SUPERVISOR_SCAN_INTERVAL,
+        },
+    }
+```
+
+---
+
+## 7. Sequence diagrams
+
+### 7.1 Happy path (no death)
+
+```
+Parent          calc_and_save.delay        Redis            Worker          Postgres
+ │  WaitForTasks                                                 │
+ │ ────────────.delay()────────────►       │                     │
+ │                                  LPUSH queue ────────────────►│
+ │                                                               │ task_prerun
+ │                                                               │   HSET lex:task:<id>
+ │  r.get() (block)                                              │
+ │                                                               │ <run body>
+ │                                                               │ on_success
+ │                                                               │   UPDATE celery_taskmeta SUCCESS ─►
+ │  r.get() returns                                                                                  │
+ │                                                               │ task_postrun
+ │                                                               │   DEL lex:task:<id>
+```
+
+### 7.2 Worker dies, requeue succeeds on attempt 2
+
+```
+Parent          Worker A          Redis            Supervisor       Worker B          Postgres
+ │ .delay()                                                                              │
+ │ ──────────► LPOP queue                                                                │
+ │             task_prerun: HSET lex:task:<id> attempt=0, dt=<dt>                        │
+ │             HB thread: HSET last_hb_iso every 5s
+ │             [process killed — no postrun]                                             │
+ │                                                                                       │
+ │             (HB stops; last_hb_iso ages)                                              │
+ │                                                                                       │
+ │                                                  scan: last_hb 18s ago → stale        │
+ │                                                  SET lex:task:<id>:lock NX EX 30      │
+ │                                                  attempt+1=1 ≤ max(4)                 │
+ │                                                  HDEL unacked <dt>; ZREM unacked_idx  │
+ │                                                  app.send_task(name, args, task_id=<id>, headers={"lex_attempt": 1})
+ │                                                  HSET lex:task:<id> attempt=1         │
+ │                                                  DEL lex:task:<id>:lock               │
+ │                                                                                       │
+ │                                                                  LPOP queue           │
+ │                                                                  task_prerun (attempt=1)
+ │                                                                  <run body>            │
+ │                                                                  on_success ──────────►│ SUCCESS row
+ │ r.get() returns                                                                       │
+```
+
+### 7.3 Worker dies max+1 times → failure injected
+
+Same as above for the first 4 retries. On the 5th detection (attempt+1=5 > max 4):
+
+```
+                                                  scan: stale
+                                                  attempt+1=5 > max 4
+                                                  app.backend.mark_as_failure(<id>, WorkerLost("max requeue exceeded"))
+                                                  cleanup_redis_for_task(<id>)
+ │ r.get() raises WorkerLost                                                              │
+ │ WaitForTasks.wait_for_completion propagates                                            │
+ │ CalculationModel.execute_calculation captures → is_calculated=ERROR                    │
+```
+
+---
+
+## 8. Configuration knobs (default values)
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `LEX_TASK_RECOVERY_ENABLED` | `true` | Master switch. `false` disables heartbeats, signal handlers, beat task. |
+| `LEX_TASK_HEARTBEAT_INTERVAL` | `5` | Seconds between heartbeats inside the worker. |
+| `LEX_TASK_HB_TTL_MULTIPLIER` | `3` | Heartbeat TTL = interval × mult (15s default). |
+| `LEX_TASK_SUPERVISOR_SCAN_INTERVAL` | `10` | Seconds between supervisor sweeps. Must be ≥ heartbeat interval to avoid false positives. |
+| `LEX_TASK_MAX_RETRIES` | `4` | Maximum requeues per task. 5th detection = inject failure. |
+| `@lex_shared_task(max_retries=N)` | (uses env) | Per-task override. |
+
+Recommended infra values for first rollout: keep defaults. Tune `LEX_TASK_MAX_RETRIES` per environment.
+
+---
+
+## 9. Implementation phases
+
+Work the phases in order. After each phase, **append to Section 15 (Progress log)** with what you did, what tests pass, and what's still TODO. Open a PR per phase to keep blast radius small.
+
+### Phase 1 — Module scaffolding + settings + feature flag (no behavior change)
+
+Goal: get the module in place behind `LEX_TASK_RECOVERY_ENABLED=false`. Nothing runs yet.
+
+- Add `lex/lex_app/celery_recovery/__init__.py` exposing `enable()` (currently a no-op).
+- Add `redis_keys.py` with the key formatters (`worker_key(host)`, `task_key(task_id)`, `task_lock_key(task_id)`).
+- Add `exceptions.py` with `WorkerLost(Exception)` and `MaxRequeueExceeded(WorkerLost)`.
+- Add the five new env vars to `lex/lex_app/settings.py`.
+- Unit tests: import the module, assert flag default, assert `enable()` is idempotent.
+
+### Phase 2 — Heartbeat thread + signal handlers (worker-side bookkeeping, no recovery)
+
+Goal: workers write heartbeats; tasks register/deregister in Redis. Supervisor does not exist yet. Parent behavior unchanged.
+
+- Implement `HeartbeatThread` (daemon thread, sleeps `LEX_TASK_HEARTBEAT_INTERVAL`, writes `lex:wrk:<host>` and refreshes all `lex:task:<id>:last_hb_iso` for tasks in the in-flight set).
+- Implement `task_prerun` / `task_postrun` / `worker_ready` / `worker_shutting_down` handlers.
+- `task_prerun` writes the full task envelope to `lex:task:<id>` (`task_name, queue, args_b64=pickle.dumps(args), kwargs_b64=pickle.dumps(kwargs), attempt, max_retries, delivery_tag, parent_task_id, last_hb_iso`).
+- `task_postrun` deletes `lex:task:<id>`.
+- Connect handlers from `celery_recovery/__init__.py:enable()`, called from `lex/lex_app/celery.py` after `app.autodiscover_tasks(...)` when `LEX_TASK_RECOVERY_ENABLED`.
+- Tests:
+  - Unit: heartbeat thread writes expected keys (mock Redis with `fakeredis`).
+  - Unit: signal handlers register/deregister correctly.
+  - Integration (skipped unless `LEX_RUN_REDIS_CELERY_TESTS=true`): run a real worker for a real task, assert `lex:wrk:<host>` exists and `lex:task:<id>` appears+disappears.
+
+### Phase 3 — Supervisor sweep + bounded requeue (the real recovery path)
+
+Goal: stale-heartbeat detection + requeue with attempt counter. No failure injection yet.
+
+- Implement `supervisor.sweep_once()` per the algorithm in Section 5.3.
+- Implement `republish_task(task_id, data, new_attempt)` using `app.send_task(name, args=pickle.loads(...), kwargs=..., task_id=task_id, queue=..., headers={"lex_attempt": new_attempt})`. Update `lex:task:<id>` with the new attempt counter before sending so a fresh `task_prerun` reads the right value even if headers are lost.
+- Implement `unacked` cleanup. Determine the actual Redis key names used by the Celery Redis transport (likely `unacked` + `unacked_index`, possibly prefixed by `global_keyprefix`). Confirm by inspecting `redis-cli KEYS '<prefix>:*'` on a running instance, document the exact keys, and only then write the deletions.
+- Implement the supervisor lock (`SET lex:task:<id>:lock NX EX 30`) to allow multiple supervisor replicas safely.
+- Register the periodic beat task `lex.celery_recovery.tasks.sweep_dead_workers` that calls `sweep_once()`.
+- Tests:
+  - Unit: stale heartbeat → requeue called, attempt counter bumped.
+  - Unit: fresh heartbeat → not requeued.
+  - Unit: lock collision → second supervisor skips.
+  - Integration: start worker, force-kill it mid-task with `os.kill(pid, SIGKILL)` (gated test), assert task eventually completes when a new worker is started.
+
+### Phase 4 — Failure injection on max retries exceeded
+
+Goal: bounded recovery. After max retries, the parent's `result.get()` raises.
+
+- Implement `write_failure_to_backend(task_id, exc)` using `app.backend.mark_as_failure`.
+- In `sweep_once`, if `attempt + 1 > max_retries`, call it instead of `republish_task`, then clean up `lex:task:<id>`.
+- Tests:
+  - Unit: with `max_retries=1`, two consecutive stale detections → first requeues, second injects failure.
+  - Unit: after `mark_as_failure`, `AsyncResult(task_id).get()` raises the expected exception class.
+  - Integration (gated): kill worker repeatedly, assert parent calculation transitions to `ERROR` after the configured budget.
+
+### Phase 5 — `@lex_shared_task(max_retries=N)` per-task override
+
+Goal: let calculation authors opt into a tighter or looser retry budget.
+
+- Extend `lex_shared_task` in `lex/lex_app/celery_tasks.py:589-638` to accept `max_retries=None`.
+- When `task_prerun` registers the task, prefer `task.max_retries_override` (a new attribute set by the decorator) over the env default.
+- Tests: per-task override is honored in supervisor decisions.
+
+### Phase 6 — Operator visibility
+
+Goal: nothing changes for the user, but DevOps can answer "why was that task requeued".
+
+- Add a structured log line whenever the supervisor acts: `lex_recovery action=requeue|fail task_id=... attempt=... reason=stale_heartbeat last_hb_age_s=...`.
+- Optional: add a `lex celery recovery status` CLI subcommand that prints alive workers + in-flight tasks.
+
+### Phase 7 — Docs + CLAUDE.md update + remove this file's "not yet implemented" banner
+
+- Add a customer-facing doc: `docs/features/processing/worker recovery.md` (kept conversational per existing docs style — do **not** expose internal Redis key names there).
+- Add an operator doc: `docs/ci-cd/celery-worker-recovery.md` with the Redis key inventory, knobs, and troubleshooting.
+- Append a Section 16 to this file in `CLAUDE.md`-style if the user wants persistent context.
+
+---
+
+## 10. Testing plan
+
+### Unit tests (mandatory before each phase merges)
+
+Use `fakeredis` for Redis. New file: `lex/test_project/tests/celery_async/test_8r_worker_recovery.py`.
+
+- 8.50: `task_prerun` writes the expected hash with attempt=0 when no header.
+- 8.51: `task_prerun` reads `lex_attempt` header when present.
+- 8.52: `task_postrun` deletes the hash.
+- 8.53: heartbeat thread writes `lex:wrk:<host>` with the configured TTL.
+- 8.54: heartbeat thread refreshes `last_hb_iso` for in-flight tasks.
+- 8.55: `sweep_once` ignores fresh heartbeats.
+- 8.56: `sweep_once` requeues stale heartbeats, increments attempt.
+- 8.57: `sweep_once` injects failure on attempt+1 > max_retries.
+- 8.58: supervisor lock prevents double-action across two `sweep_once` calls.
+- 8.59: per-task `@lex_shared_task(max_retries=N)` overrides env default.
+- 8.60: `LEX_TASK_RECOVERY_ENABLED=false` short-circuits all signal handlers and the beat task.
+
+### Integration tests (gated, opt-in)
+
+Existing gate: `LEX_RUN_REDIS_CELERY_TESTS=true`. New file: `lex/test_project/tests/celery_async/test_8s_worker_recovery_smoke.py`.
+
+- Start a real worker, dispatch `calc_and_save`, kill the worker with `SIGKILL` mid-body, assert task completes via a new worker within `max_retries × scan_interval` seconds.
+- Same as above but kill the worker `max_retries+1` times → assert `AsyncResult.get()` raises `WorkerLost`.
+
+### Manual / chaos test in staging
+
+- Deploy with `LEX_TASK_MAX_RETRIES=2`. Kick a parent calculation with 5 children. `kubectl delete pod` one child's worker. Confirm the child finishes on a new pod and the parent succeeds.
+- Repeat but `kubectl delete pod` the same task 3 times in a row. Confirm the parent fails with `WorkerLost` in `error_message`.
+
+---
+
+## 11. Rollout plan
+
+1. Phase 1 + Phase 2 deployed with `LEX_TASK_RECOVERY_ENABLED=false`. No behavior change. Verify nothing breaks.
+2. Flip `LEX_TASK_RECOVERY_ENABLED=true` in **one** worker pool first. Watch logs for false positives (heartbeat misses on healthy workers due to GC pauses or load spikes). Tune `LEX_TASK_HEARTBEAT_INTERVAL` and `LEX_TASK_HB_TTL_MULTIPLIER` if seen.
+3. Roll out to all worker pools. Keep `LEX_TASK_MAX_RETRIES=4`.
+4. Add an alert: any `lex_recovery action=fail` log line pages DevOps. This catches the "real" worker death cases that exhausted retries.
+
+### Rollback
+
+`LEX_TASK_RECOVERY_ENABLED=false` cleanly disables everything. Existing `visibility_timeout=inf` behavior returns. Tasks may still hang on dead workers, but no new failure mode is introduced.
+
+---
+
+## 12. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| False positive: heartbeat misses due to GIL contention → healthy worker's task gets requeued in parallel with the original | Same `task_id` means only one of the two on_success calls wins (idempotent UPDATE). But duplicate side-effects in `calc_and_save` body (saves, hooks) could double-write. **Mitigation:** ensure `calc_and_save` body is idempotent (it largely is — it does `model.save()` on the same PK), and document this constraint. Add a sanity check in `task_prerun`: if the result backend already shows `SUCCESS` for this task_id, exit early. |
+| Redis is down → no heartbeats → supervisor thinks every task is dead | Supervisor must check `lex:wrk:<host>` is also stale. If the host key is also missing, only act if **both** worker key is gone *and* task heartbeat is stale (worker truly dead). If only the task heartbeat is stale but worker key is fresh, skip (worker alive but heartbeat thread stuck — log WARN, do not requeue). |
+| Supervisor itself dies | It's a periodic beat task; the next beat tick re-runs it. Multiple beat instances are not a problem because of the supervisor lock. |
+| Failure-injection race: worker completes a microsecond after supervisor injects FAILURE | Supervisor lock + check `app.backend.get_task_meta(task_id)` shows `STARTED`/`SENT` (not yet terminal) before injecting. If terminal, skip. |
+| Pickled args include large or non-picklable values | Pickle is already the wire format in this project. Same constraint as today. |
+| `unacked` cleanup uses internal Celery Redis transport keys that could change between Celery versions | Pin Celery minor version. Add a regression test on a real Redis that re-publish + cleanup leaves zero leftover entries. |
+
+---
+
+## 13. Open questions (answer before Phase 3)
+
+- **O-1** Exact Redis key names of Celery's `unacked` store under our `global_keyprefix=<INSTANCE_RESOURCE_IDENTIFIER>:`. Confirm on a running staging Redis.
+- **O-2** Does `app.backend.mark_as_failure` on the Postgres backend pickle the exception in a way that `AsyncResult.get(propagate=True)` re-raises the exact class (not just the message)? Verify with a smoke test in Phase 4.
+- **O-3** Use `celery.exceptions.WorkerLostError` or our own `WorkerLost`? Celery's class is well-known but its message format is opinionated. Decide based on what the parent calculation's `error_message` field will look like.
+- **O-4** Should heartbeat refresh be paused during long synchronous DB queries (where the GIL is held but the task is healthy)? Probably yes if the heartbeat thread misses too many wake-ups. Measure first.
+- **O-5** Per-`CalculationModel` opt-out — should a CalculationModel be able to mark itself as "do not retry on worker death" (e.g. one-time side effects)? Out of scope for v1; revisit after rollout.
+
+---
+
+## 14. Prompt for the next agent
+
+Paste this as your starting message if you (or another agent) pick this work up:
+
+> You are continuing implementation of the Celery worker-death recovery feature for `lex-app`. Read `docs/celery-worker-recovery/plan.md` end-to-end before doing anything else.
+>
+> Constraints you must honor:
+> 1. Do not change `visibility_timeout=float("inf")` in `lex/lex_app/settings.py`. The supervisor must work on top of it, not replace it.
+> 2. Re-publish must reuse the original `task_id` so `AsyncResult.get()` in the parent's `WaitForTasks.wait_for_completion()` keeps working without change.
+> 3. The feature must short-circuit cleanly when `LEX_TASK_RECOVERY_ENABLED=false`. No connections to Redis, no signal handlers connected, no beat task scheduled.
+> 4. Idempotency of `calc_and_save` is assumed but verify the task body in `lex/lex_app/celery_tasks.py:742-802` does not have side effects that double-running would corrupt before you ship Phase 3.
+> 5. All new code goes under `lex/lex_app/celery_recovery/`. Do not modify `lex/lex_app/celery_tasks.py` except for the per-task `max_retries` override in Phase 5.
+> 6. Add tests in `lex/test_project/tests/celery_async/test_8r_worker_recovery.py` (unit) and `test_8s_worker_recovery_smoke.py` (integration, gated by `LEX_RUN_REDIS_CELERY_TESTS=true`).
+> 7. After finishing each phase: append to Section 15 of `docs/celery-worker-recovery/plan.md` (what you implemented, file paths, test status, anything you punted). Do not move on to the next phase until tests are green and the log is updated.
+>
+> Order of work: Phase 1 → 2 → 3 → 4 → 5 → 6 → 7. Open a PR per phase.
+>
+> Before starting Phase 3, answer the open questions in Section 13. Document the answers in Section 15.
+>
+> If you find a flaw in the design, stop, write a `Section 17 — Design changes` block in this doc, and ask for confirmation before deviating from the plan.
+
+---
+
+## 15. Progress log
+
+Append entries here after each work session. Newest at top.
+
+### 2026-05-20 — Cluster 8t rewritten as customer-shaped end-to-end (Copilot)
+
+What I did:
+- Rewrote `lex/test_project/tests/celery_async/test_8t_worker_recovery_production.py` from scratch. The first 8t pass (10 scenarios asserting on supervisor summary dicts and forged-envelope state) violated the test-plan §9 Golden Rule — it was implementation-coupled, asserting on internal bookkeeping rather than what the customer sees. The replacement follows the rules cluster 8k established for the rest of cluster 8: real `CeleryCalc` models persisted via `_prime_calc`, real `@lex_shared_task`-decorated `calculate()` body, real survivor worker booted via `start_worker`, real result-backend round trip, and assertions on `CeleryCalc.objects.get(pk=...).is_calculated`.
+- Every test forges the dead-worker envelope using the **real** task name (`getattr(CeleryCalc.calculate, "task").name`) and the **real** calc instance as args (`args=(calc,)`), so the supervisor's `send_task` round-trip publishes a message that the survivor worker executes through the exact `CallbackTask.on_success` / `on_failure` path a customer would hit in production. The forge is the only thing that stands in for SIGKILL — and it's observationally identical to a real worker death from the supervisor's point of view (envelope present, `last_hb_iso` stale, no `lex:wrk:<host>`).
+- The supervisor is invoked via `sweep_dead_workers.apply().get()` — the actual Celery beat-task wrapper, not a direct call to `sweep_once`. This is the production invocation path.
+
+Scenarios (numbered after cluster 8s at 8.85):
+
+| #    | Customer story proven                                                                                                                          | Customer-visible assertion                                                                                |
+|------|------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| 8.85 | Dead worker mid-calc → supervisor requeues → survivor finishes the job                                                                          | `fresh.is_calculated == SUCCESS`, `calculation_error_message == ""`, audit + status seams fired           |
+| 8.86 | Worker died on the last allowed attempt → parent's `.get()` raises `WorkerLost` carrying task_id + attempt + diagnostic message                  | `assertRaises(MaxRequeueExceeded)`, `isinstance(WorkerLost)`, message mentions "retries" + "worker"        |
+| 8.87 | Heartbeat thread was slow but worker is healthy → supervisor must NOT double-execute the calc                                                   | `fresh.is_calculated` stays `IN_PROGRESS` (no spurious SUCCESS write from a wrongly-requeued body)         |
+| 8.88 | Worker finished the calc ~1 ms before the supervisor decided to inject failure → recovery does NOT overwrite the SUCCESS                         | `result.state == "SUCCESS"`, `.get()` returns the original calc instance (round-tripped through pickle)    |
+| 8.89 | Node went down with N worker pods on it → ALL the in-flight calcs recover, not just the first the scan cursor hit                               | every `fresh.is_calculated == SUCCESS` for the batch; no row left in `IN_PROGRESS`                         |
+| 8.90 | Recovered calc body raises a normal application error → row reaches `ERROR` via the framework's normal failure path (recovery + failure compose) | `fresh.is_calculated == ERROR`, status seam fired                                                          |
+
+Why this matters:
+- Cluster 8r proves the recovery package's *logic*. Cluster 8s proves the two *contracts* the unit suite can't (same task_id, exception propagation). Cluster 8t proves the *customer-visible outcomes* — the rows on the customer's dashboard, the exceptions their parent calculations catch, the audit entries that get filed. If a recovery internal regresses, every 8t scenario fails at the `is_calculated` assertion, which is the only signal that actually matters to the customer.
+- 8.86 also documents an intentional design-boundary contract: recovery's failure injection writes to the **result backend**, not the `CalculationModel` row. The child row stays `IN_PROGRESS`; the parent calc is expected to catch `WorkerLost` and set its own `is_calculated`. The test asserts this explicitly so a future "recovery flips the row directly" change forces an update to the customer docs.
+
+Files touched:
+- `lex/test_project/tests/celery_async/test_8t_worker_recovery_production.py` — rewritten (~530 lines, 6 customer-shaped scenarios + helpers).
+- `docs/celery-worker-recovery/plan.md` — status banner updated, this entry written.
+
+Tests:
+- Live Redis (`redis://127.0.0.1:6379/15`): **36 passed in 11.9 s** (28 cluster 8r unit + 2 cluster 8s smoke + 6 cluster 8t customer-shape). All assertions are on `CeleryCalc.is_calculated`, `calculation_error_message`, `AsyncResult` state, or the patched audit / status seams — no recovery internals are asserted on.
+- Gate off: **36 tests, 28 passed, 8 skipped** — gating + skip discipline are correct.
+
+Decisions made (and why):
+- **Rewrote, not patched.** The first 8t pass had wrong assertion targets across the board; surgery would have left half the file implementation-coupled. A clean rewrite documenting the customer-shape pattern from the top of the file is a better template for the next agent who adds recovery scenarios.
+- **Forge envelopes, not SIGKILL workers.** The same rationale as cluster 8s: `start_worker` runs in-process. Forging the post-mortem envelope state is observationally identical to a real worker death from the supervisor's point of view, and it's deterministic. The customer-shape rule is satisfied at the level above the supervisor — task name, args, survivor worker, callback path, DB row — which is everything that ever ships in production code.
+- **Invoke via `sweep_dead_workers.apply().get()`.** This is the actual beat-task wrapper, not `sweep_once`. Hits the same code path the periodic scheduler hits in production, including the summary-logging branch.
+- **Mock only the same seams cluster 8k already mocks** — `ensure_terminal_calculation_audit` and `update_calculation_status`. These are fan-out side effects (WebSocket / Channels / external audit) that are external boundaries per the test-plan §9 Rule 3. The DB row update done by `CallbackTask.on_success` / `on_failure` happens *before* those seams, so the rule-2 "real DB models" assertion still bites.
+- **Inherit from `E2ETestCase` when gated on, `SimpleTestCase` otherwise.** Same pattern as cluster 8k's `_RedisCalculationBase`. Keeps the file collectable on machines without Redis without paying the DB-setup cost on every scenario when the gate is off.
+
+Open items / punts:
+- Same as the previous 8t entry: the `unacked` / `unacked_index` cleanup is still deferred (bounded leak per dead worker with `visibility_timeout=float("inf")`).
+- 8.86 leaves the child row at `IN_PROGRESS` deliberately. If the next iteration of recovery starts updating `CalculationModel` rows directly when injecting failure, that scenario's third assertion needs flipping and the customer-facing doc at `docs/features/processing/worker recovery.md` needs an update.
+
+Next phase entry criteria:
+- [x] cluster 8t rewritten in customer-shape per test-plan §9
+- [x] 6 scenarios landed, all green against live Redis
+- [x] combined unit + smoke + customer-shape suite green (36/36)
+- [x] plan banner + log updated
+- [ ] PR opened / merged (deferred)
+
+---
+
+### 2026-05-20 — Production-grade integration suite (cluster 8t) (Copilot) — SUPERSEDED
+
+> **Superseded:** This pass violated the test-plan §9 Golden Rule (implementation-coupled assertions on supervisor summary dicts and forged Redis state, not on customer-visible `CeleryCalc.is_calculated`). Rewritten on the same day — see the entry above. The original entry is preserved unchanged below as a record of the wrong-shape approach so future agents recognise the anti-pattern.
+
+
+
+What I did:
+- Added `lex/test_project/tests/celery_async/test_8t_worker_recovery_production.py` — a 10-scenario, real-broker integration suite that fills the gap between the cluster 8r unit tests (which run on FakeRedis with a mocked Celery app) and the minimum smoke harness in cluster 8s (which only covered the two contracts the unit suite literally couldn't prove). 8t exercises the production properties from Sections 5, 7 and 12 of the plan against a live Redis broker + result backend.
+- Reused the existing helpers from cluster 8k (`_temporary_celery_config`, `_make_redis_result_backend`, `_redis_celery_overrides`, `_require_redis_broker`, `_redis_tests_requested`, `_temporary_env`) and cluster 8s (`_bound_recovery_redis`, `_write_stale_envelope`) by direct import, plus added a thin `_recovery_smoke_celery` wrapper that bundles the pickle-everywhere config every scenario needs.
+- Gated identically to 8k/8s — `LEX_RUN_REDIS_CELERY_TESTS=true` plus reachable Redis at `LEX_CELERY_REDIS_TEST_URL`. With the gate off every scenario raises `SkipTest`, so the default suite stays green on machines with no Redis.
+
+Scenarios (all numbered after 8s at 8.75):
+
+| #    | Property proved                                                                                              |
+|------|--------------------------------------------------------------------------------------------------------------|
+| 8.75 | Progressive requeue across sweep cycles: four sweeps drive `attempt` 0→1→2→3→failure, parent's `.get()` raises `MaxRequeueExceeded` with the right attributes |
+| 8.76 | Worker-alive guard blocks the false-positive requeue (this is the bug we fixed in the prefork-hostname patch) |
+| 8.77 | Supervisor lock (`SET NX EX`) under real thread concurrency — exactly one of two simultaneous sweeps requeues |
+| 8.78 | Pickled complex args (nested dict/list/tuple, bytes, datetime with tz, unicode) survive the envelope round-trip and a real worker executes the requeue with the original payload |
+| 8.79 | Per-task `lex_max_retries` from envelope beats `LEX_TASK_MAX_RETRIES=99` env (Phase-5 decorator surface flows end-to-end) |
+| 8.80 | Backend idempotency — pre-existing SUCCESS is NOT overwritten by `mark_as_failure`; supervisor reports `deferred_at_cap` and cleans the envelope |
+| 8.81 | The Celery beat task `lex.lex_app.celery_recovery.tasks.sweep_dead_workers` invokes `sweep_once` end-to-end and returns the same summary shape |
+| 8.82 | Multiple stale envelopes (5) are all handled in a single sweep — supervisor doesn't bail after the first match |
+| 8.83 | Empty/missing envelope (race: deleted between scan and hgetall) is a no-op, no crash, no spurious counter increments |
+| 8.84 | True end-to-end: forge dead-worker envelope → sweep → boot real worker → live worker picks up the requeue under the SAME task_id → `task_postrun` cleans the envelope → parent's `AsyncResult.get()` returns the body's return value |
+
+Why this matters:
+- Cluster 8r proves the supervisor's *logic* with FakeRedis; cluster 8s proves the *contracts* with two minimum end-to-end scenarios. Neither proves the *production properties* — false-positive guard under real worker keys, lock under real concurrency, pickle round-trip fidelity, backend idempotency, multi-envelope handling, beat-task wiring, full e2e with real signal handlers. 8t closes that gap.
+- Answers the open item carried in 8s's "Open items / punts": there is now a green live-broker run on the books (40/40 tests in 3.6 s including the unit suite).
+- Verifies open question **O-2** from Section 13 (`AsyncResult.get(propagate=True)` re-raises the exact `MaxRequeueExceeded` subclass with attributes preserved) against a real Redis result backend, not just a unit-tested contract.
+
+Files touched:
+- `lex/test_project/tests/celery_async/test_8t_worker_recovery_production.py` — new (~560 lines, 10 scenarios + shared helpers).
+- `docs/celery-worker-recovery/plan.md` — status banner updated, this entry written.
+
+Tests:
+- Local laptop with `redis://127.0.0.1:6379/15`: **40 passed in 3.582 s** (28 cluster 8r unit + 2 cluster 8s smoke + 10 cluster 8t production). No failures, no errors, no skipped tests under the live-Redis gate.
+- Same combined suite with the gate off: **40 tests, 28 passed, 12 skipped** — proves the gating is correct.
+
+Decisions made (and why):
+- **Numbered as cluster 8t rather than appended to 8s.** 8s is the minimal smoke harness for the two contracts the unit suite cannot prove; 8t is a different intent — production-grade properties. Keeping them separate means the smoke harness stays cheap and obvious, while 8t can grow as we identify more production properties without diluting 8s.
+- **Shared the cluster 8k + 8s helpers by direct import** rather than duplicating them. The `_temporary_celery_config` wrinkle around `app._backend` injection is too subtle to copy-paste safely — one source of truth.
+- **Pinned `pool="solo"` for `start_worker` calls.** Avoids the prefork-fork boundary issues for the two scenarios that boot a real worker (8.78, 8.84). Production runs prefork; the production correctness of prefork is already proven by the prefork-hostname fix landed earlier this session. The smoke worker is just a consumer here, not the system under test.
+- **Each scenario uses a uuid-suffixed queue + task_id.** Reruns and parallel execution are safe with no manual Redis flushing required — the `_bound_recovery_redis` cleanup on exit takes care of the `lex:*` namespace, and Celery queues are uniquely named per test.
+- **Did NOT shell out to a separate process to SIGKILL a worker.** `start_worker` runs inside the test runner; killing it kills the test. Forging the dead-worker envelope state in Redis (no `lex:wrk:<host>` key, aged `last_hb_iso`) is observationally identical to a real worker death from the supervisor's point of view, and it's deterministic.
+
+Open items / punts:
+- The `unacked` / `unacked_index` cleanup is still deferred (same as previous entries). With `visibility_timeout=float("inf")` this is a bounded leak per dead worker. 8t exercises every supervisor code path that exists today; once cleanup lands, add scenarios 8.85+ here to prove it.
+- The optional `lex celery recovery status` CLI subcommand is still not shipped; operators have `redis-cli` and the structured log lines.
+
+Next phase entry criteria:
+- [x] 10 production scenarios landed, all green against live Redis
+- [x] combined unit + smoke + production suite green (40/40)
+- [x] plan banner updated, log entry written
+- [x] first live-broker run on the books (the open item from the cluster 8s entry)
+- [ ] PR opened / merged (deferred)
+
+---
+
+### 2026-05-20 — Local chaos-test affordance + corrected recipe (Copilot)
+
+What I did:
+- Added an env-gated `recovery_smoke_slow` task to `lex/lex_app/celery_recovery/tasks.py`. It registers **only** when `LEX_RECOVERY_SMOKE_TASK=true` is set in the environment, so it cannot leak into a customer worker fleet by accident. The body sleeps a configurable number of seconds and emits a WARNING log line every ~5 s so an operator running the chaos recipe can clearly see the task is *executing* (not still queued) before they SIGKILL the worker — the earlier sharp edge in the manual recipe.
+- Updated `docs/ci-cd/celery-worker-recovery.md` with a new "Manual local chaos test" section. It calls out the **two-worker rule** explicitly (beat schedules sweeps, but a worker has to consume them — if you SIGKILL the only worker the sweep task sits in the queue forever and recovery never fires), gives the four-terminal recipe (beat / victim / survivor / driver), and documents the expected log lines in order with the timing windows derived from the short-knob defaults (`interval=2`, `multiplier=2`, `scan=3`, `max_retries=2` → full requeue→fail cycle in ~12 s).
+
+Why this matters:
+- The first local-chaos run before this change showed that a single-worker setup looks broken — beat's `last_run_at=None`, no Redis keys, no log lines — even though the framework code is correct. The recipe needed to capture that and the project needed a known-stable slow task to fire.
+- A built-in chaos task means the recipe is reproducible across projects without each one having to wire its own `time.sleep` task.
+
+Files touched:
+- `lex/lex_app/celery_recovery/tasks.py` — added the env-gated `recovery_smoke_slow` task next to `sweep_dead_workers`. Default behavior unchanged (the gate is off).
+- `docs/ci-cd/celery-worker-recovery.md` — new "Manual local chaos test" section between "Disabling recovery for a single run" and "Related docs".
+- `docs/celery-worker-recovery/plan.md` — this entry.
+
+Tests:
+- Cluster 8r + 8s: **28 passed, 2 skipped** (no regression — the new task is import-time gated and the gate is off in tests).
+
+Decisions made (and why):
+- **Env-gated registration, not a separate module.** Keeping it in `tasks.py` next to `sweep_dead_workers` means an operator running the recipe doesn't need to know an extra import path; setting `LEX_RECOVERY_SMOKE_TASK=true` and starting `lex celery worker` is enough. A separate module would give a cleaner boundary but would require the recipe to mention "and also import this module before starting the worker", which is exactly the kind of step humans skip.
+- **Sleep + log every 5 s, not just `time.sleep(seconds)`.** The kill must land while the task is *running*, not while it's still in the broker queue waiting. The periodic log line is the operator's signal that the task body has started.
+- **Two-worker rule documented as the first thing in the recipe.** The previous local run failed exactly because of this misconception, and any operator following the docs verbatim would hit the same wall. Putting it before the commands shortens the next person's diagnosis time to zero.
+
+Open items / punts:
+- Same as the prior 8s entry: the live-broker smoke (cluster 8s) still needs one green run against a real Redis; the `unacked` / `unacked_index` cleanup is still deferred behind staging access.
+
+Next phase entry criteria:
+- [x] new task registered behind env flag, off by default
+- [x] recipe corrected and operator doc updated
+- [x] cluster 8r + 8s still green
+- [x] log entry written
+
+---
+
+### 2026-05-20 — Integration smoke harness (cluster 8s) (Copilot)
+
+What I did:
+- Added `lex/test_project/tests/celery_async/test_8s_worker_recovery_smoke.py` — gated, real-broker proof for the two end-to-end claims the unit suite can't prove on its own:
+  1. **8.73 — requeue happy path.** Forge a stale `lex:task:<id>` envelope (omitting the worker key so the staleness check fires), call `sweep_once()`, then boot a real `celery.contrib.testing.worker.start_worker` and assert `AsyncResult.get()` on the **original** task_id returns the original payload. Proves `app.send_task(name, args, kwargs, task_id=<same_id>, headers=...)` round-trips through a live Redis broker into a real worker without breaking the parent's join.
+  2. **8.74 — failure injection terminal path.** Same forge but with `attempt == max_retries`. Sweep calls `mark_as_failure` on the Redis result backend. Assert `AsyncResult.get(propagate=True)` raises `MaxRequeueExceeded` with the correct `task_id` and `attempt` attributes preserved. Answers open question O-2 from Section 13 ("does the backend pickle the exception in a way that `get(propagate=True)` re-raises the exact class") — yes, against a real Redis result backend.
+- Reused the cluster 8k bootstrap helpers (`_temporary_celery_config`, `_redis_celery_overrides`, `_make_redis_result_backend`, `_require_redis_broker`, `_redis_tests_requested`, `_temporary_env`) by direct import. Pickle serializer pinned for both task and result so `MaxRequeueExceeded` survives the round trip with its custom attributes intact.
+- Bound the recovery package's Redis client to the test broker via `set_client_factory`, and added a `_bound_recovery_redis` context manager that flushes any `lex:task:*` / `lex:wrk:*` keys on exit so reruns don't interfere with each other.
+
+Why we don't actually kill a worker:
+- `start_worker` runs the worker inside the test process. A `SIGKILL` would kill the test runner. Forging the post-mortem envelope state in Redis is observationally identical to a real worker death from the supervisor's point of view: the supervisor reads `lex:task:<id>` with a stale `last_hb_iso` and no `lex:wrk:<host>` key, which is exactly what a real `kubectl delete pod --grace-period=0` leaves behind.
+
+Files touched:
+- `lex/test_project/tests/celery_async/test_8s_worker_recovery_smoke.py` — new (~270 lines, 2 scenarios).
+- `docs/celery-worker-recovery/plan.md` — status banner updated, this entry written.
+
+Tests:
+- Combined run `test_8r_worker_recovery.py` + `test_8s_worker_recovery_smoke.py`: **28 passed, 2 skipped, 0.20 s** (unit suite still green; both smoke scenarios skipped because `LEX_RUN_REDIS_CELERY_TESTS` is unset on this machine).
+- When the gate is set and a Redis broker is reachable, the two scenarios will each take ~5–10 s (broker connect + worker boot + result join).
+
+Open items / punts:
+- **First live-broker run still owed.** This was deferred behind staging access — the harness exists, but no one has yet run it against a real Redis. Action for the next agent: `LEX_RUN_REDIS_CELERY_TESTS=true LEX_CELERY_REDIS_TEST_URL=redis://...:6379/15 python -m lex test lex.test_project.tests.celery_async.test_8s_worker_recovery_smoke --verbosity=2 --noinput` against the staging Redis (or a local `docker run --rm -p 6379:6379 redis:7`). Either log a green run here or open an issue with whatever falls over.
+- `unacked` / `unacked_index` cleanup is still deferred — Section 5.3 spec says wait until exact key names are confirmed on a running staging Redis. Same prerequisite as the live smoke run; do them in the same session.
+- Optional `lex celery recovery status` CLI subcommand still not shipped. Plan explicitly marks it optional; operators can use `redis-cli SCAN lex:wrk:*` + log filters as documented in `docs/ci-cd/celery-worker-recovery.md`.
+
+Decisions made (and why):
+- **Forge the envelope rather than kill a worker.** Forging exercises the exact code path (`sweep_once → send_task` / `mark_as_failure`) deterministically. Killing a worker would add a flaky timing-sensitive layer on top without proving anything more about the supervisor itself.
+- **Skip cleanly, not error, when the gate is off.** Same convention as cluster 8k. Keeps the default CI suite green on machines with no Redis, but `LEX_RUN_REDIS_CELERY_TESTS=true` + no reachable Redis still errors loudly (via `_require_redis_broker`), so we never silently "pass" a gated release check.
+- **Distinct uuid-suffixed queue per scenario.** Belt-and-braces against cross-test pollution if Redis db 15 isn't flushed between runs.
+- **Pickle serializer pinned.** `MaxRequeueExceeded` carries custom attributes (`task_id`, `attempt`, `worker_hostname`) — JSON would lose them. The production framework runs pickle everywhere already so this matches reality.
+
+Next phase entry criteria:
+- [x] harness landed and collects cleanly in skip mode
+- [x] cluster 8r unit suite still green
+- [x] log entry written
+- [ ] one green run against a real Redis broker (next agent / staging)
+- [ ] `unacked` / `unacked_index` cleanup wired up in supervisor (same prerequisite)
+
+---
+
+### 2026-05-20 — Phase 6 & 7 — Operator visibility + docs (Claude)
+
+Phase 6 — Operator visibility:
+
+- Added `_hb_age_seconds(last_hb_iso, now)` helper in `supervisor.py` so every action log can carry `last_hb_age_s=...` for diagnosibility.
+- Enriched the three actionable log lines (`action=requeue`, `action=skip reason=worker_alive_but_task_stale`, `action=mark_as_failure reason=max_retries_exceeded`) with `reason=` and `last_hb_age_s=` fields. The summary line (`lex_recovery sweep summary=...`) is unchanged — it still surfaces the per-sweep counts including the new `failed` key from Phase 4.
+- Did **not** ship the optional `lex celery recovery status` CLI subcommand; the Phase 6 spec marks it optional and DevOps can answer the same question by scanning the `lex_recovery` log lines and `redis-cli SCAN lex:wrk:*`.
+- Did **not** touch Celery's `unacked` / `unacked_index` keys yet — bounded leak per Section 5 of the plan; deferred until we verify the exact key names on a running staging Redis.
+- All 28 cluster 8r tests still pass after the log changes.
+
+Phase 7 — Docs:
+
+- Customer-facing doc: `docs/features/processing/worker recovery.md`. Kept the style conversational, no internal class names exposed, focused on what calculation authors need (default behavior, `lex_max_retries=N`, how the failure surfaces from `WaitForTasks`, kill switch).
+- Operator doc: `docs/ci-cd/celery-worker-recovery.md`. Knobs table, full Redis key inventory, structured log shape, troubleshooting recipes for "tasks never requeued", "supervisor double-acts", "`MaxRequeueExceeded` never raises". Cross-links to the plan and the feature doc.
+- Removed the "PLAN — not yet implemented" status banner. New banner: `IMPLEMENTED — Phases 1–7 landed 2026-05-20 (integration smoke against a real broker still pending)`. The TL;DR section now points at both new docs and notes the remaining open item.
+- Added the two new doc paths to the `related-files` frontmatter so the next agent can find them from the plan.
+
+Outstanding (not blocking the feature):
+
+- Real-broker integration smoke run (kill a worker mid-task with SIGKILL, assert parent's `MaxRequeueExceeded` propagates). Deferred — it's gated behind staging access.
+- `unacked` / `unacked_index` cleanup after confirming exact key names on a running Redis.
+- Optional `lex celery recovery status` CLI subcommand.
+
+Next phase entry criteria:
+- [x] Phases 6 + 7 implemented
+- [x] log entry written
+- [ ] integration smoke against real broker
+- [ ] PR opened / merged (deferred)
+
+---
+
+### 2026-05-20 — Phase 5 — Per-task `lex_max_retries` decorator surface (Claude)
+
+What I did:
+- Extended `lex_shared_task` in `lex/lex_app/celery_tasks.py` with a new keyword-only argument `lex_max_retries`. When provided, the decorator stamps the value onto the underlying Celery Task object (resolving the `PromiseProxy` via `_get_current_object()` so the attribute survives proxy resolution) as `task.lex_max_retries`. The heartbeat handler already reads this attribute in `task_prerun` (8.55) and falls back to the `LEX_TASK_MAX_RETRIES` env default when absent — so the cap is now wireable per-task without further changes.
+- Used a distinct attribute name (`lex_max_retries`, not Celery's built-in `max_retries`) on purpose. Celery's `max_retries` governs in-task `self.retry()` calls; ours governs worker-death requeues. They are orthogonal and users may want to set both. The docstring on the decorator now spells this out.
+- Bad inputs (non-int, negative) log a warning and the attribute is simply not set — the supervisor falls back to the env default. Task registration is never aborted on a bad value.
+
+Files touched:
+- `lex/lex_app/celery_tasks.py:589` — `lex_shared_task` now accepts `*, lex_max_retries=None, **task_opts`. Attribute write happens after `shared_task(**options)(wrapper)` and is wrapped in try/except so the worst case is a silent fall-back to env default, never a broken task registration.
+- `lex/test_project/tests/celery_async/test_8r_worker_recovery.py` — added `TestCluster08r_Decorator` with 3 tests (8.70 happy path, 8.71 omitted kwarg → attribute absent, 8.72 negative value → attribute absent + task still usable). Each test calls the decorator with a unique celery task name because `shared_task` shares a global registry per process.
+
+Tests (full cluster 8r run under Django, ArmiraCashflowDB venv):
+- 28 / 28 passing (9 scaffolding + 7 heartbeat + 3 decorator + 9 supervisor).
+
+Open items / punts:
+- Did not yet flip any in-tree `@lex_shared_task` call sites to pass `lex_max_retries=`. Default is fine for now; opportunistic tightening can happen as we identify long-running tasks that should fail faster.
+
+Decisions made (and why):
+- Keyword-only argument (`*, lex_max_retries`). Reason: avoids positional confusion with other `task_opts` and surfaces in IDE autocomplete with the explicit name. Also future-proofs the signature.
+- Resolved the `PromiseProxy` before setting the attribute. Reason: writing to a proxy and reading via `_get_current_object` later can silently miss when the proxy slot stores its own copy. Resolving up-front makes the attribute live on the same object the signal handler will see.
+- Did not validate against an upper bound. Reason: ops may legitimately want a high cap for very long-running tasks; the cap is gated by the supervisor's per-sweep work, not memory.
+
+Next phase entry criteria:
+- [x] all Phase 5 tests written and passing in smoke
+- [x] log entry written
+- [ ] PR opened / merged (deferred)
+
+---
+
+### 2026-05-20 — Phase 4 — Failure injection on max retries exceeded (Claude)
+
+What I did:
+- Replaced the Phase-3 `deferred_at_cap` log-only branch in `sweep_once` with a call to a new `_write_failure_to_backend(client, task_id, attempt, max_retries, hostname)` helper.
+- `_write_failure_to_backend` builds a `MaxRequeueExceeded(...)` carrying `worker_hostname`, `attempt`, `task_id`, then calls `current_app.backend.mark_as_failure(task_id, exc)`. It is idempotent: it consults `backend.get_task_meta(task_id)` first and skips the write if the state is already in `celery.states.READY_STATES`.
+- After a successful (or already-terminal) injection it deletes `lex:task:<id>` so subsequent sweeps don't see the task again. If `mark_as_failure` itself raises, the envelope is **kept** so the next sweep retries the injection — better a duplicate failure than a silently-stuck parent.
+- Added `"failed": 0` to the `sweep_once` summary dict and the counter is now incremented on every successful injection. The existing `deferred_at_cap` counter is still used, but now only for the "already terminal in backend" sub-case (someone else finished it first).
+- Failure propagation back to the parent's `WaitForTasks` call is automatic: `MaxRequeueExceeded` is a `WorkerLost` subclass which is a plain `Exception`, the Postgres result backend pickles it, and `AsyncResult.get(propagate=True)` re-raises it from `wait_for_completion`. Open question **O-2** from Section 13 is therefore answered "yes" by the celery contract; integration smoke test is deferred to a real broker run.
+
+Files touched:
+- `lex/lex_app/celery_recovery/supervisor.py` — added `MaxRequeueExceeded` import, added `_write_failure_to_backend(...)`, rewired the cap branch, added `"failed": 0` to summary.
+- `lex/test_project/tests/celery_async/test_8r_worker_recovery.py` — rewrote 8.64 for the new behavior; added 8.66 (already-terminal skip), 8.67 (meta lookup raises → still inject), 8.68 (mark_as_failure raises → envelope kept).
+
+Tests (all passed in standalone smoke run, 25/25 cluster 8r tests green):
+- 8.64 cap + dead worker → `mark_as_failure` called with `MaxRequeueExceeded(attempt=4, task_id="t-cap")`, envelope deleted, `summary["failed"] == 1`.
+- 8.66 cap but backend already SUCCESS → `mark_as_failure` not called, envelope still cleaned up, `summary["deferred_at_cap"] == 1` (we didn't inject anything new).
+- 8.67 `get_task_meta` raises → proceed with `mark_as_failure` anyway. `summary["failed"] == 1`.
+- 8.68 `mark_as_failure` raises → envelope preserved with `attempt=b"4"`, `summary["failed"] == 0` (we don't claim a win we didn't earn).
+
+Open items / punts:
+- Integration test against a real Postgres + redis broker to verify `AsyncResult.get(propagate=True)` actually re-raises `MaxRequeueExceeded` (not just `Exception("...")`). The pickling contract is reliable per Celery's source but worth one real-broker smoke run. Tracked for Phase 6 along with the `unacked` cleanup work.
+- Did not yet make `mark_as_failure` aware of `parent_task_id` — when the parent task dies independently we still inject for the child. Phase 6 risk-table item.
+
+Decisions made (and why):
+- Idempotency check uses `get_task_meta` then `state in READY_STATES`, not a separate Redis flag. Reason: the backend is already authoritative on terminal state; adding a second source of truth would just create a window where they disagree.
+- On `mark_as_failure` failure we leave the envelope and return `False`. The supervisor only increments `summary["failed"]` if we actually wrote the backend, which means the dashboards won't lie when the backend is having a bad minute.
+- Used `celery.states.READY_STATES` rather than hand-rolling a set of terminal status strings. If celery adds a new terminal state in the future our check stays correct.
+
+Next phase entry criteria:
+- [x] all Phase 4 tests written and passing in smoke
+- [x] log entry written
+- [ ] PR opened / merged (deferred)
+
+---
+
+### 2026-05-20 — Phase 3 — Supervisor sweep + bounded requeue (Claude)
+
+What I did:
+- Added `supervisor.py` with `sweep_once(now=None)`, the lock helpers (`_acquire_lock` / `_release_lock` using SET NX EX), the staleness check, and `_republish_task` that uses `current_app.send_task(name, args, kwargs, task_id=<same>, headers={"lex_attempt": N+1})`.
+- Added `tasks.py` with the beat shared task `lex.lex_app.celery_recovery.tasks.sweep_dead_workers`.
+- Registered the beat entry in `settings.py` (only when `LEX_TASK_RECOVERY_ENABLED`). django-celery-beat's DatabaseScheduler ingests `CELERY_BEAT_SCHEDULE` on startup so no manual provisioning is needed.
+- Persists `attempt = N+1` to the Redis hash *before* `send_task` so even if the header gets dropped somewhere in transport, the next `task_prerun` reads the right value.
+- Phase 3 does **not** inject failure on cap exceeded — `deferred_at_cap` is just logged. Phase 4 wires `mark_as_failure`.
+
+Files touched:
+- `lex/lex_app/celery_recovery/supervisor.py` — new (~190 lines).
+- `lex/lex_app/celery_recovery/tasks.py` — new.
+- `lex/lex_app/settings.py` — added the `CELERY_BEAT_SCHEDULE["lex-celery-recovery-sweep"]` entry, gated on `LEX_TASK_RECOVERY_ENABLED`.
+- `lex/test_project/tests/celery_async/test_8r_worker_recovery.py` — added `TestCluster08r_Supervisor` (6 tests: 8.60–8.65) and `nx=True` support to `FakeRedis.set`.
+
+Tests:
+- 8.60 fresh heartbeat → no action.
+- 8.61 stale heartbeat + dead worker → `send_task` called with original `task_id`, `lex_attempt=N+1` header, attempt counter bumped in hash.
+- 8.62 stale task heartbeat but worker key still alive → skip with WARN.
+- 8.63 lock already held → skip.
+- 8.64 `attempt+1 > max_retries` → `deferred_at_cap`, no `send_task`.
+- 8.65 only a `:lock` key exists → not yielded by the scan.
+- All 6 passed in standalone smoke run.
+
+Open items / punts (carried forward):
+- Did not touch Celery's `unacked` / `unacked_index` keys yet. With `visibility_timeout=float("inf")` they don't time out so they leak per dead worker. Bounded leak; Phase 6 cleans up after we verify the exact key names on a running staging Redis (open question O-1 in Section 13).
+- Did not add `parent_task_id` to the envelope yet — not needed until orphan detection lands.
+
+Decisions made (and why):
+- Lock TTL is configurable via `LEX_TASK_LOCK_TTL` (default 30s). Long enough for one sweep to do its work; short enough that a dead supervisor doesn't block recovery for more than a minute.
+- Missing `last_hb_iso` is treated as stale (rather than "ignore"). Reason: the only way that field disappears is the hash TTL elapsing, which only happens long after the worker died. Treating it as stale is the right safety default.
+- Worker-key alive check is done **after** staleness so we don't pay an extra Redis round-trip on non-stale tasks (the common case).
+
+Next phase entry criteria:
+- [x] all Phase 3 tests written and passing in smoke
+- [x] log entry written
+- [ ] PR opened / merged (deferred)
+
+---
+
+### 2026-05-20 — Phase 2 — Heartbeat thread + signal handlers (Claude)
+
+What I did:
+- Added `redis_client.py` (lazy, factory-overridable connection wrapper) and `heartbeat.py` (in-flight registry, daemon heartbeat thread, four signal handlers).
+- Wired `enable()` to call `heartbeat.connect_signal_handlers()`, and hooked `enable()` into `lex/lex_app/celery.py` right after `autodiscover_tasks`, wrapped in try/except so a missing Redis can never crash worker boot.
+- Added a minimal in-memory `FakeRedis` to the test file so tests don't need a running broker.
+
+Files touched:
+- `lex/lex_app/celery_recovery/redis_client.py` — new. `get_client()` is the only entry point; `set_client_factory()` is the test hook.
+- `lex/lex_app/celery_recovery/heartbeat.py` — new. ~280 lines. Contains the `_InFlightRegistry`, `HeartbeatThread`, `start_heartbeat`/`stop_heartbeat`, the four signal handlers, and `connect_signal_handlers()`.
+- `lex/lex_app/celery_recovery/__init__.py` — `enable()` now connects signals via the heartbeat module. Still idempotent and still env-gated.
+- `lex/lex_app/celery.py` — added the `from lex.lex_app import celery_recovery; celery_recovery.enable()` call.
+- `lex/test_project/tests/celery_async/test_8r_worker_recovery.py` — added `FakeRedis` (in-memory shim) and `TestCluster08r_Heartbeat` (7 tests: 8.50–8.56).
+
+Tests:
+- 8.50 task_prerun first delivery → attempt=0
+- 8.51 task_prerun reads `lex_attempt` header → attempt=2 on requeue
+- 8.52 task_postrun deletes the hash
+- 8.53 heartbeat writes `lex:wrk:<host>` with TTL
+- 8.54 heartbeat refreshes `last_hb_iso` on in-flight tasks
+- 8.55 per-task `task.lex_max_retries` override is recorded (Phase 5 will wire the decorator)
+- 8.56 `worker_shutting_down` removes the worker key
+- All 7 passed via standalone smoke run (no Django venv on this machine; next agent: run via `lex test ...test_8r_worker_recovery` to confirm under the Django runner).
+
+Open items / punts:
+- The heartbeat thread reads env vars on every tick via `_heartbeat_interval()`. This is intentional so tests can patch `LEX_TASK_HEARTBEAT_INTERVAL` and the change takes effect on the next loop. In production the values don't change. Keep this behavior.
+- `task.lex_max_retries` is being *recorded* by `task_prerun` but no decorator is writing it yet. The fallback to `LEX_TASK_MAX_RETRIES` env default works today; the per-task surface lands in Phase 5.
+- Did not yet stash `parent_task_id` in the envelope. Decision: add it in Phase 3 once the supervisor needs it for cross-checking whether the parent is still alive (risk-table item).
+
+Decisions made (and why):
+- `decode_responses=False`. Args/kwargs are pickled+base64; mixing decoded strings and raw bytes in the same hash is awkward. Tests treat field names as bytes too — keeps fake and real Redis consistent.
+- Hash TTL = `ttl_seconds * 4` (longer than worker TTL). Reason: when the supervisor wakes up on the next scan after a worker dies, it must still find the envelope to re-publish. Worker key has the shorter TTL so it expires when the worker dies — that's the staleness signal.
+- The heartbeat thread *never* raises out — failures log and the supervisor catches them via the natural missed-heartbeat path. Anything else would couple worker liveness to Redis liveness in a way we don't want.
+
+Next phase entry criteria:
+- [x] all Phase 2 tests written and passing in smoke
+- [x] log entry written
+- [ ] PR opened / merged (deferred)
+
+---
+
+### 2026-05-20 — Phase 1 — Module scaffolding + settings + feature flag (Claude)
+
+What I did:
+- Added the five recovery env knobs to `lex/lex_app/settings.py` right after the existing `celery_active = CELERY_ACTIVE` block: `LEX_TASK_RECOVERY_ENABLED` (default `true`), `LEX_TASK_HEARTBEAT_INTERVAL` (5), `LEX_TASK_HB_TTL_MULTIPLIER` (3), `LEX_TASK_SUPERVISOR_SCAN_INTERVAL` (10), `LEX_TASK_MAX_RETRIES` (4).
+- Scaffolded `lex/lex_app/celery_recovery/` with `__init__.py`, `redis_keys.py`, `exceptions.py`.
+- `enable()` is a no-op stub for now — it just flips a module-level flag and respects `LEX_TASK_RECOVERY_ENABLED`.
+- `redis_keys.py` centralizes the namespace: `lex:wrk:<host>`, `lex:task:<task_id>`, `lex:task:<task_id>:lock`, plus SCAN patterns.
+- `exceptions.py` defines `WorkerLost` (carries `worker_hostname`, `attempt`, `task_id`) and `MaxRequeueExceeded(WorkerLost)` so the parent can `except WorkerLost` and catch both the transient and terminal cases.
+
+Files touched:
+- `lex/lex_app/settings.py` — added the recovery knobs block.
+- `lex/lex_app/celery_recovery/__init__.py` — new.
+- `lex/lex_app/celery_recovery/redis_keys.py` — new.
+- `lex/lex_app/celery_recovery/exceptions.py` — new.
+- `lex/test_project/tests/celery_async/test_8r_worker_recovery.py` — new (Phase 1 portion only — keys, exceptions, `enable()` flag behavior; later phases extend this file).
+
+Tests:
+- 9 unit tests in `TestCluster08r_RecoveryScaffolding` covering keys, exceptions, and `enable()` idempotency / master-switch behavior.
+- Verified via a direct-import smoke that the recovery package has zero Django dependencies and imports clean on a bare Python — important for unit-test runs without a configured Django.
+- Did **not** run the Django test runner because this machine has no project venv at the path documented in `CLAUDE.md` (`project_example/.venv/`). Next agent: when you have the venv, run `lex test lex.test_project.tests.celery_async.test_8r_worker_recovery --verbosity=2 --noinput --keepdb` and confirm green before starting Phase 2.
+
+Open items / punts:
+- None for this phase. Heartbeat, signal handlers, supervisor are all Phase 2+.
+
+Decisions made (and why):
+- `enable()` reads the env var directly instead of `django.conf.settings` so the package stays import-safe in tests that don't configure Django. The Django settings entries duplicate the same values — that's fine and keeps the settings module the operator-facing documentation surface.
+- Kept `MaxRequeueExceeded` as a subclass of `WorkerLost` per the rationale above. Single `except WorkerLost` is the recommended catch in `CalculationModel.execute_calculation`.
+
+Next phase entry criteria:
+- [x] all phase tests written
+- [x] log entry written
+- [ ] PR opened / merged (deferred — user has not asked to commit yet)
+
+---
+
+### 2026-05-20 — Plan written (Claude, this session)
+
+- Read `docs/lex_topics/12-celery-async-dispatch.md`, `docs/features/processing/celery and async calculations.md`, `lex/lex_app/celery.py`, `lex/lex_app/celery_tasks.py`, `lex/core/tasks/CeleryTaskDispatcher.py`, `lex/lex_app/settings.py:370-447`.
+- Identified the root cause of infra-only deadlock: `visibility_timeout=float("inf")` neutralizes Celery's only Redis-transport recovery signal, so `task_acks_late=True` + `task_reject_on_worker_lost=True` never fire on worker death.
+- Confirmed the parent waits via `AsyncResult.get()` in `WaitForTasks.wait_for_completion` (`lex/lex_app/celery_tasks.py:415-432`) and that the result backend is Postgres, so `app.backend.mark_as_failure` is the right injection point.
+- Confirmed concurrency=1 + post-task `Control.shutdown` makes the per-worker-per-task assumption safe.
+- Wrote this plan in 7 phases.
+- **No code changes yet.** Next agent starts at Phase 1.
+
+### TEMPLATE — copy this when starting a new entry
+
+```
+### YYYY-MM-DD — Phase N — <short title> (<agent name>)
+
+What I did:
+- ...
+
+Files touched:
+- path/to/file.py — what changed
+
+Tests:
+- new test files / new test methods
+- pass/fail summary
+- coverage delta if measured
+
+Open items / punts:
+- ...
+
+Decisions made (and why):
+- ...
+
+Next phase entry criteria:
+- [ ] all phase tests green
+- [ ] log entry written
+- [ ] PR opened / merged
+```
+
+---
+
+## 16. Glossary
+
+- **Heartbeat key**: `lex:wrk:<hostname>` (worker liveness) and `last_hb_iso` field inside `lex:task:<task_id>` hash (task liveness).
+- **Stale**: `now - last_hb_iso > LEX_TASK_HEARTBEAT_INTERVAL × LEX_TASK_HB_TTL_MULTIPLIER`.
+- **Attempt**: number of times this `task_id` has been delivered to a worker. 0 on first dispatch from the parent. Incremented by the supervisor when it requeues.
+- **Requeue**: `app.send_task(..., task_id=<same_id>, headers={"lex_attempt": N+1})`.
+- **Failure injection**: `app.backend.mark_as_failure(<task_id>, WorkerLost(...))` so the parent's `AsyncResult.get()` raises.
+- **Supervisor**: the periodic Celery beat task `lex.celery_recovery.tasks.sweep_dead_workers` that scans `lex:task:*` keys.

--- a/lex/lex_app/celery.py
+++ b/lex/lex_app/celery.py
@@ -312,3 +312,16 @@ def validate_celery_redis_config():
 # Validate configuration on import (optional - can be disabled in production)
 if os.getenv('CELERY_VALIDATE_CONFIG', 'True').lower() == 'true':
     validate_celery_redis_config()
+
+
+# Worker-recovery: connect the heartbeat handlers and register the sweep task.
+# Gated internally by CELERY_ACTIVE + LEX_TASK_RECOVERY_ENABLED, so this is a
+# no-op for local/sync/CI runs. Importing the supervisor registers the
+# `sweep_dead_workers` task referenced by the beat schedule in settings.
+try:
+    from lex.lex_app.celery_recovery import enable as _enable_recovery
+    from lex.lex_app.celery_recovery import supervisor as _recovery_supervisor  # noqa: F401
+
+    _enable_recovery(app)
+except Exception:  # pragma: no cover - never block worker boot on recovery wiring
+    logger.exception("Failed to wire Celery worker-recovery; continuing without it")

--- a/lex/lex_app/celery_recovery/__init__.py
+++ b/lex/lex_app/celery_recovery/__init__.py
@@ -1,0 +1,54 @@
+"""Celery worker-recovery subsystem.
+
+Detects abruptly-killed workers via expiring Redis heartbeats and requeues
+their in-flight tasks under a bounded retry budget, writing a terminal
+FAILURE/ABORTED state when the budget is exhausted. This is layered on top
+of Celery deliberately, because ``visibility_timeout=float("inf")`` (see
+settings) neutralises Celery's own Redis-transport redelivery — recovery
+must never rely on ``visibility_timeout``.
+
+Wire it from the Celery app module via :func:`enable`. Everything is gated
+behind ``CELERY_ACTIVE`` and ``LEX_TASK_RECOVERY_ENABLED`` so local/sync/CI
+runs are unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_enabled = False
+
+
+def _recovery_enabled() -> bool:
+    from django.conf import settings
+
+    if not getattr(settings, "CELERY_ACTIVE", False):
+        return False
+    return bool(getattr(settings, "LEX_TASK_RECOVERY_ENABLED", True))
+
+
+def enable(app=None) -> bool:
+    """Connect the heartbeat signal handlers. Idempotent; gated by config.
+
+    Returns ``True`` when the handlers are now connected, ``False`` when
+    recovery is disabled (so the caller can log accordingly).
+    """
+    global _enabled
+    if _enabled:
+        return True
+    if not _recovery_enabled():
+        logger.debug("Celery recovery disabled (CELERY_ACTIVE/LEX_TASK_RECOVERY_ENABLED)")
+        return False
+
+    from celery.signals import task_postrun, task_prerun, task_revoked
+
+    from . import heartbeat
+
+    task_prerun.connect(heartbeat.on_task_prerun, weak=False)
+    task_postrun.connect(heartbeat.on_task_postrun, weak=False)
+    task_revoked.connect(heartbeat.on_task_revoked, weak=False)
+    _enabled = True
+    logger.info("Celery worker-recovery heartbeat handlers connected")
+    return True

--- a/lex/lex_app/celery_recovery/entrypoint.py
+++ b/lex/lex_app/celery_recovery/entrypoint.py
@@ -1,0 +1,38 @@
+"""Console-script entrypoint for the worker-recovery supervisor.
+
+Exposed via ``[project.scripts]`` as ``lex-recovery-supervisor`` so the
+supervisor can be launched as a single command in a container without going
+through the full ``lex`` CLI. It bootstraps Django exactly like the lex CLI
+does (see ``lex/bin/lex.py`` and ``lex/lex_app/celery.py``) and then forwards
+to the ``run_recovery_supervisor`` management command, passing through any
+CLI args (e.g. ``--once``, ``--interval``).
+
+Usage:
+
+    lex-recovery-supervisor              # always-on loop
+    lex-recovery-supervisor --once       # single pass and exit
+    lex-recovery-supervisor --interval 5
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    # Mirror the lex CLI / celery.py bootstrap: default the settings module if
+    # the operator did not set it, then run django.setup() once.
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "lex_app.settings")
+
+    import django
+
+    django.setup()
+
+    from django.core.management import call_command
+
+    call_command("run_recovery_supervisor", *sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/lex/lex_app/celery_recovery/exceptions.py
+++ b/lex/lex_app/celery_recovery/exceptions.py
@@ -1,0 +1,19 @@
+"""Exceptions raised by the worker-recovery subsystem."""
+
+from __future__ import annotations
+
+
+class MaxRequeueExceeded(Exception):
+    """Raised/recorded when a task's bounded retry budget is exhausted.
+
+    The supervisor writes this as the task's FAILURE result so that any
+    parent blocked on ``AsyncResult.get()`` unblocks instead of hanging
+    forever, and so the failure reason is legible in the result backend.
+    """
+
+    def __init__(self, task_id: str, retries: int):
+        self.task_id = task_id
+        self.retries = retries
+        super().__init__(
+            f"Task {task_id} exceeded the recovery retry budget after {retries} requeues"
+        )

--- a/lex/lex_app/celery_recovery/heartbeat.py
+++ b/lex/lex_app/celery_recovery/heartbeat.py
@@ -1,0 +1,124 @@
+"""Worker-side heartbeat: proof-of-life for in-flight tasks.
+
+While a task runs, a small daemon thread re-stamps that task's Redis
+heartbeat key every ``LEX_TASK_HEARTBEAT_INTERVAL`` seconds. The key's TTL
+is a multiple of the interval, so a missed refresh (the worker process was
+SIGKILLed, OOM-killed, or the pod was evicted) lets the key expire and the
+supervisor can prove the task is dead.
+
+The handlers are wired by :func:`celery_recovery.enable`; they are inert
+unless recovery is enabled (the registry itself no-ops when disabled).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, Optional, Tuple
+
+from . import registry
+
+logger = logging.getLogger(__name__)
+
+# task_id -> (thread, stop_event)
+_threads: Dict[str, Tuple[threading.Thread, threading.Event]] = {}
+_threads_lock = threading.Lock()
+
+# Tasks that must never be tracked/requeued by the recovery machinery
+# itself (requeuing the sweep would be pointless and could self-amplify).
+_UNTRACKED_TASK_NAMES = frozenset({"lex.lex_app.celery_recovery.supervisor.sweep_dead_workers"})
+
+
+def _settings():
+    from django.conf import settings
+
+    return settings
+
+
+def _heartbeat_interval() -> int:
+    return max(1, int(getattr(_settings(), "LEX_TASK_HEARTBEAT_INTERVAL", 5)))
+
+
+def _queue_of(task) -> Optional[str]:
+    """Best-effort: the routing key this task arrived on, for re-dispatch."""
+    request = getattr(task, "request", None)
+    delivery_info = getattr(request, "delivery_info", None) or {}
+    return delivery_info.get("routing_key")
+
+
+def _beat_loop(task_id: str, stop_event: threading.Event, interval: int) -> None:
+    """Refresh the heartbeat every ``interval`` seconds until stopped."""
+    while not stop_event.wait(interval):
+        try:
+            registry.refresh_heartbeat(task_id)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("Celery recovery: heartbeat loop refresh failed for %s", task_id)
+
+
+def on_task_prerun(sender=None, task_id=None, task=None, args=None, kwargs=None, **extra):
+    """Register the task and start refreshing its heartbeat."""
+    name = getattr(task, "name", None) or getattr(sender, "name", None)
+    if not task_id or name in _UNTRACKED_TASK_NAMES:
+        return
+    try:
+        registry.register(
+            task_id=task_id,
+            name=name,
+            args=args,
+            kwargs=kwargs,
+            queue=_queue_of(task),
+        )
+    except Exception:
+        logger.warning("Celery recovery: prerun register failed for %s", task_id, exc_info=True)
+        return
+
+    interval = _heartbeat_interval()
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_beat_loop,
+        args=(task_id, stop_event, interval),
+        name=f"lex-recovery-hb-{task_id[:8]}",
+        daemon=True,
+    )
+    with _threads_lock:
+        # Defensive: never leak a prior thread for the same id (requeue reuse).
+        prior = _threads.pop(task_id, None)
+        if prior is not None:
+            prior[1].set()
+        _threads[task_id] = (thread, stop_event)
+    thread.start()
+
+
+def on_task_postrun(sender=None, task_id=None, task=None, args=None, kwargs=None, **extra):
+    """Stop the heartbeat and deregister the now-terminal task."""
+    name = getattr(task, "name", None) or getattr(sender, "name", None)
+    if not task_id or name in _UNTRACKED_TASK_NAMES:
+        return
+    with _threads_lock:
+        entry = _threads.pop(task_id, None)
+    if entry is not None:
+        entry[1].set()
+    try:
+        registry.deregister(task_id)
+    except Exception:
+        logger.warning("Celery recovery: postrun deregister failed for %s", task_id, exc_info=True)
+
+
+def on_task_revoked(sender=None, request=None, **extra):
+    """Revoke fast-path: drop a cancelled task from the recovery registry.
+
+    When a task is revoked (typically a user cancellation) we stop its local
+    heartbeat thread and deregister it immediately so the supervisor can
+    never later detect it as "dead" and requeue it. Best-effort: never raise.
+    """
+    task_id = getattr(request, "id", None)
+    if not task_id:
+        return
+    with _threads_lock:
+        entry = _threads.pop(task_id, None)
+    if entry is not None:
+        entry[1].set()
+    try:
+        registry.deregister(task_id)
+    except Exception:
+        logger.warning("Celery recovery: revoked deregister failed for %s", task_id, exc_info=True)

--- a/lex/lex_app/celery_recovery/redis_keys.py
+++ b/lex/lex_app/celery_recovery/redis_keys.py
@@ -1,0 +1,31 @@
+"""Redis key builders for the worker-recovery subsystem.
+
+All keys are namespaced with the instance identifier so multiple lex
+instances sharing one Redis never collide. The prefix matches Celery's
+broker ``global_keyprefix`` convention (``<instance>:``) used by
+``cluster_cancel_index`` and the Celery transport options in settings.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def key_prefix() -> str:
+    """Instance-scoped prefix (matches Celery's broker ``global_keyprefix``)."""
+    return f"{os.getenv('INSTANCE_RESOURCE_IDENTIFIER', 'celery')}:"
+
+
+def heartbeat_key(task_id: str) -> str:
+    """Liveness marker refreshed by the running worker; TTL-bounded."""
+    return f"{key_prefix()}lex:recover:hb:{task_id}"
+
+
+def payload_key(task_id: str) -> str:
+    """Re-dispatch payload (base64 pickle) for one in-flight task."""
+    return f"{key_prefix()}lex:recover:task:{task_id}"
+
+
+def index_key() -> str:
+    """SET of every task_id currently tracked for recovery."""
+    return f"{key_prefix()}lex:recover:index"

--- a/lex/lex_app/celery_recovery/registry.py
+++ b/lex/lex_app/celery_recovery/registry.py
@@ -1,0 +1,291 @@
+"""Redis-backed registry of in-flight tasks for worker recovery.
+
+This is the single source of truth the supervisor reads to decide which
+tasks to requeue. For every task a worker is running we keep three keys
+(see :mod:`redis_keys`):
+
+* ``index``        — a SET of all tracked task_ids (cheap to enumerate);
+* ``payload:<id>`` — the base64(pickle) re-dispatch payload + retry count;
+* ``hb:<id>``      — a short-TTL liveness marker the worker refreshes.
+
+When a worker dies abruptly nobody refreshes ``hb:<id>``; it expires while
+the task_id is still in ``index`` with a live payload. That divergence —
+"tracked but no heartbeat" — is exactly how the supervisor recognises a
+dead worker without ever relying on Celery's ``visibility_timeout`` (which
+is deliberately ``inf`` in settings).
+
+Every operation is best-effort: it degrades to a silent no-op when Redis
+is unavailable or recovery is disabled, so local/sync/test execution is
+unaffected.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import pickle
+from typing import Any, Dict, List, Optional
+
+from . import redis_keys
+
+logger = logging.getLogger(__name__)
+
+_client = None
+_client_initialised = False
+
+# Payload lives long enough to outlast the longest expected task so the
+# supervisor can always read it after a death. Bounded so a leaked entry
+# (e.g. worker SIGKILLed between requeue and re-registration) self-cleans.
+_DEFAULT_PAYLOAD_TTL = 86400  # 24h, matches the pod activeDeadline.
+
+
+def _settings():
+    from django.conf import settings
+
+    return settings
+
+
+def _enabled_by_config() -> bool:
+    s = _settings()
+    if not getattr(s, "CELERY_ACTIVE", False):
+        return False
+    return bool(getattr(s, "LEX_TASK_RECOVERY_ENABLED", True))
+
+
+def _heartbeat_ttl() -> int:
+    s = _settings()
+    interval = int(getattr(s, "LEX_TASK_HEARTBEAT_INTERVAL", 5))
+    multiplier = int(getattr(s, "LEX_TASK_HB_TTL_MULTIPLIER", 3))
+    return max(1, interval * multiplier)
+
+
+def _payload_ttl() -> int:
+    return int(getattr(_settings(), "LEX_TASK_PAYLOAD_TTL_SECONDS", _DEFAULT_PAYLOAD_TTL))
+
+
+def _get_client():
+    """Lazily build a redis-py client from the Celery broker URL.
+
+    Returns ``None`` (so callers no-op) whenever recovery is disabled or
+    the client cannot be constructed.
+    """
+    global _client, _client_initialised
+    if not _enabled_by_config():
+        return None
+    if _client_initialised:
+        return _client
+    _client_initialised = True
+    try:
+        import redis
+
+        url = getattr(_settings(), "CELERY_BROKER_URL", None)
+        _client = redis.from_url(url, decode_responses=True) if url else None
+    except Exception:
+        logger.warning(
+            "Celery recovery: redis client unavailable; recovery is inert",
+            exc_info=True,
+        )
+        _client = None
+    return _client
+
+
+def reset_client_cache() -> None:
+    """Drop the cached client. Used by tests after changing settings."""
+    global _client, _client_initialised
+    _client = None
+    _client_initialised = False
+
+
+def _encode(payload: Dict[str, Any]) -> str:
+    return base64.b64encode(pickle.dumps(payload)).decode("ascii")
+
+
+def _decode(raw: str) -> Dict[str, Any]:
+    return pickle.loads(base64.b64decode(raw))
+
+
+def register(
+    task_id: str,
+    name: str,
+    args: Any,
+    kwargs: Any,
+    queue: Optional[str],
+) -> None:
+    """Track ``task_id`` as in-flight and stamp its first heartbeat.
+
+    Idempotent across requeues: if a payload already exists (the supervisor
+    re-dispatched this same task_id), its accumulated ``retries`` count is
+    preserved rather than reset to zero.
+    """
+    if not task_id:
+        return
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        retries = 0
+        existing = client.get(redis_keys.payload_key(task_id))
+        if existing:
+            try:
+                retries = int(_decode(existing).get("retries", 0))
+            except Exception:
+                retries = 0
+        payload = {
+            "name": name,
+            "args": args,
+            "kwargs": kwargs,
+            "queue": queue,
+            "retries": retries,
+        }
+        client.set(redis_keys.payload_key(task_id), _encode(payload), ex=_payload_ttl())
+        client.sadd(redis_keys.index_key(), task_id)
+        client.set(redis_keys.heartbeat_key(task_id), "1", ex=_heartbeat_ttl())
+    except Exception:
+        logger.warning("Celery recovery: register failed for %s", task_id, exc_info=True)
+
+
+def refresh_heartbeat(task_id: str) -> None:
+    """Re-stamp the liveness marker for a still-running task.
+
+    Also extends the payload key's TTL so a task that outlives the default
+    payload TTL (24h) keeps a recoverable payload for as long as it is
+    alive. Only the *expiry* is bumped — never the payload value, which the
+    supervisor may have rewritten with an incremented ``retries`` count.
+    """
+    if not task_id:
+        return
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.set(redis_keys.heartbeat_key(task_id), "1", ex=_heartbeat_ttl())
+        client.expire(redis_keys.payload_key(task_id), _payload_ttl())
+    except Exception:
+        logger.debug("Celery recovery: heartbeat refresh failed for %s", task_id)
+
+
+def deregister(task_id: str) -> None:
+    """Stop tracking ``task_id`` (it reached a terminal state)."""
+    if not task_id:
+        return
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.srem(redis_keys.index_key(), task_id)
+        client.delete(redis_keys.payload_key(task_id))
+        client.delete(redis_keys.heartbeat_key(task_id))
+    except Exception:
+        logger.warning("Celery recovery: deregister failed for %s", task_id, exc_info=True)
+
+
+def list_tracked() -> List[str]:
+    """Return every task_id currently tracked for recovery."""
+    client = _get_client()
+    if client is None:
+        return []
+    try:
+        return list(client.smembers(redis_keys.index_key()) or [])
+    except Exception:
+        logger.warning("Celery recovery: list_tracked failed", exc_info=True)
+        return []
+
+
+def is_alive(task_id: str) -> bool:
+    """True while the worker is still refreshing this task's heartbeat."""
+    client = _get_client()
+    if client is None:
+        return True  # fail safe: never declare dead when Redis is unreadable
+    try:
+        return bool(client.exists(redis_keys.heartbeat_key(task_id)))
+    except Exception:
+        logger.warning("Celery recovery: is_alive check failed for %s", task_id, exc_info=True)
+        return True
+
+
+def get_payload(task_id: str) -> Optional[Dict[str, Any]]:
+    """Return the re-dispatch payload for ``task_id`` (or ``None``)."""
+    client = _get_client()
+    if client is None:
+        return None
+    try:
+        raw = client.get(redis_keys.payload_key(task_id))
+        return _decode(raw) if raw else None
+    except Exception:
+        logger.warning("Celery recovery: get_payload failed for %s", task_id, exc_info=True)
+        return None
+
+
+def grant_grace(task_id: str, grace_seconds: int) -> None:
+    """Grant a heartbeat grace window (re-stamp ``hb:<id>`` to a short TTL).
+
+    Used right *before* a requeue dispatch: it delays the next dead-task
+    detection long enough for the re-dispatched run to start and resume its
+    own heartbeat, without touching the payload value. If the dispatch then
+    fails, only this grace TTL was consumed — the retry budget (stored in the
+    payload) is untouched, so the next pass retries without burning a slot.
+    """
+    if not task_id:
+        return
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.set(redis_keys.heartbeat_key(task_id), "1", ex=max(1, grace_seconds))
+    except Exception:
+        logger.warning("Celery recovery: grant_grace failed for %s", task_id, exc_info=True)
+
+
+def persist_payload(task_id: str, payload: Dict[str, Any]) -> None:
+    """Write the re-dispatch payload value (with the standard payload TTL).
+
+    Called *after* a successful requeue dispatch so the incremented
+    ``retries`` count is only committed once the message is actually on the
+    broker. Splitting this from :func:`grant_grace` is what keeps a failed
+    dispatch from consuming the retry budget (see :func:`grant_grace`).
+    """
+    if not task_id:
+        return
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.set(redis_keys.payload_key(task_id), _encode(payload), ex=_payload_ttl())
+    except Exception:
+        logger.warning("Celery recovery: persist_payload failed for %s", task_id, exc_info=True)
+
+
+def record_requeue(task_id: str, payload: Dict[str, Any], grace_seconds: int) -> None:
+    """Persist the incremented payload and grant a heartbeat grace window.
+
+    Thin backward-compatible wrapper kept for any caller/test that still
+    references the combined operation. New code should call
+    :func:`grant_grace` (before dispatch) and :func:`persist_payload` (after
+    dispatch) separately so a failed dispatch does not burn the retry budget.
+    """
+    grant_grace(task_id, grace_seconds)
+    persist_payload(task_id, payload)
+
+
+def try_acquire_recovery_lock(task_id: str, ttl_seconds: int) -> bool:
+    """Acquire a short-lived per-task recovery lock (``SET ... NX EX``).
+
+    Returns ``True`` only when *this* supervisor won the lock, so two
+    supervisor replicas never act on the same dead task in the same window.
+    Best-effort: returns ``False`` on any Redis error or when recovery is
+    disabled, so a supervisor that cannot take the lock simply skips the task
+    (which is the safe outcome — another replica may hold it).
+    """
+    if not task_id:
+        return False
+    client = _get_client()
+    if client is None:
+        return False
+    try:
+        lock_key = f"{redis_keys.key_prefix()}lex:recover:lock:{task_id}"
+        return bool(client.set(lock_key, "1", nx=True, ex=max(1, ttl_seconds)))
+    except Exception:
+        logger.warning(
+            "Celery recovery: try_acquire_recovery_lock failed for %s", task_id, exc_info=True
+        )
+        return False

--- a/lex/lex_app/celery_recovery/supervisor.py
+++ b/lex/lex_app/celery_recovery/supervisor.py
@@ -1,0 +1,307 @@
+"""Supervisor: detect dead workers and requeue their tasks (bounded).
+
+A single scan pass (:func:`scan_and_recover`) reads the registry, finds
+tasks that are still tracked but whose heartbeat has expired, and for each:
+
+* **within budget** — re-dispatches the *same* ``task_id`` onto its queue
+  (so a parent waiting on ``AsyncResult(task_id).get()`` still receives the
+  eventual result) and grants a short heartbeat grace so the next scan does
+  not re-detect it before the new run starts;
+* **budget exhausted** — writes a FAILURE result (unblocking any waiter)
+  and flips the calculation row out of ``IN_PROGRESS`` to ``ABORTED`` so it
+  stops being stuck, then drops it from the registry.
+
+Run it either way:
+
+* via Celery beat — the wired ``sweep_dead_workers`` task runs one pass; or
+* via a dedicated always-on process — :func:`run_forever` loops it.
+
+The always-on form is preferable in the cluster (see the module docs): the
+re-dispatch itself puts a message on the queue KEDA watches, which is what
+brings a fresh worker up to actually run the recovered task — without the
+beat path's churn of spawning a worker every interval just to poll.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from celery import shared_task
+
+from . import registry
+from .exceptions import MaxRequeueExceeded
+
+logger = logging.getLogger(__name__)
+
+
+def _settings():
+    from django.conf import settings
+
+    return settings
+
+
+def _max_retries() -> int:
+    return max(0, int(getattr(_settings(), "LEX_TASK_MAX_RETRIES", 4)))
+
+
+def _scan_interval() -> int:
+    return max(1, int(getattr(_settings(), "LEX_TASK_SUPERVISOR_SCAN_INTERVAL", 10)))
+
+
+def _requeue_grace_seconds() -> int:
+    return max(1, int(getattr(_settings(), "LEX_TASK_REQUEUE_GRACE_SECONDS", 60)))
+
+
+def _default_queue() -> str:
+    s = _settings()
+    return getattr(s, "CELERY_TASK_DEFAULT_QUEUE", None) or "celery"
+
+
+def _get_app():
+    from lex.lex_app.celery import app
+
+    return app
+
+
+def _requeue(app, task_id: str, payload: Dict[str, Any]) -> None:
+    """Re-dispatch ``task_id`` with an incremented retry count.
+
+    Persistence is deliberately split around the dispatch so a broker outage
+    never burns the retry budget:
+
+    1. :func:`registry.grant_grace` — only delays the next dead detection;
+    2. ``app.send_task`` — the actual re-dispatch (may raise if broker down);
+    3. :func:`registry.persist_payload` — commits the incremented ``retries``
+       count, but only *after* the message is on the broker.
+
+    If step 2 raises, ``retries`` is never persisted: the grace window simply
+    delays detection and the next pass retries without consuming a slot.
+    """
+    incremented = dict(payload)
+    incremented["retries"] = int(incremented.get("retries", 0)) + 1
+    queue = incremented.get("queue") or _default_queue()
+
+    # Grant the grace window *before* dispatching so the task can never be
+    # double-requeued if the next scan races the new worker's first heartbeat.
+    registry.grant_grace(task_id, _requeue_grace_seconds())
+
+    app.send_task(
+        incremented["name"],
+        args=incremented.get("args") or (),
+        kwargs=incremented.get("kwargs") or {},
+        task_id=task_id,
+        queue=queue,
+    )
+
+    # Only now that the message is actually on the broker do we commit the
+    # incremented retry count — a failed send_task above would have raised.
+    registry.persist_payload(task_id, incremented)
+    payload = incremented
+    logger.warning(
+        "Celery recovery: requeued dead task %s (%s) attempt %s/%s on queue %s",
+        task_id,
+        payload["name"],
+        payload["retries"],
+        _max_retries(),
+        queue,
+    )
+
+
+def _extract_calculation_models(args: Any) -> List[Any]:
+    """Mirror CallbackTask: pull CalculationModel instances out of task args."""
+    from lex.core.models.CalculationModel import CalculationModel
+
+    if not args:
+        return []
+    first = args[0]
+    candidates = first if isinstance(first, (list, tuple)) else [first]
+    return [c for c in candidates if isinstance(c, CalculationModel)]
+
+
+def _calculation_id_of(payload: Dict[str, Any]) -> Optional[str]:
+    """Extract the calculation_id carried in the task's re-dispatch kwargs.
+
+    Tasks stamp it at ``payload["kwargs"]["context"]["calculation_id"]``.
+    Returns ``None`` if any layer is missing (best-effort, never raises).
+    """
+    try:
+        return (payload.get("kwargs") or {}).get("context", {}).get("calculation_id")
+    except Exception:
+        return None
+
+
+def _abort_calculation_rows(payload: Dict[str, Any], reason: str) -> None:
+    """Flip any stuck IN_PROGRESS rows for this task to ABORTED."""
+    from lex.core.models.CalculationModel import CalculationModel
+
+    _finalize_calculation_rows(payload, CalculationModel.ABORTED, reason)
+
+
+def _cancel_calculation_rows(payload: Dict[str, Any], reason: str) -> None:
+    """Flip any stuck IN_PROGRESS rows for this task to CANCELLED.
+
+    Used when a dead task's calculation was cancelled by the user: we do not
+    requeue, we finalize the stuck rows as CANCELLED (not ABORTED).
+    """
+    from lex.core.models.CalculationModel import CalculationModel
+
+    _finalize_calculation_rows(payload, CalculationModel.CANCELLED, reason)
+
+
+def _finalize_calculation_rows(payload: Dict[str, Any], target_status: str, reason: str) -> None:
+    """Flip any stuck IN_PROGRESS rows for this task to ``target_status``."""
+    from lex.core.signals import update_calculation_status
+    from lex.core.models.CalculationModel import CalculationModel
+
+    for instance in _extract_calculation_models(payload.get("args")):
+        try:
+            model_class = instance.__class__
+            model_class._default_manager.filter(
+                pk=instance.pk, is_calculated=CalculationModel.IN_PROGRESS
+            ).update(is_calculated=target_status, error_message=reason)
+            instance.is_calculated = target_status
+            update_calculation_status(instance, exception_details=reason)
+        except Exception:
+            logger.warning(
+                "Celery recovery: failed to finalize row %s as %s",
+                instance, target_status, exc_info=True,
+            )
+
+
+def _is_cancelled(calc_id: Optional[str]) -> bool:
+    """Best-effort check of the cluster-wide cancellation marker.
+
+    Defensive on every front: an import error (module missing) or a Redis
+    failure degrades to ``False`` so the caller falls back to the normal
+    requeue path rather than wrongly finalizing a live calculation.
+    """
+    if not calc_id:
+        return False
+    try:
+        from lex.core.cancellation import cluster_cancel_index
+
+        return bool(cluster_cancel_index.is_cancelled(calc_id))
+    except Exception:
+        logger.debug("Celery recovery: cancellation check failed for %s", calc_id)
+        return False
+
+
+def _finalize_cancelled(task_id: str, payload: Dict[str, Any]) -> None:
+    """A dead task's calculation was cancelled: finalize rows, stop tracking.
+
+    Mirrors :func:`_give_up` but uses CANCELLED (not ABORTED) and does NOT
+    write a FAILURE result — the user asked to cancel, not a budget failure.
+    """
+    _cancel_calculation_rows(payload, "Calculation cancelled by user")
+    registry.deregister(task_id)
+    logger.info(
+        "Celery recovery: dead task %s belonged to a cancelled calculation; "
+        "finalized CANCELLED instead of requeueing",
+        task_id,
+    )
+
+
+def _give_up(app, task_id: str, payload: Dict[str, Any]) -> None:
+    """Budget exhausted: record FAILURE, abort the row, stop tracking."""
+    retries = int(payload.get("retries", 0))
+    exc = MaxRequeueExceeded(task_id, retries)
+    try:
+        app.backend.mark_as_failure(task_id, exc)
+    except Exception:
+        logger.warning(
+            "Celery recovery: mark_as_failure failed for %s", task_id, exc_info=True
+        )
+    _abort_calculation_rows(payload, str(exc))
+    registry.deregister(task_id)
+    logger.error(
+        "Celery recovery: gave up on task %s after %s requeues; marked ABORTED",
+        task_id,
+        retries,
+    )
+
+
+def scan_and_recover(app=None) -> Dict[str, int]:
+    """Run one recovery pass. Returns counters for observability/tests."""
+    app = app or _get_app()
+    stats = {
+        "checked": 0,
+        "alive": 0,
+        "requeued": 0,
+        "gave_up": 0,
+        "orphaned": 0,
+        "cancelled": 0,
+        "skipped_locked": 0,
+    }
+
+    for task_id in registry.list_tracked():
+        stats["checked"] += 1
+        if registry.is_alive(task_id):
+            stats["alive"] += 1
+            continue
+
+        payload = registry.get_payload(task_id)
+        if payload is None:
+            # Heartbeat gone and payload gone: nothing to act on. Drop it.
+            registry.deregister(task_id)
+            stats["orphaned"] += 1
+            continue
+
+        # Multi-supervisor safety: claim this dead task before acting on it.
+        # If another replica already holds the lock, skip it this pass — that
+        # replica will requeue/finalize it. Best-effort: a Redis failure
+        # returns False, so we conservatively skip rather than double-act.
+        if not registry.try_acquire_recovery_lock(task_id, _requeue_grace_seconds()):
+            stats["skipped_locked"] += 1
+            continue
+
+        # Never requeue a user-cancelled calculation: finalize it CANCELLED.
+        if _is_cancelled(_calculation_id_of(payload)):
+            _finalize_cancelled(task_id, payload)
+            stats["cancelled"] += 1
+            continue
+
+        if int(payload.get("retries", 0)) < _max_retries():
+            try:
+                _requeue(app, task_id, payload)
+                stats["requeued"] += 1
+            except Exception:
+                logger.warning(
+                    "Celery recovery: requeue dispatch failed for %s", task_id, exc_info=True
+                )
+        else:
+            _give_up(app, task_id, payload)
+            stats["gave_up"] += 1
+
+    if stats["checked"]:
+        logger.info("Celery recovery sweep: %s", stats)
+    return stats
+
+
+@shared_task(name="lex.lex_app.celery_recovery.supervisor.sweep_dead_workers")
+def sweep_dead_workers() -> Dict[str, int]:
+    """Celery-beat entrypoint: one recovery pass (see module docstring)."""
+    return scan_and_recover()
+
+
+_stop = threading.Event()
+
+
+def run_forever(interval: Optional[int] = None) -> None:
+    """Always-on supervisor loop (for a dedicated recovery process)."""
+    interval = interval or _scan_interval()
+    app = _get_app()
+    logger.info("Celery recovery supervisor loop started (interval=%ss)", interval)
+    _stop.clear()
+    while not _stop.wait(interval):
+        try:
+            scan_and_recover(app)
+        except Exception:
+            logger.exception("Celery recovery: scan pass failed")
+
+
+def stop_forever() -> None:
+    """Signal :func:`run_forever` to exit (used by tests/shutdown)."""
+    _stop.set()

--- a/lex/lex_app/management/commands/run_recovery_supervisor.py
+++ b/lex/lex_app/management/commands/run_recovery_supervisor.py
@@ -1,0 +1,138 @@
+"""Always-on Celery worker-recovery supervisor (management command).
+
+Runs the recovery sweep loop as a single, dedicated, always-on process. In
+the cluster the backend (KEDA ScaledObject, 0..1) and the Celery workers
+(KEDA ScaledJob) both scale to zero, so neither can reliably host the loop —
+this command exists to be deployed as a singleton companion pod that just
+keeps calling :func:`scan_and_recover` forever.
+
+Each pass detects tasks whose worker died (expired heartbeat) and either
+re-dispatches them (within the retry budget) or finalizes them ABORTED. See
+``lex/lex_app/celery_recovery/supervisor.py`` for the recovery semantics.
+
+Run it:
+
+    # always-on loop (the deployed form)
+    manage.py run_recovery_supervisor
+    lex run_recovery_supervisor
+
+    # single pass and exit (cron / debugging)
+    manage.py run_recovery_supervisor --once
+
+Gating: recovery only does real work when ``CELERY_ACTIVE`` and
+``LEX_TASK_RECOVERY_ENABLED`` are both on. If they are off the supervisor
+still starts (so a misconfiguration is loud, not a silent exit) but every
+pass is an inert no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Run the always-on Celery worker-recovery supervisor loop "
+        "(detects dead workers and requeues their in-flight tasks). "
+        "Use --once for a single sweep."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--interval",
+            type=int,
+            default=None,
+            help=(
+                "Seconds between recovery sweeps. Defaults to the "
+                "LEX_TASK_SUPERVISOR_SCAN_INTERVAL setting (10s)."
+            ),
+        )
+        parser.add_argument(
+            "--once",
+            action="store_true",
+            help="Run a single scan_and_recover() pass and exit (cron/debugging).",
+        )
+
+    def handle(self, *args, **options):
+        # Import inside handle so Django is fully set up first and so the
+        # command module stays import-light for `manage.py` discovery.
+        from lex.lex_app.celery import app
+        from lex.lex_app.celery_recovery import enable, supervisor
+
+        interval = options["interval"]
+        run_once = options["once"]
+
+        celery_active = bool(getattr(settings, "CELERY_ACTIVE", False))
+        recovery_enabled = bool(getattr(settings, "LEX_TASK_RECOVERY_ENABLED", True))
+
+        self.stdout.write(
+            "Starting Celery worker-recovery supervisor "
+            f"(CELERY_ACTIVE={celery_active}, "
+            f"LEX_TASK_RECOVERY_ENABLED={recovery_enabled}, "
+            f"interval={interval if interval is not None else 'settings-default'}, "
+            f"once={run_once})"
+        )
+        logger.info(
+            "run_recovery_supervisor starting: CELERY_ACTIVE=%s "
+            "LEX_TASK_RECOVERY_ENABLED=%s interval=%s once=%s",
+            celery_active,
+            recovery_enabled,
+            interval,
+            run_once,
+        )
+
+        if not (celery_active and recovery_enabled):
+            warning = (
+                "Recovery is DISABLED (CELERY_ACTIVE and/or "
+                "LEX_TASK_RECOVERY_ENABLED are off). The supervisor will run "
+                "but every sweep is an inert no-op. Set CELERY_ACTIVE=TRUE and "
+                "LEX_TASK_RECOVERY_ENABLED=true to activate recovery."
+            )
+            self.stdout.write(self.style.WARNING(warning))
+            logger.warning(warning)
+
+        # Harmless on the supervisor (consumer-side) process; just ensures the
+        # recovery package is initialized. enable() is gated/idempotent.
+        try:
+            enable(app)
+        except Exception:  # pragma: no cover - never block startup on wiring
+            logger.exception(
+                "run_recovery_supervisor: enable(app) failed; continuing"
+            )
+
+        if run_once:
+            stats = supervisor.scan_and_recover(app)
+            self.stdout.write(f"Recovery sweep stats: {stats}")
+            logger.info("run_recovery_supervisor --once complete: %s", stats)
+            return
+
+        # Graceful shutdown: K8s sends SIGTERM on pod termination. Install
+        # handlers that ask the loop to exit after the current pass finishes.
+        def _request_stop(signum, _frame):
+            logger.info(
+                "run_recovery_supervisor received signal %s; stopping loop", signum
+            )
+            supervisor.stop_forever()
+
+        signal.signal(signal.SIGTERM, _request_stop)
+        signal.signal(signal.SIGINT, _request_stop)
+
+        # run_forever already catches per-pass exceptions internally; this
+        # wrapper is just a final safety net so any unexpected failure exits
+        # non-zero and lets K8s restart the pod.
+        try:
+            supervisor.run_forever(interval)
+        except Exception:
+            logger.exception(
+                "run_recovery_supervisor: supervisor loop crashed; exiting non-zero"
+            )
+            raise
+
+        self.stdout.write("Celery worker-recovery supervisor stopped cleanly.")
+        logger.info("run_recovery_supervisor stopped cleanly.")

--- a/lex/tests/unit/infra/test_celery_recovery.py
+++ b/lex/tests/unit/infra/test_celery_recovery.py
@@ -1,0 +1,229 @@
+"""
+Unit tests for the Celery worker-recovery subsystem
+(``lex/lex_app/celery_recovery/``).
+
+What is tested:
+  * ``registry`` encodes/decodes the re-dispatch payload losslessly.
+  * ``supervisor.scan_and_recover`` leaves live tasks alone, requeues a dead
+    task under budget (same task_id, incremented retry count), and gives up
+    once the bounded budget is exhausted (FAILURE result + row abort).
+  * A dead task whose payload has vanished is dropped rather than requeued.
+
+How it runs:
+  Pure logic — Redis and Celery are never contacted. ``registry`` access and
+  the row-abort side effect are patched, and a fake Celery app records
+  ``send_task`` / ``backend.mark_as_failure`` calls.
+"""
+
+import types
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from lex.lex_app.celery_recovery import heartbeat, registry, supervisor
+from lex.lex_app.celery_recovery.exceptions import MaxRequeueExceeded
+
+
+def _fake_app():
+    backend = types.SimpleNamespace(mark_as_failure=mock.Mock())
+    return types.SimpleNamespace(send_task=mock.Mock(), backend=backend)
+
+
+class RegistryPayloadCodecTests(SimpleTestCase):
+    def test_encode_decode_round_trip(self):
+        payload = {
+            "name": "calc_and_save",
+            "args": ([1, 2, 3],),
+            "kwargs": {"context": {"calculation_id": "c1"}},
+            "queue": "inst-q",
+            "retries": 2,
+        }
+        restored = registry._decode(registry._encode(payload))
+        self.assertEqual(restored, payload)
+
+
+class ScanAndRecoverTests(SimpleTestCase):
+    def setUp(self):
+        # Default settings stubs so the supervisor's helpers are deterministic.
+        # The recovery lock and cancellation gate are stubbed to their
+        # "act normally" values (lock acquired, not cancelled) so the core
+        # requeue/give-up behaviour is exercised; tests that target those two
+        # gates override these stubs explicitly.
+        self._patches = [
+            mock.patch.object(supervisor, "_max_retries", return_value=4),
+            mock.patch.object(supervisor, "_requeue_grace_seconds", return_value=60),
+            mock.patch.object(supervisor, "_default_queue", return_value="default-q"),
+            mock.patch.object(registry, "try_acquire_recovery_lock", return_value=True),
+            mock.patch.object(supervisor, "_is_cancelled", return_value=False),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+    def test_live_task_is_left_alone(self):
+        app = _fake_app()
+        with mock.patch.object(registry, "list_tracked", return_value=["t-alive"]), \
+             mock.patch.object(registry, "is_alive", return_value=True), \
+             mock.patch.object(registry, "get_payload") as get_payload:
+            stats = supervisor.scan_and_recover(app)
+        self.assertEqual(stats["alive"], 1)
+        self.assertEqual(stats["requeued"], 0)
+        app.send_task.assert_not_called()
+        get_payload.assert_not_called()
+
+    def test_dead_task_under_budget_is_requeued_same_id(self):
+        app = _fake_app()
+        payload = {
+            "name": "calc_and_save",
+            "args": ((),),
+            "kwargs": {},
+            "queue": "inst-q",
+            "retries": 1,
+        }
+        with mock.patch.object(registry, "list_tracked", return_value=["t-dead"]), \
+             mock.patch.object(registry, "is_alive", return_value=False), \
+             mock.patch.object(registry, "get_payload", return_value=payload), \
+             mock.patch.object(registry, "grant_grace") as grant_grace, \
+             mock.patch.object(registry, "persist_payload") as persist_payload:
+            stats = supervisor.scan_and_recover(app)
+
+        self.assertEqual(stats["requeued"], 1)
+        # Same task_id reused so the parent's AsyncResult still resolves.
+        _, kwargs = app.send_task.call_args
+        self.assertEqual(kwargs["task_id"], "t-dead")
+        self.assertEqual(kwargs["queue"], "inst-q")
+        # Grace granted before dispatch; incremented retries persisted after.
+        grant_grace.assert_called_once()
+        saved_payload = persist_payload.call_args[0][1]
+        self.assertEqual(saved_payload["retries"], 2)
+
+    def test_dead_task_without_payload_is_dropped(self):
+        app = _fake_app()
+        with mock.patch.object(registry, "list_tracked", return_value=["t-orphan"]), \
+             mock.patch.object(registry, "is_alive", return_value=False), \
+             mock.patch.object(registry, "get_payload", return_value=None), \
+             mock.patch.object(registry, "deregister") as deregister:
+            stats = supervisor.scan_and_recover(app)
+        self.assertEqual(stats["orphaned"], 1)
+        deregister.assert_called_once_with("t-orphan")
+        app.send_task.assert_not_called()
+
+    def test_exhausted_budget_marks_failure_and_aborts(self):
+        app = _fake_app()
+        payload = {
+            "name": "calc_and_save",
+            "args": ((),),
+            "kwargs": {},
+            "queue": "inst-q",
+            "retries": 4,  # == max, so the next detection gives up
+        }
+        with mock.patch.object(registry, "list_tracked", return_value=["t-dead"]), \
+             mock.patch.object(registry, "is_alive", return_value=False), \
+             mock.patch.object(registry, "get_payload", return_value=payload), \
+             mock.patch.object(registry, "deregister") as deregister, \
+             mock.patch.object(supervisor, "_abort_calculation_rows") as abort_rows:
+            stats = supervisor.scan_and_recover(app)
+
+        self.assertEqual(stats["gave_up"], 1)
+        app.send_task.assert_not_called()
+        deregister.assert_called_once_with("t-dead")
+        abort_rows.assert_called_once()
+        exc = app.backend.mark_as_failure.call_args[0][1]
+        self.assertIsInstance(exc, MaxRequeueExceeded)
+
+    def test_cancelled_calculation_is_finalized_not_requeued(self):
+        """Fix A: a dead task whose calculation was cancelled is finalized
+        CANCELLED (row finalize + deregister), never requeued."""
+        app = _fake_app()
+        payload = {
+            "name": "calc_and_save",
+            "args": ((),),
+            "kwargs": {"context": {"calculation_id": "calc-99"}},
+            "queue": "inst-q",
+            "retries": 1,  # under budget — would normally requeue
+        }
+        with mock.patch.object(registry, "list_tracked", return_value=["t-dead"]), \
+             mock.patch.object(registry, "is_alive", return_value=False), \
+             mock.patch.object(registry, "get_payload", return_value=payload), \
+             mock.patch.object(supervisor, "_is_cancelled", return_value=True), \
+             mock.patch.object(registry, "deregister") as deregister, \
+             mock.patch.object(supervisor, "_cancel_calculation_rows") as cancel_rows:
+            stats = supervisor.scan_and_recover(app)
+
+        self.assertEqual(stats["cancelled"], 1)
+        self.assertEqual(stats["requeued"], 0)
+        app.send_task.assert_not_called()
+        cancel_rows.assert_called_once()
+        deregister.assert_called_once_with("t-dead")
+
+    def test_calculation_id_of_reads_nested_context(self):
+        """Fix A helper: calculation_id is read from kwargs.context."""
+        payload = {"kwargs": {"context": {"calculation_id": "calc-7"}}}
+        self.assertEqual(supervisor._calculation_id_of(payload), "calc-7")
+        # Missing layers degrade to None rather than raising.
+        self.assertIsNone(supervisor._calculation_id_of({"kwargs": {}}))
+        self.assertIsNone(supervisor._calculation_id_of({}))
+
+    def test_dead_task_skipped_when_lock_not_acquired(self):
+        """Fix B: when another supervisor holds the recovery lock, this pass
+        skips the task entirely — no requeue, counted under skipped_locked."""
+        app = _fake_app()
+        payload = {
+            "name": "calc_and_save",
+            "args": ((),),
+            "kwargs": {},
+            "queue": "inst-q",
+            "retries": 1,
+        }
+        with mock.patch.object(registry, "list_tracked", return_value=["t-dead"]), \
+             mock.patch.object(registry, "is_alive", return_value=False), \
+             mock.patch.object(registry, "get_payload", return_value=payload), \
+             mock.patch.object(registry, "try_acquire_recovery_lock", return_value=False):
+            stats = supervisor.scan_and_recover(app)
+
+        self.assertEqual(stats["skipped_locked"], 1)
+        self.assertEqual(stats["requeued"], 0)
+        app.send_task.assert_not_called()
+
+    def test_requeue_does_not_persist_retries_when_dispatch_fails(self):
+        """Fix D: if send_task raises (broker down), the retry budget is NOT
+        consumed — grant_grace ran but persist_payload did not."""
+        app = _fake_app()
+        app.send_task.side_effect = RuntimeError("broker down")
+        payload = {
+            "name": "calc_and_save",
+            "args": ((),),
+            "kwargs": {},
+            "queue": "inst-q",
+            "retries": 1,
+        }
+        with mock.patch.object(registry, "grant_grace") as grant_grace, \
+             mock.patch.object(registry, "persist_payload") as persist_payload:
+            with self.assertRaises(RuntimeError):
+                supervisor._requeue(app, "t-dead", payload)
+
+        grant_grace.assert_called_once()
+        # Budget not burned: incremented payload never persisted.
+        persist_payload.assert_not_called()
+        # Original payload retries unchanged (we built a copy internally).
+        self.assertEqual(payload["retries"], 1)
+
+
+class TaskRevokedHandlerTests(SimpleTestCase):
+    def test_on_task_revoked_deregisters_request_id(self):
+        """Fix E: a revoked task is deregistered by its request id so the
+        supervisor can never later requeue it."""
+        request = types.SimpleNamespace(id="t-revoked")
+        with mock.patch.object(registry, "deregister") as deregister:
+            heartbeat.on_task_revoked(request=request)
+        deregister.assert_called_once_with("t-revoked")
+
+    def test_on_task_revoked_without_id_is_noop(self):
+        """No request id (or no request) → best-effort no-op, never raises."""
+        with mock.patch.object(registry, "deregister") as deregister:
+            heartbeat.on_task_revoked(request=None)
+            heartbeat.on_task_revoked(request=types.SimpleNamespace(id=None))
+        deregister.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ Homepage = "https://github.com/ExcellenceCloudGmbH/lex-app"
 [project.scripts]
 lex = "lex.__main__:main"
 lex-generate-configs = "generate_pycharm_configs:generate_pycharm_configs"
+lex-recovery-supervisor = "lex.lex_app.celery_recovery.entrypoint:main"
 
 [tool.setuptools]
 py-modules = ["generate_pycharm_configs"]


### PR DESCRIPTION
## Summary

Detect abruptly-killed Celery workers (SIGKILL / OOM / pod eviction) via Redis heartbeats and requeue their in-flight tasks under a bounded retry budget, so calculations no longer get stuck `IN_PROGRESS` forever.

This is layered on top of Celery on purpose: settings set `visibility_timeout=float("inf")` + `task_acks_late` + `task_reject_on_worker_lost`, which disables Celery's native Redis redelivery. **Recovery never touches `visibility_timeout`** — it is heartbeat-based.

## How it works

- Each running task starts a daemon thread that re-stamps a Redis heartbeat key (`hb:<task_id>`, short TTL). If the worker is killed, the thread dies and the key expires.
- A singleton always-on supervisor scans for "tracked-but-no-heartbeat" tasks and re-dispatches them with the **same `task_id`** (so a parent blocked on `AsyncResult.get()` still resolves). The requeue message itself creates KEDA queue pressure to bring a fresh worker up.
- On retry-budget exhaustion: `mark_as_failure` + flip the stuck row `IN_PROGRESS → ABORTED`.
- Everything is best-effort no-op when Redis is unreachable or recovery is disabled.

## Edge cases handled

- Cancelled calculation is finalized `CANCELLED`, never requeued.
- Per-task Redis lock (`SET NX EX`) so multiple supervisor replicas never double-act.
- Heartbeat refresh also extends the payload-key TTL so long tasks stay recoverable past 24h.
- `grant_grace` before dispatch / `persist_payload` after, so a broker outage during requeue doesn't burn the retry budget.
- Revoke fast-path deregister so a revoked task can't later be detected as dead.

## Deployment

- New `lex-recovery-supervisor` console script + `run_recovery_supervisor` management command (`--once` / `--interval`).
- Intended to run as a dedicated singleton Deployment (workers and backend both scale to 0 under KEDA, so neither can host an always-on watchdog). Reference manifest under `docs/celery-worker-recovery/k8s/`. The matching Helm template for the `lex-instance` chart is in a companion infra PR.

## Enable / disable

Gated by `CELERY_ACTIVE` + `LEX_TASK_RECOVERY_ENABLED` (default `true`). No-op for local/sync/CI.

## Test plan

- [x] 11 unit tests in `lex/tests/unit/infra/test_celery_recovery.py` pass
- [x] All recovery modules + console script + management command import cleanly under Django
- [x] `lex-recovery-supervisor --once` exits 0 with Redis down (best-effort no-op)
- [ ] End-to-end on a cluster instance: kill a worker mid-calc, confirm same-task-id requeue and completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)