### PR TITLE
Fix recovery supervisor crash-loop: bootstrap sys.path before django.setup()

### DIFF
--- a/lex/lex_app/celery_recovery/entrypoint.py
+++ b/lex/lex_app/celery_recovery/entrypoint.py
@@ -18,12 +18,25 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 
 def main() -> None:
-    # Mirror the lex CLI / celery.py bootstrap: default the settings module if
-    # the operator did not set it, then run django.setup() once.
+    # Mirror the lex CLI bootstrap (see lex/bin/lex.py). The framework's modules
+    # import each other as *top-level* packages (e.g. ``from core.models...``,
+    # ``lex_app.settings``), which only resolves when the inner ``lex/`` package
+    # directory is on sys.path. The lex CLI appends it; launching this console
+    # script goes around the CLI, so we must replicate it here or django.setup()
+    # dies with ``ModuleNotFoundError: No module named 'core'`` while populating
+    # apps. ``parents[2]`` of this file is that inner ``lex/`` directory.
+    package_root = Path(__file__).resolve().parents[2].as_posix()
+    if package_root not in sys.path:
+        sys.path.append(package_root)
+
+    # Default the settings module if the operator did not set it, mirroring the
+    # CLI / celery.py, then run django.setup() once.
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "lex_app.settings")
+    os.environ.setdefault("LEX_APP_PACKAGE_ROOT", package_root)
 
     import django
 


### PR DESCRIPTION
## Summary

The `lex-recovery-supervisor` console script (added in #596) crash-looped in the cluster with `ModuleNotFoundError: No module named 'core'` during `django.setup()`.

## Root cause

The framework's modules import each other as **top-level** packages — e.g. `lex/core/models/__init__.py` does `from core.models.LexModel import ...`, and `DJANGO_SETTINGS_MODULE=lex_app.settings`. That only resolves when the inner `lex/` package directory is on `sys.path`. The `lex` CLI appends it (`lex/bin/lex.py`: `sys.path.append(LEX_APP_PACKAGE_ROOT)`), so worker/backend pods — which boot through the CLI — get it for free.

The console-script entrypoint went around the CLI and called `django.setup()` directly without that append, so app population failed importing `core`. (Not reproducible in an editable dev install, which already has the source root on `sys.path` via a `.pth` — only a clean wheel install in the image exposes it.)

## Fix

Append `parents[2]` of `entrypoint.py` (the inner `lex/` dir) to `sys.path` before `django.setup()`, mirroring the CLI. One file, no behavior change for any other path.

## Note

This was the second of two boot blockers for the supervisor. The first (missing GCS/SharePoint secret volume mounts) is fixed in the infra chart: LEX_TERRAFORM_MODULES#21.

## Test plan

- [x] Verified `django.setup()` completes and `core` resolves with the package root appended
- [ ] Rebuild worker image from this version and confirm `recovery-supervisor-<instance>` boots and logs periodic scan stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)