### PR TITLE
feat(serializers): clearable file fields — file removal was impossible through the REST update path

### DIFF
--- a/lex/api/serializers/base_serializers.py
+++ b/lex/api/serializers/base_serializers.py
@@ -83,6 +83,38 @@ class FilteredListSerializer(serializers.ListSerializer):
         return [r for r in (self.child.to_representation(item) for item in iterable) if r]
 
 
+class LexClearableFileField(serializers.FileField):
+    """FileField that accepts an empty string as an explicit "clear" marker.
+
+    Multipart updates have no way to express file removal otherwise: omitting
+    the key means "keep the current file" (DRF semantics), and DRF's stock
+    FileField rejects ``""`` as "not a file". An empty string maps to Django's
+    empty value for FileField storage, clearing the reference regardless of
+    the column's null-ability. Clearing a required (``blank=False``) file is
+    rejected the same way omitting it on create would be.
+
+    Note: without ``allow_blank`` DRF's ``Field.get_value`` rewrites ``""``
+    from HTML/multipart input into "field omitted" (or ``None`` when
+    ``allow_null=True``) before validation ever runs, so the clear marker
+    would silently degrade to keep-semantics. ``allow_blank = True`` makes
+    ``get_value`` pass the empty string through to ``to_internal_value``.
+    """
+
+    # Let '' survive DRF's HTML-input empty-value rewriting (see docstring).
+    allow_blank = True
+
+    def to_internal_value(self, data):
+        if data == "" or data is None:
+            if self.required:
+                self.fail("required")
+            return ""
+        return super().to_internal_value(data)
+
+
+class LexClearableImageField(LexClearableFileField, serializers.ImageField):
+    """Image variant of :class:`LexClearableFileField` (same clear semantics)."""
+
+
 # --- UPDATED PERMISSION-AWARE BASE SERIALIZER ---
 class LexSerializer(serializers.ModelSerializer):
     """
@@ -91,6 +123,15 @@ class LexSerializer(serializers.ModelSerializer):
     """
     # Define a new field to hold the scopes for each record.
     lex_reserved_scopes = serializers.SerializerMethodField()
+
+    # Map model file fields (and subclasses like PDFField / XLSXField — DRF's
+    # ClassLookupDict walks the MRO) to the clearable variants so multipart
+    # updates can remove a stored file by sending an empty value.
+    serializer_field_mapping = {
+        **serializers.ModelSerializer.serializer_field_mapping,
+        models.FileField: LexClearableFileField,
+        models.ImageField: LexClearableImageField,
+    }
 
     # ------------------------------------------------------------------
     # Per-serializer caches (populated once, reused across all records)

--- a/lex/test_project/test-plan/clusters/12-serializers/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/12-serializers/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 12
 slug: serializers
 title: Serializer Contract
-max_scenario: 38
+max_scenario: 41
 letters:
   a:
     title: Read contract — field visibility & framework-managed fields
@@ -72,3 +72,13 @@ letters:
       xfail: 0
     note: live regression gates — BUG-025 fixed in the same change (explicit 'Z' rendering for
       naive-UTC datetimes on USE_TZ=False targets via REST_FRAMEWORK DATETIME_FORMAT)
+  h:
+    title: Clearing a FileField through the REST update path
+    scenarios: 12.39-12.41
+    status: complete
+    tests:
+      pass: 3
+      skip: 0
+      xfail: 0
+    note: LexClearableFileField/-ImageField — an explicit empty multipart value clears the stored
+      file (omit still keeps, upload still replaces); frontend twin F9 batch 9d sends the marker

--- a/lex/test_project/test-plan/clusters/12-serializers/batches.md
+++ b/lex/test_project/test-plan/clusters/12-serializers/batches.md
@@ -19,3 +19,21 @@
 | Prereqs | none |
 | Status | ✅ Complete — 3 pass / 0 fail (BUG-025 fixed in the same change; markers dropped) |
 | Note | Confirms **BUG-025** (customer tickets 2026-07-13, instance 1409: `edited_at` and log times shifted −2h). Asserts the CORRECT contract — every REST-serialized datetime ends in `Z`/`±HH:MM` — which fails on `USE_TZ=False` targets because naive-UTC values serialize as bare ISO strings that browsers parse as local time. Fixed in the same change — settings.py renders naive-UTC datetimes with an explicit `Z` on `USE_TZ=False` targets (`REST_FRAMEWORK["DATETIME_FORMAT"]`); the batch runs as a live regression gate. |
+
+---
+
+### Batch 12h — Clearing a FileField through the REST update path ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 12.39 – 12.41 |
+| Type | E |
+| Files covered | `api/serializers/base_serializers.py` (`LexClearableFileField`, `LexClearableImageField`, `LexSerializer.serializer_field_mapping`) |
+| Test file | `lex/test_project/tests/serializers/test_12h_filefield_clear.py` |
+| Test classes | `TestCluster12h_FileFieldClear` |
+| Fixtures | new `AttachmentItem` test model (FileField, blank=True) |
+| Est. tests | 3 |
+| Coverage gain | file-field write-path clear/keep/replace semantics |
+| Prereqs | none |
+| Status | ✅ Complete — 3 pass / 0 fail |
+| Note | Customer report 2026-07-13: a file removed in the edit form reappeared after save. Multipart updates had no way to express removal (omit = keep, DRF rejects `""` as "not a file"), so the admin frontend's dropped-null payload silently kept the old file. Model file fields (incl. `PDFField`/`XLSXField` via MRO lookup) now map to clearable variants: explicit empty value → clear (`allow_blank = True` so DRF's HTML-input handling doesn't rewrite `""` into "omitted"); required (`blank=False`) files reject the clear. 12.39 empty value clears; 12.40 omit keeps; 12.41 upload replaces. Frontend twin: process-admin-general-client F9 batch 9d (provider sends the `''` marker for cleared stored files). Ship both halves together. |

--- a/lex/test_project/test-plan/clusters/12-serializers/cluster.md
+++ b/lex/test_project/test-plan/clusters/12-serializers/cluster.md
@@ -111,3 +111,11 @@ cluster-2 models are too shallow; we need a model with one of every
 **Why a regression matters:** `edited_at` and calculation-log times are audit-relevant, customer-facing values; a silent 2-hour shift undermines trust in the whole audit trail.
 
 **Scenario range:** 12.36 – 12.38. **Test file:** `lex/test_project/tests/serializers/test_12g_datetime_tz_ambiguity.py`. **Type:** E. **Status:** ✅ Complete — BUG-025 fixed in the same change (explicit `Z` rendering on `USE_TZ=False` targets); all three run as live regression gates. Scenarios: 12.36 `edited_at` carries a timezone designator; 12.37 `created_at` likewise; 12.38 `CalculationLog.timestamp` likewise.
+
+### 12h. Clearing a FileField through the REST update path ✅
+
+**What it tests:** the three file-field write semantics — an explicit empty multipart value clears the stored file, omitting the key keeps it, uploading replaces it. Before this batch removal was impossible through the API: DRF's stock FileField rejects `""` and omit means keep, so the admin frontend's cleared-file saves silently preserved the old file (customer report 2026-07-13: "removed file gets added again").
+
+**Why a regression matters:** users must be able to remove attachments; a removal that silently un-does itself corrupts the record's document trail.
+
+**Scenario range:** 12.39 – 12.41. **Test file:** `lex/test_project/tests/serializers/test_12h_filefield_clear.py`. **Type:** E. **Status:** ✅ Complete. Scenarios: 12.39 empty value clears; 12.40 omit keeps; 12.41 upload replaces.

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -21,7 +21,7 @@
 | 9. Signals & WebSocket | 6 | 42 | 14 | 0 | 0 |
 | 10. API Layer | 13 | 71 | 21 | 0 | 0 |
 | 11. Stress & Performance | 9 | 22 | 0 | 0 | 0 |
-| 12. Serializer Contract | 7 | 38 | 6 | 0 | 0 |
+| 12. Serializer Contract | 8 | 41 | 9 | 0 | 0 |
 | 13. Export Endpoint | 5 | 30 | 0 | 0 | 0 |
 | 14. AG Grid Query Endpoint | 6 | 33 | 0 | 0 | 0 |
 | 15. Calculation Logging Surface | 7 | 31 | 10 | 0 | 0 |
@@ -231,6 +231,7 @@
 | 12e | Serializer factory contract | 12.26-12.35 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 12f |  | 12.29-12.31 | complete | 3 | 0 | 0 | 12.29–12.31 (`TagItem`/`TaggableItem`/`EditScopedItem` fixtures added April 23 |
 | 12g | Datetime timezone ambiguity (BUG-025, fixed) | 12.36-12.38 | complete | 3 | 0 | 0 | live regression gates — BUG-025 fixed in the same change (explicit 'Z' rendering for naive-UTC datetimes on USE_TZ=False targets via REST_FRAMEWORK DATETIME_FORMAT) |
+| 12h | Clearing a FileField through the REST update path | 12.39-12.41 | complete | 3 | 0 | 0 | LexClearableFileField/-ImageField — an explicit empty multipart value clears the stored file (omit still keeps, upload still replaces); frontend twin F9 batch 9d sends the marker |
 
 ## 13. Export Endpoint (`exports`)
 

--- a/lex/test_project/test-plan/progress/sessions/2026-07-13-filefield-clear.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-07-13-filefield-clear.md
@@ -1,0 +1,22 @@
+---
+date: 2026-07-13
+clusters: [12h]
+tests_added: "3 (12.39–12.41) + source in 2 files (base_serializers + test model)"
+suite_tally: "12h 3 pass / 0 fail; regression: serializers+exports+crud_api+api_layer = 193 pass / 1 xfail / 0 fail"
+---
+
+**Batch 12h landed — clearable file fields (customer report 2026-07-13:
+removing a file from a FileField and saving brings it back).** Root cause is a
+two-sided gap: the admin frontend drops a cleared FileInput's `null` from the
+multipart body, and even if it hadn't, DRF gives multipart clients no way to
+express file removal (omit = keep, `""` = "not a file" validation error) — so
+removal was impossible by construction. Fix: `LexSerializer` now maps model
+file fields (including `PDFField`/`XLSXField` subclasses via DRF's MRO lookup)
+to `LexClearableFileField`/`LexClearableImageField`, which accept an explicit
+empty value as "clear the stored file" (`allow_blank = True` keeps DRF's
+HTML-input handling from rewriting `""` into "omitted"); required
+(`blank=False`) files reject the clear like a missing required field. Omit
+still keeps, upload still replaces (12.40/12.41 pin both). Frontend twin:
+process-admin-general-client F9 batch 9d sends the `''` marker for fields
+whose previous value was a stored file URL — ship both halves together.
+See [batch 12h](../../clusters/12-serializers/batches.md).

--- a/lex/test_project/tests/serializers/models.py
+++ b/lex/test_project/tests/serializers/models.py
@@ -283,6 +283,23 @@ class EditScopedItem(LexModel):
         return True
 
 
+class AttachmentItem(LexModel):
+    """File-bearing model for the clearable-file-field scenarios (12h).
+
+    ``document`` mirrors the common project shape: ``blank=True``,
+    ``null=False`` — Django stores the empty value as ``""``.
+    """
+
+    name = models.CharField(max_length=100)
+    document = models.FileField(upload_to="test_uploads/", blank=True)
+
+    class Meta:
+        app_label = "lex_app"
+
+    def __str__(self) -> str:  # pragma: no cover
+        return self.name
+
+
 ALL_MODELS = [
     RelatedItem,
     WideItem,
@@ -290,6 +307,7 @@ ALL_MODELS = [
     TagItem,
     TaggableItem,
     EditScopedItem,
+    AttachmentItem,
 ]
 
 # URL names expected by ``process_admin_rest_api`` — lowercased model name.
@@ -299,4 +317,5 @@ PROTECTED_WIDE = "protectedwideitem"
 TAG = "tagitem"
 TAGGABLE = "taggableitem"
 EDIT_SCOPED = "editscopeditem"
+ATTACHMENT = "attachmentitem"
 

--- a/lex/test_project/tests/serializers/test_12h_filefield_clear.py
+++ b/lex/test_project/tests/serializers/test_12h_filefield_clear.py
@@ -1,0 +1,132 @@
+"""Cluster 12h — clearing a FileField through the REST update path.
+
+Intent: removing a file from a record must be possible through the API. DRF's
+multipart semantics give a client only two signals — send a file (replace) or
+omit the key (keep) — so file removal was silently impossible: the admin
+frontend dropped the cleared (null) value from the FormData, the backend never
+saw the field, and the "removed" file reappeared after save (customer report
+2026-07-13). The framework now maps model file fields to
+``LexClearableFileField``, which treats an explicit empty value as "clear the
+stored file" while keeping omit-means-keep and upload-means-replace intact.
+Cluster 12h — scenarios 12.39–12.41. Type: E.
+Covers: lex/api/serializers/base_serializers.py (LexClearableFileField,
+        LexClearableImageField, LexSerializer.serializer_field_mapping).
+Run: python -m lex pytest lex/test_project/tests/serializers/test_12h_filefield_clear.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework import status
+
+from lex.test_project.tests._e2e_test_case import E2ETestCase
+
+from .models import ALL_MODELS, ATTACHMENT, AttachmentItem
+
+pytestmark = pytest.mark.serializers
+
+
+class TestCluster12h_FileFieldClear(E2ETestCase):
+    """Cluster 12h: empty value clears, omit keeps, upload replaces."""
+
+    e2e_models = ALL_MODELS
+
+    def _item_with_file(self, name: str = "doc-item") -> AttachmentItem:
+        item = AttachmentItem(name=name)
+        item.document.save(
+            "original.txt", SimpleUploadedFile("original.txt", b"original content"),
+            save=False,
+        )
+        # bulk_create skips save() so no calculation/audit hooks fire — these
+        # scenarios only exercise the serializer write path.
+        AttachmentItem.objects.bulk_create([item])
+        return AttachmentItem.objects.get(name=name)
+
+    def test_12_39_empty_value_clears_the_stored_file(self) -> None:
+        """
+        Scenario 12.39: an explicit empty value on a file field clears it.
+        Given: a record whose FileField holds a stored file
+        When: PUT the record with the file field sent as an empty string
+              (multipart — the only way a form client can express removal)
+        Then: the update succeeds and the stored file reference is gone
+        """
+        item = self._item_with_file()
+        self.assertTrue(bool(item.document), "Precondition: the file must exist.")
+
+        resp = self.client.put(
+            self.url_detail(ATTACHMENT, item.pk),
+            data={"name": item.name, "document": ""},
+            format="multipart",
+        )
+        self.assertEqual(
+            resp.status_code, status.HTTP_200_OK,
+            f"Clearing the file must be a valid update, got {resp.status_code}: "
+            f"{getattr(resp, 'data', None)!r}",
+        )
+        item.refresh_from_db()
+        self.assertFalse(
+            bool(item.document),
+            f"The cleared file must not survive the save — still stores "
+            f"{item.document.name!r}.",
+        )
+
+    def test_12_40_omitting_the_key_keeps_the_stored_file(self) -> None:
+        """
+        Scenario 12.40: omitting the file key preserves the stored file.
+        Given: a record whose FileField holds a stored file
+        When: PUT the record without the file field in the payload
+        Then: the stored file is untouched (DRF omit-means-keep semantics)
+        """
+        item = self._item_with_file(name="keep-item")
+        original_name = item.document.name
+
+        resp = self.client.put(
+            self.url_detail(ATTACHMENT, item.pk),
+            data={"name": "keep-item-renamed"},
+            format="multipart",
+        )
+        self.assertEqual(
+            resp.status_code, status.HTTP_200_OK,
+            f"Update without the file key failed: {resp.status_code}",
+        )
+        item.refresh_from_db()
+        self.assertEqual(
+            item.document.name, original_name,
+            "A payload that omits the file field must not touch the stored file.",
+        )
+        self.assertEqual(
+            item.name, "keep-item-renamed",
+            "The non-file change must still apply.",
+        )
+
+    def test_12_41_uploading_a_new_file_still_replaces(self) -> None:
+        """
+        Scenario 12.41: uploading a file still replaces the stored one.
+        Given: a record whose FileField holds a stored file
+        When: PUT the record with a new file in the payload
+        Then: the field references the new file's content
+        """
+        item = self._item_with_file(name="replace-item")
+
+        resp = self.client.put(
+            self.url_detail(ATTACHMENT, item.pk),
+            data={
+                "name": item.name,
+                "document": SimpleUploadedFile("newer.txt", b"newer content"),
+            },
+            format="multipart",
+        )
+        self.assertEqual(
+            resp.status_code, status.HTTP_200_OK,
+            f"Replacing the file failed: {resp.status_code}",
+        )
+        item.refresh_from_db()
+        self.assertTrue(
+            bool(item.document), "The replacement file must be stored."
+        )
+        with item.document.open("rb") as fh:
+            self.assertEqual(
+                fh.read(), b"newer content",
+                "The stored file must be the newly uploaded one.",
+            )


### PR DESCRIPTION
## What

Backend half of the fix for the customer report (2026-07-13): *removing a file from a FileField in the edit form and saving brings the file back.*

## Root cause

Multipart updates had **no way to express file removal**: omitting the key means "keep the current file" (DRF semantics), and DRF's stock `FileField` rejects `""` as "not a file". The admin frontend additionally dropped the cleared (`null`) value from the FormData — so the backend never heard about the removal and the old file survived every save. Removal was impossible by construction.

## Fix

`LexSerializer` now maps model file fields — including `PDFField` / `XLSXField` subclasses via DRF's MRO-walking field lookup — to new clearable variants:

- **`LexClearableFileField` / `LexClearableImageField`**: an explicit empty value clears the stored file; clearing a required (`blank=False`) file is rejected like a missing required field.
- `allow_blank = True` is load-bearing: without it, DRF's HTML-input handling rewrites `""` into "field omitted" *before validation*, silently degrading the clear back to keep-semantics (caught by the first test run).
- Omit still keeps, upload still replaces — both pinned by tests.

## Tests

Batch **12h** (scenarios 12.39–12.41, type E, new `AttachmentItem` test model): empty value clears / omit keeps / upload replaces — 3 pass. Regression across serializers, exports, crud_api, api_layer: **193 pass / 1 pre-existing xfail / 0 fail**. Plan shards, session fragment, and dashboard synced (`validate` OK).

## Companion PR

Frontend twin: process-admin-general-client — the data provider now sends the explicit `''` marker for cleared stored-file fields (F9 batch 9d, BUG-F-021). **The two halves should ship together**: the marker without this field is a validation error; this field without the marker never receives a clear. (Graceful degradation either way — worst case is the current keep-behavior — but the bug is only fixed with both.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
