### PR TITLE
feat(serializers): FK display names in the read contract (batch 12i)

### DIFF
--- a/lex/api/serializers/base_serializers.py
+++ b/lex/api/serializers/base_serializers.py
@@ -71,6 +71,54 @@ def _get_capabilities(model_class: type) -> dict:
     return caps
 
 
+# --- FOREIGN-KEY DISPLAY-NAME HELPERS ---
+# The list/detail serializers emit a foreign key as its raw primary-key id
+# (DRF's default for ``fields = "__all__"``). That id is what filtering and
+# editing need, so it stays untouched — but a grid rendering a bare "79" in a
+# "Fund" column is useless to a customer. These helpers add an *additive*
+# companion key ``<fk>__short_description`` carrying ``str(related)`` (the model
+# author's ``__str__``/short_description — the documented customization point),
+# mirroring the resolution ModelExport already does for exported files
+# (``_apply_foreign_key_display_names``). Purely additive: the raw id column is
+# never replaced, so nothing that reads the id breaks.
+
+# Cache: model_class -> [(fk_field_name, remote_model), …] for single-valued
+# relations only. Reverse relations and many-to-many are excluded (DRF doesn't
+# emit reverse rels under these names, and an M2M value is a list, not one id —
+# ModelExport leaves those unresolved too).
+_fk_display_fields_cache: dict = {}
+
+
+def _get_fk_display_fields(model) -> list:
+    """Return cached ``[(field_name, remote_model), …]`` for a model's
+    single-valued foreign keys (FK / OneToOne). Best-effort — an unresolvable
+    model yields an empty list rather than raising."""
+    cached = _fk_display_fields_cache.get(model)
+    if cached is not None:
+        return cached
+    fields = []
+    try:
+        # Lazy import: avoids a settings-time circular import between the
+        # serializer layer and process_admin.models (which pulls in core models).
+        from lex.process_admin.models.utils import get_relation_fields
+        for field in get_relation_fields(model):
+            if getattr(field, "many_to_many", False):
+                continue
+            remote_model = getattr(getattr(field, "remote_field", None), "model", None)
+            name = getattr(field, "name", None)
+            if remote_model is not None and isinstance(name, str) and name:
+                fields.append((name, remote_model))
+    except Exception:
+        fields = []
+    _fk_display_fields_cache[model] = fields
+    return fields
+
+
+def _fk_display_key(field_name: str) -> str:
+    """Companion key carrying the resolved display name for a FK column."""
+    return f"{field_name}__{SHORT_DESCR_NAME}"
+
+
 # --- NEW FILTERING LIST SERIALIZER ---
 class FilteredListSerializer(serializers.ListSerializer):
     """
@@ -80,7 +128,83 @@ class FilteredListSerializer(serializers.ListSerializer):
 
     def to_representation(self, data):
         iterable = data.all() if isinstance(data, models.Manager) else data
-        return [r for r in (self.child.to_representation(item) for item in iterable) if r]
+        child = self.child
+        # Suppress the child's per-instance FK name resolution while building
+        # the list — we resolve names in a single batched query per FK below
+        # (one query per FK field, not one per row) to stay N-safe.
+        prev_skip = getattr(child, "_skip_fk_display_names", False)
+        child._skip_fk_display_names = True
+        try:
+            representations = [
+                r for r in (child.to_representation(item) for item in iterable) if r
+            ]
+        finally:
+            child._skip_fk_display_names = prev_skip
+        self._batch_add_fk_display_names(representations)
+        return representations
+
+    def _batch_add_fk_display_names(self, representations: list) -> None:
+        """Add ``<fk>__short_description`` to every row, resolving each FK's
+        display names in ONE ``pk__in`` query (mirrors
+        ``ModelExport._apply_foreign_key_display_names``). Best-effort: on any
+        failure the raw ids are left in place rather than breaking the response.
+        The key is emitted whenever the raw FK column is present (``None`` when
+        the FK is null) so the list row shape stays stable row-to-row."""
+        if not representations:
+            return
+        try:
+            model = getattr(getattr(self.child, "Meta", None), "model", None)
+            if model is None:
+                return
+            for field_name, remote_model in _get_fk_display_fields(model):
+                display_key = _fk_display_key(field_name)
+                # Collect only the pks actually present on this page.
+                referenced_pks = set()
+                column_present = False
+                for rep in representations:
+                    if field_name not in rep:
+                        continue
+                    column_present = True
+                    val = rep.get(field_name)
+                    if val is not None and not isinstance(val, (list, tuple, set, dict)):
+                        referenced_pks.add(val)
+                if not column_present:
+                    continue
+
+                names = _resolve_fk_names(remote_model, referenced_pks)
+                for rep in representations:
+                    if field_name not in rep:
+                        continue
+                    val = rep.get(field_name)
+                    if val is None or isinstance(val, (list, tuple, set, dict)):
+                        rep[display_key] = None
+                    else:
+                        rep[display_key] = names.get(val, names.get(str(val)))
+        except Exception:
+            pass
+
+
+def _resolve_fk_names(remote_model, referenced_pks) -> dict:
+    """Build ``{pk: str(obj), str(pk): str(obj)}`` for the referenced pks with a
+    single query (mirrors ModelExport). Falls back to a bounded scan only if the
+    pks are of mixed/incoercible types."""
+    names: dict = {}
+    if not referenced_pks:
+        return names
+    try:
+        related_iter = remote_model.objects.filter(pk__in=referenced_pks).iterator(
+            chunk_size=2000
+        )
+        for item in related_iter:
+            readable = str(item)
+            names[item.pk] = readable
+            names[str(item.pk)] = readable
+    except (TypeError, ValueError):
+        for item in remote_model.objects.all().iterator(chunk_size=2000):
+            readable = str(item)
+            names[item.pk] = readable
+            names[str(item.pk)] = readable
+    return names
 
 
 class LexClearableFileField(serializers.FileField):
@@ -651,7 +775,35 @@ class LexSerializer(serializers.ModelSerializer):
         except Exception:
             pass
 
+        # Add FK display-name companions (<fk>__short_description) for the
+        # detail / single-object path. During list serialization this is
+        # suppressed (FilteredListSerializer batches it in one query per FK);
+        # for a single object one query per FK is fine.
+        if not getattr(self, "_skip_fk_display_names", False):
+            self._add_fk_display_names_single(representation)
+
         return representation
+
+    def _add_fk_display_names_single(self, representation: dict) -> None:
+        """Per-instance twin of ``FilteredListSerializer._batch_add_fk_display_names``.
+        Emits ``<fk>__short_description`` for each single-valued FK present in the
+        representation so the detail shape matches the list shape. Best-effort."""
+        try:
+            model = getattr(getattr(self, "Meta", None), "model", None)
+            if model is None:
+                return
+            for field_name, remote_model in _get_fk_display_fields(model):
+                if field_name not in representation:
+                    continue
+                display_key = _fk_display_key(field_name)
+                val = representation.get(field_name)
+                if val is None or isinstance(val, (list, tuple, set, dict)):
+                    representation[display_key] = None
+                    continue
+                names = _resolve_fk_names(remote_model, {val})
+                representation[display_key] = names.get(val, names.get(str(val)))
+        except Exception:
+            pass
 
 
 # --- UPDATED BASE TEMPLATE ---

--- a/lex/test_project/test-plan/clusters/12-serializers/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/12-serializers/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 12
 slug: serializers
 title: Serializer Contract
-max_scenario: 41
+max_scenario: 45
 letters:
   a:
     title: Read contract — field visibility & framework-managed fields
@@ -82,3 +82,16 @@ letters:
       xfail: 0
     note: LexClearableFileField/-ImageField — an explicit empty multipart value clears the stored
       file (omit still keeps, upload still replaces); frontend twin F9 batch 9d sends the marker
+  i:
+    title: Foreign-key display names in the read contract (BUG-F-003 backend fix)
+    scenarios: 12.42-12.45
+    status: complete
+    tests:
+      pass: 4
+      skip: 0
+      xfail: 0
+    note: additive companion `<fk>__short_description` = str(related) emitted alongside the raw FK id
+      on both list and detail paths; list resolves names in one batched pk__in query per FK (mirrors
+      ModelExport._apply_foreign_key_display_names), detail resolves per-instance; raw id untouched so
+      filtering/editing unaffected; null FK → null companion. Resolves the backend root cause of
+      frontend BUG-F-003 (FK columns rendered as bare ids)

--- a/lex/test_project/test-plan/clusters/12-serializers/batches.md
+++ b/lex/test_project/test-plan/clusters/12-serializers/batches.md
@@ -37,3 +37,21 @@
 | Prereqs | none |
 | Status | ✅ Complete — 3 pass / 0 fail |
 | Note | Customer report 2026-07-13: a file removed in the edit form reappeared after save. Multipart updates had no way to express removal (omit = keep, DRF rejects `""` as "not a file"), so the admin frontend's dropped-null payload silently kept the old file. Model file fields (incl. `PDFField`/`XLSXField` via MRO lookup) now map to clearable variants: explicit empty value → clear (`allow_blank = True` so DRF's HTML-input handling doesn't rewrite `""` into "omitted"); required (`blank=False`) files reject the clear. 12.39 empty value clears; 12.40 omit keeps; 12.41 upload replaces. Frontend twin: process-admin-general-client F9 batch 9d (provider sends the `''` marker for cleared stored files). Ship both halves together. |
+
+---
+
+### Batch 12i — Foreign-key display names in the read contract ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 12.42 – 12.45 |
+| Type | E |
+| Files covered | `api/serializers/base_serializers.py` (`FilteredListSerializer._batch_add_fk_display_names`, `LexSerializer._add_fk_display_names_single`, `_get_fk_display_fields`/`_resolve_fk_names` helpers) |
+| Test file | `lex/test_project/tests/serializers/test_12i_fk_display_names.py` |
+| Test classes | `TestCluster12i_ForeignKeyDisplayNames` |
+| Fixtures | reuse cluster-12 `WideItem` (nullable FK `related` → `RelatedItem`, custom `__str__`) |
+| Est. tests | 4 |
+| Coverage gain | FK read-contract enrichment (list + detail parity, batch N-safety) |
+| Prereqs | none |
+| Status | ✅ Complete — 4 pass / 0 fail |
+| Note | Resolves the **backend root cause of frontend BUG-F-003** (FK columns render as bare ids like `79`). Every serialized row now carries an **additive** companion key `<fk>__short_description` = `str(related)` (the model author's `__str__`/`short_description` — the documented customization point) alongside the untouched raw id, so filtering/editing on the id are unaffected. The list path resolves the whole page's names in **one `pk__in` query per FK** (mirrors `ModelExport._apply_foreign_key_display_names`); the detail path resolves per-instance (one query, fine) so list-row shape ⊆ detail shape (the 12c invariant holds). Null FK → null companion (stable row shape). Permission-hidden FK columns get no companion (the key is emitted only when the raw column survived visibility filtering). Frontend twin: the grid/detail render the companion instead of the raw id (F3/F9.6). |

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -21,7 +21,7 @@
 | 9. Signals & WebSocket | 6 | 42 | 14 | 0 | 0 |
 | 10. API Layer | 13 | 71 | 21 | 0 | 0 |
 | 11. Stress & Performance | 9 | 22 | 0 | 0 | 0 |
-| 12. Serializer Contract | 8 | 41 | 9 | 0 | 0 |
+| 12. Serializer Contract | 9 | 45 | 13 | 0 | 0 |
 | 13. Export Endpoint | 5 | 30 | 0 | 0 | 0 |
 | 14. AG Grid Query Endpoint | 6 | 33 | 0 | 0 | 0 |
 | 15. Calculation Logging Surface | 7 | 31 | 10 | 0 | 0 |
@@ -232,6 +232,7 @@
 | 12f |  | 12.29-12.31 | complete | 3 | 0 | 0 | 12.29–12.31 (`TagItem`/`TaggableItem`/`EditScopedItem` fixtures added April 23 |
 | 12g | Datetime timezone ambiguity (BUG-025, fixed) | 12.36-12.38 | complete | 3 | 0 | 0 | live regression gates — BUG-025 fixed in the same change (explicit 'Z' rendering for naive-UTC datetimes on USE_TZ=False targets via REST_FRAMEWORK DATETIME_FORMAT) |
 | 12h | Clearing a FileField through the REST update path | 12.39-12.41 | complete | 3 | 0 | 0 | LexClearableFileField/-ImageField — an explicit empty multipart value clears the stored file (omit still keeps, upload still replaces); frontend twin F9 batch 9d sends the marker |
+| 12i | Foreign-key display names in the read contract (BUG-F-003 backend fix) | 12.42-12.45 | complete | 4 | 0 | 0 | additive companion `<fk>__short_description` = str(related) emitted alongside the raw FK id on both list and detail paths; list resolves names in one batched pk__in query per FK (mirrors ModelExport._apply_foreign_key_display_names), detail resolves per-instance; raw id untouched so filtering/editing unaffected; null FK → null companion. Resolves the backend root cause of frontend BUG-F-003 (FK columns rendered as bare ids) |
 
 ## 13. Export Endpoint (`exports`)
 

--- a/lex/test_project/test-plan/progress/sessions/2026-07-14-fk-display-names.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-07-14-fk-display-names.md
@@ -1,0 +1,39 @@
+---
+date: 2026-07-14
+clusters: [12i]
+tests_added: "4 (12.42–12.45) + source in 1 file (base_serializers)"
+suite_tally: "12i 4 pass / 0 fail; regression: serializers+crud_api+queries+exports+audit_logging+permissions+journeys+api_layer+history = 754 pass / 2 xfail / 3 skip / 0 fail"
+---
+
+**Batch 12i landed — foreign-key display names in the read contract (backend
+root cause of frontend BUG-F-003: FK columns render as bare ids like `79`).**
+A foreign key serializes as its raw pk (DRF's default for `fields="__all__"`),
+which the customer sees as a meaningless number where they expect a name. Fix:
+every serialized row now carries an **additive** companion key
+`<fk>__short_description` = `str(related)` — the model author's
+`__str__`/`short_description`, i.e. the documented customization point — next to
+the **untouched** raw id, so anything that filters or edits on the id keeps
+working.
+
+Two paths, one contract:
+- **List** — `FilteredListSerializer._batch_add_fk_display_names` resolves the
+  whole page's names in **one `pk__in` query per FK field** (mirrors
+  `ModelExport._apply_foreign_key_display_names`), suppressing the per-instance
+  path so it stays N-safe.
+- **Detail** — `LexSerializer._add_fk_display_names_single` resolves per
+  instance (one query, fine for a single object), so **list-row shape ⊆ detail
+  shape** (the 12c invariant holds — no contract drift).
+
+Null FK → null companion (row shape stays stable row-to-row). The companion is
+emitted only when the raw FK column survived visibility filtering, so a
+permission-hidden FK leaks no name. Best-effort throughout: any resolution
+failure leaves the raw ids in place rather than breaking the response.
+
+12.42 list row carries the companion = `str(related)`; 12.43 the label honors a
+custom `__str__` (not the id/field name); 12.44 raw id preserved **and** detail
+carries the same companion; 12.45 null FK → null companion + query count does
+not scale with row count (3-row vs 9-row page, equal FK-target query count).
+
+Frontend twin: the grid and detail views render `<fk>__short_description`
+instead of the bare id (F3 / F9.6). See
+[batch 12i](../../clusters/12-serializers/batches.md).

--- a/lex/test_project/tests/serializers/test_12i_fk_display_names.py
+++ b/lex/test_project/tests/serializers/test_12i_fk_display_names.py
@@ -1,0 +1,207 @@
+"""
+Cluster 12i: Foreign-key display names in the read contract.
+
+Intent (BUG-F-003): a foreign key is emitted as its raw primary-key id
+(``related: 79``). That id is what filtering and editing need, so it must stay
+— but a customer looking at a grid sees a bare number where they expect a name.
+The serializer's job is to *also* hand the frontend the human-readable label so
+the grid can show "Alpha Fund" instead of "79", WITHOUT the frontend having to
+issue a second round-trip per cell.
+
+The contract this pins:
+
+* every serialized row carries an additive companion key
+  ``<fk>__short_description`` alongside the raw ``<fk>`` id;
+* its value is ``str(related)`` — the model author's ``__str__`` /
+  ``short_description``, which is the documented customization point (so a
+  project that wants a different label just overrides ``__str__``);
+* the raw id is left **unchanged** (nothing that filters/edits on the id breaks);
+* a null FK yields a null companion (present, ``None``) so the row shape is
+  stable row-to-row;
+* the whole page's names are resolved in ONE query per FK field — no N+1.
+
+This mirrors, on the read path, the resolution ``ModelExport`` already performs
+for exported files (``_apply_foreign_key_display_names``): same ``pk__in`` batch,
+same ``str(obj)`` source of truth. It is the frontend twin of F9.6 / F3 (FK
+columns showing display names).
+
+Golden Rule: we assert the customer-visible outcome (the name is available and
+correct, the id still works), not the serializer's internal field wiring.
+
+Scenario numbering: 12.42–12.45.
+
+Run:
+    lex test lex.test_project.tests.serializers.test_12i_fk_display_names \
+        --verbosity=2 --noinput --keepdb
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from rest_framework import status
+
+from lex.test_project.tests._e2e_test_case import E2ETestCase
+
+from .models import ALL_MODELS, RELATED, WIDE, RelatedItem, WideItem
+
+import pytest
+
+pytestmark = pytest.mark.serializers
+
+# The companion key the frontend reads to render the FK's label.
+FK_FIELD = "related"
+FK_DISPLAY_KEY = "related__short_description"
+
+
+def _relateditem_query_count(captured: CaptureQueriesContext) -> int:
+    """Number of captured SQL statements that touch the RelatedItem table.
+
+    RelatedItem is only ever loaded to resolve the FK display name, so this
+    count is exactly the FK-resolution query count for the request.
+    """
+    return sum(
+        1 for q in captured.captured_queries if "relateditem" in q["sql"].lower()
+    )
+
+
+class TestCluster12i_ForeignKeyDisplayNames(E2ETestCase):
+    """GET list / detail — foreign keys carry a human-readable companion."""
+
+    e2e_models = ALL_MODELS
+
+    # -- 12.42 ---------------------------------------------------------
+    def test_12_42_list_row_carries_fk_display_name(self) -> None:
+        """Scenario 12.42: each list row exposes ``<fk>__short_description``
+        equal to ``str(related)`` for its FK, alongside the raw id.
+
+        This is the fix's headline: the grid can render the FK's name from the
+        list payload alone, no per-cell fetch.
+        """
+        fund = RelatedItem.objects.create(name="Alpha Fund")
+        WideItem.objects.create(name="row-A", related=fund)
+
+        resp = self.list_get(WIDE)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        rows = self.extract_results(resp.data)
+
+        row = next(r for r in rows if r.get("name") == "row-A")
+        self.assertIn(
+            FK_DISPLAY_KEY, row,
+            f"FK display companion missing from list row. Keys: {sorted(row)}",
+        )
+        self.assertEqual(
+            row[FK_DISPLAY_KEY], str(fund),
+            "FK companion must equal str(related) — the model's display label.",
+        )
+
+    # -- 12.43 ---------------------------------------------------------
+    def test_12_43_display_name_honors_custom_str(self) -> None:
+        """Scenario 12.43: the label comes from the related model's ``__str__``
+        (the customization point), not from the id or the field name.
+
+        ``RelatedItem.__str__`` returns ``self.name``; a project overriding
+        ``__str__`` is exactly how a customer changes what the grid shows.
+        """
+        fund = RelatedItem.objects.create(name="Distinctive-Label-42")
+        WideItem.objects.create(name="row-str", related=fund)
+
+        resp = self.list_get(WIDE)
+        rows = self.extract_results(resp.data)
+        row = next(r for r in rows if r.get("name") == "row-str")
+
+        self.assertEqual(row[FK_DISPLAY_KEY], "Distinctive-Label-42")
+        # And it is genuinely the __str__ output, not the repr / id / pk-string.
+        self.assertEqual(row[FK_DISPLAY_KEY], str(fund))
+        self.assertNotEqual(row[FK_DISPLAY_KEY], str(fund.pk))
+
+    # -- 12.44 ---------------------------------------------------------
+    def test_12_44_raw_id_preserved_and_detail_matches_list(self) -> None:
+        """Scenario 12.44: the raw FK id is untouched (filtering/editing keep
+        working) and the detail shape carries the same companion as the list
+        (no list-vs-detail contract drift — the 12c invariant).
+        """
+        fund = RelatedItem.objects.create(name="Beta Fund")
+        item = WideItem.objects.create(name="row-id", related=fund)
+
+        # List: raw id preserved + companion present.
+        list_resp = self.list_get(WIDE)
+        list_row = next(
+            r for r in self.extract_results(list_resp.data) if r.get("name") == "row-id"
+        )
+        self.assertEqual(
+            list_row[FK_FIELD], fund.pk,
+            "Raw FK id must be preserved unchanged for filtering/editing.",
+        )
+        self.assertEqual(list_row[FK_DISPLAY_KEY], str(fund))
+
+        # Detail: same two keys, same values (list row shape ⊆ detail shape).
+        detail_resp = self.client.get(self.url_detail(WIDE, item.pk))
+        self.assertEqual(detail_resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(detail_resp.data[FK_FIELD], fund.pk)
+        self.assertEqual(detail_resp.data[FK_DISPLAY_KEY], str(fund))
+        self.assertLessEqual(
+            set(list_row.keys()), set(detail_resp.data.keys()),
+            "List row carries a key absent from detail — contract drift.",
+        )
+
+    # -- 12.45 ---------------------------------------------------------
+    def test_12_45_null_fk_and_no_n_plus_one(self) -> None:
+        """Scenario 12.45: a null FK yields a null companion (present, no crash),
+        and display-name resolution does NOT scale with the row count.
+
+        N-safety is the reason the batch lives on the list serializer: a naive
+        per-row ``str(self.related)`` would issue one RelatedItem query per row,
+        so the query count against the FK target would grow with distinct FKs.
+        We prove it doesn't by measuring a small page and a larger page (each row
+        a DISTINCT RelatedItem) and asserting the FK-target query count is equal
+        — the batch adds a fixed cost regardless of N.
+        """
+        # Null-FK row first: companion must be present and None (stable shape).
+        WideItem.objects.create(name="row-null", related=None)
+        for i in range(2):
+            fund = RelatedItem.objects.create(name=f"Fund-{i}")
+            WideItem.objects.create(name=f"row-{i}", related=fund)
+
+        with CaptureQueriesContext(connection) as small:
+            resp_small = self.list_get(WIDE)
+        self.assertEqual(resp_small.status_code, status.HTTP_200_OK)
+        rows_small = self.extract_results(resp_small.data)
+        count_small = _relateditem_query_count(small)
+
+        # Null FK → companion present, value None.
+        null_row = next(r for r in rows_small if r.get("name") == "row-null")
+        self.assertIn(FK_DISPLAY_KEY, null_row, "Companion key must exist even for a null FK.")
+        self.assertIsNone(null_row[FK_DISPLAY_KEY])
+        self.assertIsNone(null_row[FK_FIELD])
+
+        # Grow the page: 6 more rows, each a DISTINCT RelatedItem.
+        for i in range(2, 8):
+            fund = RelatedItem.objects.create(name=f"Fund-{i}")
+            WideItem.objects.create(name=f"row-{i}", related=fund)
+
+        with CaptureQueriesContext(connection) as large:
+            resp_large = self.list_get(WIDE)
+        self.assertEqual(resp_large.status_code, status.HTTP_200_OK)
+        rows_large = self.extract_results(resp_large.data)
+        count_large = _relateditem_query_count(large)
+
+        # Every populated row resolved correctly on the larger page.
+        for i in range(8):
+            row = next(r for r in rows_large if r.get("name") == f"row-{i}")
+            self.assertEqual(row[FK_DISPLAY_KEY], f"Fund-{i}")
+
+        # The FK-target query count did NOT grow with 4× the distinct FKs — the
+        # resolution is batched, not per-row.
+        self.assertEqual(
+            count_small, count_large,
+            f"FK display-name resolution scales with row count "
+            f"(3 rows → {count_small} queries, 9 rows → {count_large}); "
+            f"it must be a fixed per-page cost.",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## What & why

Resolves the **backend root cause of frontend BUG-F-003**: a foreign key serializes as its raw pk (DRF default for `fields="__all__"`), so the grid renders a bare number where the customer expects a name.

Every serialized row now carries an **additive** companion key `<fk>__short_description` = `str(related)` — the model author's `__str__`/`short_description` (the documented customization point) — alongside the **untouched** raw id, so anything that filters or edits on the id keeps working.

## How

- **List path** — `FilteredListSerializer._batch_add_fk_display_names` resolves the whole page's names in **one `pk__in` query per FK field** (mirrors `ModelExport._apply_foreign_key_display_names`), suppressing the per-instance path to stay N-safe.
- **Detail path** — `LexSerializer._add_fk_display_names_single` resolves per instance (one query), so **list-row shape ⊆ detail shape** (the cluster-12c invariant holds).
- Null FK → null companion (stable row shape). Companion emitted only when the raw FK column survived visibility filtering, so permission-hidden FKs leak no name. Best-effort: any resolution failure leaves raw ids in place.

The `__` suffix is collision-safe: Django field names can't contain `__` (the ORM lookup separator), so the companion can never shadow a real model field.

## Tests — cluster 12i (E-tier, 4 pass)

`lex/test_project/tests/serializers/test_12i_fk_display_names.py`

- **12.42** list row carries `<fk>__short_description` = `str(related)`
- **12.43** honors the related model's custom `__str__` (the customization point)
- **12.44** raw id preserved unchanged + detail parity (list ⊆ detail)
- **12.45** null FK → null companion + query count does **not** scale with row count (no N+1)

Regression: serializers + crud_api + queries + exports + audit + permissions + journeys + api_layer + history = **754 pass / 2 xfail / 3 skip / 0 fail**.

## Paired frontend change

The frontend half (render the companion instead of the raw id) is on `process-admin-general-client` PR #442 (batch F3e). The frontend falls back to the raw id when the companion is absent, so deploy order is flexible. Once this ships in a lex-app release, the frontend's E-tier gate F3.3 flips from `test.fail` to a live regression gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)