### PR TITLE
fix(calclog): PDF export renders like the log view (batch 15h)

### DIFF
--- a/lex/api/views/calculations/DownloadMarkdownPdf.py
+++ b/lex/api/views/calculations/DownloadMarkdownPdf.py
@@ -1,11 +1,136 @@
 import io
+import logging
 
 import markdown2
 from django.http import HttpResponse
 from lex.audit_logging.models.CalculationLog import CalculationLog
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
-from xhtml2pdf import pisa
+
+logger = logging.getLogger(__name__)
+
+# Markdown extras chosen to match what the frontend log view renders
+# (markdown-it, default preset): tables, fenced code blocks, and
+# strikethrough. Deliberately NOT "code-friendly" — that extra disables
+# ``__bold__`` intra-word emphasis, which the log view DOES render, so the
+# PDF would silently diverge from the on-screen log.
+MARKDOWN_EXTRAS = ["tables", "fenced-code-blocks", "strike"]
+
+# GitHub-style stylesheet mirroring the frontend calculation-log view
+# (CalculationLogDialog / CalculationLogTree): sans-serif body, bordered
+# headings, shaded monospace code blocks, bordered tables with a tinted
+# header row, and a left-rail blockquote. ``pre-wrap`` keeps long log lines
+# on the page instead of overflowing the sheet.
+PDF_STYLESHEET = """
+@page {
+  size: A4;
+  margin: 18mm 16mm;
+}
+body {
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 10.5pt;
+  line-height: 1.55;
+  color: #24292f;
+}
+h1, h2, h3, h4, h5, h6 {
+  color: #1f2328;
+  border-bottom: 1px solid #d0d7de;
+  padding-bottom: 0.3em;
+  margin-top: 20px;
+  margin-bottom: 12px;
+  page-break-after: avoid;
+}
+h1 { font-size: 17pt; }
+h2 { font-size: 14pt; }
+h3 { font-size: 12pt; }
+p { margin: 0 0 8px 0; }
+ul, ol { padding-left: 2em; margin: 0 0 8px 0; }
+li { margin: 2px 0; }
+a { color: #0969da; text-decoration: underline; }
+img { max-width: 100%; }
+blockquote {
+  color: #656d76;
+  border-left: 3px solid #d0d7de;
+  padding: 0 1em;
+  margin: 8px 0;
+}
+pre {
+  background-color: #f6f8fa;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  padding: 10px;
+  font-family: Courier, monospace;
+  font-size: 9pt;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  page-break-inside: avoid;
+}
+code {
+  background-color: #eff1f3;
+  padding: 0.15em 0.35em;
+  border-radius: 4px;
+  font-family: Courier, monospace;
+  font-size: 9pt;
+}
+pre code { background-color: transparent; padding: 0; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 10px 0;
+  page-break-inside: auto;
+}
+th, td {
+  border: 1px solid #d0d7de;
+  padding: 5px 9px;
+  text-align: left;
+  font-size: 9.5pt;
+}
+th { background-color: #f6f8fa; font-weight: bold; }
+tr { page-break-inside: avoid; }
+del { color: #656d76; }
+hr { border: none; border-top: 1px solid #d0d7de; margin: 14px 0; }
+"""
+
+
+def render_markdown_to_html(md_text: str) -> str:
+    """Markdown → HTML with the same feature surface the log view renders."""
+    return markdown2.markdown(md_text or "", extras=MARKDOWN_EXTRAS)
+
+
+def build_document_html(md_text: str) -> str:
+    """Full printable HTML document for a calculation log."""
+    return (
+        '<!DOCTYPE html><html><head><meta charset="utf-8">'
+        f"<style>{PDF_STYLESHEET}</style></head>"
+        f"<body>{render_markdown_to_html(md_text)}</body></html>"
+    )
+
+
+def render_pdf_bytes(full_html: str) -> bytes:
+    """Render HTML → PDF.
+
+    WeasyPrint first (near-browser CSS fidelity — the PDF matches the
+    on-screen log view); if it is unavailable or fails at runtime (its
+    system libraries — pango/cairo — are not guaranteed on every target),
+    fall back to xhtml2pdf so the endpoint keeps working with reduced
+    styling rather than 500ing.
+    """
+    try:
+        import weasyprint
+
+        return weasyprint.HTML(string=full_html).write_pdf()
+    except Exception:
+        logger.warning(
+            "WeasyPrint unavailable or failed; falling back to xhtml2pdf",
+            exc_info=True,
+        )
+        from xhtml2pdf import pisa
+
+        result = io.BytesIO()
+        status = pisa.CreatePDF(src=full_html, dest=result)
+        if status.err:
+            raise RuntimeError("xhtml2pdf failed to render the document")
+        return result.getvalue()
 
 
 class DownloadMarkdownPdf(APIView):
@@ -13,49 +138,15 @@ class DownloadMarkdownPdf(APIView):
 
     def get(self, request, pk, format=None):
         obj = CalculationLog.objects.filter(pk=pk).first()
-        md_text = obj.calculation_log or ""
+        md_text = (obj.calculation_log if obj else "") or ""
 
-        # Convert Markdown → HTML (with table support)
-        html_body = markdown2.markdown(
-            md_text,
-            extras=["tables", "fenced-code-blocks", "code-friendly"]
-        )
-
-        # Wrap in full HTML + CSS
-        full_html = f"""
-        <!DOCTYPE html>
-        <html>
-        <head>
-          <meta charset="utf-8">
-          <style>
-            table {{
-              width: 100%;
-              border-collapse: collapse;
-              margin: 1em 0;
-            }}
-            th, td {{
-              border: 1px solid #000;
-              padding: 4px;
-              text-align: left;
-            }}
-            th {{
-              background-color: #f2f2f2;
-            }}
-          </style>
-        </head>
-        <body>
-          {html_body}
-        </body>
-        </html>
-        """
-
-        result = io.BytesIO()
-        pisa_status = pisa.CreatePDF(src=full_html, dest=result)
-
-        if pisa_status.err:
+        full_html = build_document_html(md_text)
+        try:
+            pdf_bytes = render_pdf_bytes(full_html)
+        except Exception:
+            logger.exception("Calculation-log PDF rendering failed for pk=%s", pk)
             return HttpResponse("Error generating PDF", status=500)
 
-        result.seek(0)
-        resp = HttpResponse(result.read(), content_type='application/pdf')
-        resp['Content-Disposition'] = f'attachment; filename="document_{pk}.pdf"'
+        resp = HttpResponse(pdf_bytes, content_type="application/pdf")
+        resp["Content-Disposition"] = f'attachment; filename="document_{pk}.pdf"'
         return resp

--- a/lex/test_project/test-plan/clusters/15-calculation_logging/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/15-calculation_logging/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 15
 slug: calculation_logging
 title: Calculation Logging Surface
-max_scenario: 31
+max_scenario: 34
 letters:
   a:
     title: LexLogger builder API and content shape
@@ -68,3 +68,17 @@ letters:
       xfail: 0
     note: model_logging_context("...") heading frames — lazy row creation, heading chains, node
       reuse, routing/root records skip headings, __str__ tree titles
+  h:
+    title: PDF export renders like the log view
+    scenarios: 15.32-15.34
+    status: complete
+    tests:
+      pass: 3
+      skip: 0
+      xfail: 0
+    note: customer report 2026-07-14 — the Download-PDF of a calculation log lost markdown structure.
+      DownloadMarkdownPdf now renders via WeasyPrint (already a declared dep; xhtml2pdf kept as runtime
+      fallback) with a GitHub-style stylesheet mirroring the frontend log view, and the markdown extras
+      match the log view's parser surface (tables, fenced code, strike; dropped code-friendly which
+      silently disabled __bold__). Contract pinned; anything the log view renders appears rendered in
+      the PDF — never as raw markdown syntax

--- a/lex/test_project/test-plan/clusters/15-calculation_logging/batches.md
+++ b/lex/test_project/test-plan/clusters/15-calculation_logging/batches.md
@@ -19,3 +19,21 @@
 | Prereqs | none |
 | Status | ✅ Complete — 10 pass / 0 fail |
 | Note | Feature batch for `feat/calclog-heading-context`: `model_logging_context("Section title")` pushes a `LogHeading` frame producing a table-of-contents style node — a `CalculationLog` row with `heading` set and `content_type`/`object_id` NULL, created lazily on the first LexLogger flush inside the block. Design: `docs/superpowers/specs/2026-07-07-calclog-heading-context-design.md`. Companion batch 6q covers root-detection transparency. |
+
+---
+
+### Batch 15h — PDF export renders like the log view ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 15.32 – 15.34 |
+| Type | E |
+| Files covered | `api/views/calculations/DownloadMarkdownPdf.py` |
+| Test file | `lex/test_project/tests/calculation_logging/test_15h_pdf_export.py` |
+| Test classes | `TestCluster15h_PdfExport` |
+| Fixtures | plain `CalculationLog` rows (all fields defaulted) |
+| Est. tests | 3 |
+| Coverage gain | calc-log PDF export contract (render parity with the log view) |
+| Prereqs | none (pypdf available in the test venv for text extraction) |
+| Status | ✅ Complete — 3 pass / 0 fail |
+| Note | Customer report 2026-07-14: the exported PDF "doesn't look like the log view — markdown is not being rendered correctly". Root causes: (1) xhtml2pdf's minimal CSS support + a bare-bones stylesheet, (2) the `code-friendly` markdown2 extra silently DISABLED `__bold__` (which the log view's markdown-it renders), and `~~strike~~` was never enabled. Fix: render via **WeasyPrint** (near-browser CSS fidelity; already in requirements.txt) with a GitHub-style stylesheet mirroring the frontend log view (bordered headings, shaded code blocks with pre-wrap, bordered tables with tinted header, blockquote rail, link styling, image support); markdown extras now `tables, fenced-code-blocks, strike`. xhtml2pdf kept as a runtime fallback (WeasyPrint needs pango/cairo system libs — the endpoint degrades in styling rather than 500ing). 15.32 real PDF (magic bytes + disposition); 15.33 raw markdown syntax (`###`, `|---`, `**`, `~~`, ```` ``` ````, `](https`) never leaks into the extracted text; 15.34 every log-view feature's content survives (headings, both bold forms, strike body, all table rows, quote, fenced + inline code, link text). Frontend twin: the Download button (`CalculationLogFieldView.downloadCalculationLogPdf`) needs no change — it downloads what this endpoint produces. |

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -24,7 +24,7 @@
 | 12. Serializer Contract | 9 | 45 | 13 | 0 | 0 |
 | 13. Export Endpoint | 5 | 30 | 0 | 0 | 0 |
 | 14. AG Grid Query Endpoint | 6 | 33 | 0 | 0 | 0 |
-| 15. Calculation Logging Surface | 7 | 31 | 10 | 0 | 0 |
+| 15. Calculation Logging Surface | 8 | 34 | 13 | 0 | 0 |
 
 ## 1. Init — Project Bootstrap (`init`)
 
@@ -267,3 +267,4 @@
 | 15e | CalculatedModelMixin combinatorial pipeline | 15.16-15.18 | complete | 0 | 0 | 0 | counts not yet measured — imported at cluster-15 promotion |
 | 15f | Hierarchy preservation across the .save() boundary | 15.19-15.21 | complete | 0 | 0 | 0 | counts not yet measured — imported at cluster-15 promotion; three scenarios (15.19-15.21) marked @unittest.expectedFailure pending the execute_calculation_sync fix |
 | 15g | Object-less heading frames (TOC nodes) in the log tree | 15.22-15.31 | complete | 10 | 0 | 0 | model_logging_context("...") heading frames — lazy row creation, heading chains, node reuse, routing/root records skip headings, __str__ tree titles |
+| 15h | PDF export renders like the log view | 15.32-15.34 | complete | 3 | 0 | 0 | customer report 2026-07-14 — the Download-PDF of a calculation log lost markdown structure. DownloadMarkdownPdf now renders via WeasyPrint (already a declared dep; xhtml2pdf kept as runtime fallback) with a GitHub-style stylesheet mirroring the frontend log view, and the markdown extras match the log view's parser surface (tables, fenced code, strike; dropped code-friendly which silently disabled __bold__). Contract pinned; anything the log view renders appears rendered in the PDF — never as raw markdown syntax |

--- a/lex/test_project/test-plan/progress/sessions/2026-07-14-calclog-pdf-render.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-07-14-calclog-pdf-render.md
@@ -1,0 +1,19 @@
+---
+date: 2026-07-14
+clusters: [15h]
+tests_added: "3 (15.32–15.34) + source in 1 file (DownloadMarkdownPdf)"
+suite_tally: "15h 3 pass / 0 fail; cluster-15 environmental baseline unchanged (9 known local failures in 15b–15e, memory-documented)"
+---
+
+**Batch 15h landed — the calculation-log PDF export now renders like the log
+view (customer report 2026-07-14: markdown structure lost in the download).**
+Two root causes: xhtml2pdf's minimal CSS + bare stylesheet, and a markdown
+parser surface that silently diverged from the log view's markdown-it (the
+`code-friendly` extra disabled `__bold__`; `~~strike~~` was never enabled).
+Fix: render via **WeasyPrint** (already in requirements.txt) with a
+GitHub-style stylesheet mirroring the frontend log view; extras now
+`tables, fenced-code-blocks, strike`; xhtml2pdf kept as a runtime fallback so
+missing pango/cairo degrades styling instead of 500ing. Contract pinned:
+**anything the log view renders appears rendered in the PDF** — 15.33 raw
+syntax never leaks, 15.34 every feature's content survives (verified via
+pypdf text extraction). See [batch 15h](../../clusters/15-calculation_logging/batches.md).

--- a/lex/test_project/tests/calculation_logging/test_15h_pdf_export.py
+++ b/lex/test_project/tests/calculation_logging/test_15h_pdf_export.py
@@ -1,0 +1,142 @@
+"""Cluster 15h — Calculation-log PDF export renders like the log view.
+
+Scenarios 15.32 – 15.34.
+
+Intent (customer report 2026-07-14): the "Download PDF" button on a
+calculation log produced a document that did not look like the on-screen
+log view — markdown structure was lost. The contract this batch pins:
+**anything the log view can render must appear rendered in the exported
+PDF** — headings, bold/strike emphasis, lists, quotes, fenced code,
+links, and tables — never as raw markdown syntax (``###``, ``**``,
+``|---|``…). The PDF is generated server-side (`DownloadMarkdownPdf`),
+so this is the backend half; the frontend button simply downloads what
+this endpoint produces.
+
+Golden Rule: we assert what the customer sees in the file — content
+present, markup absent — not which rendering library produced it.
+"""
+from __future__ import annotations
+
+import io
+
+from lex.audit_logging.models.CalculationLog import CalculationLog
+
+from . import _CalcLogTestCase
+
+import pytest
+
+pytestmark = pytest.mark.calculation_logging
+
+# The full feature surface the frontend log view renders (markdown-it):
+# headings, bold (both ** and __ forms), strikethrough, italics, a table,
+# a list, a blockquote, fenced + inline code, and a link.
+FULL_SURFACE_MD = """# Investor Track Record
+
+This example demonstrates the **enhanced Markdown logger** that supports
+__DataFrames__ as markdown tables, ~~plain text only~~, *and more*.
+
+## DataFrame Example
+
+| Name    |   Age | City        |
+|:--------|------:|:------------|
+| Alice   |    30 | New York    |
+| Bob     |    25 | Los Angeles |
+| Charlie |    35 | Chicago     |
+
+### Additional Features
+
+- Text
+- Headings
+- Quotes
+
+> Markdown makes formatting simple and elegant!
+
+```python
+print('Hello, Markdown!')
+```
+
+Inline `code_span` too, and a [documentation link](https://example.com/docs).
+"""
+
+
+def _extract_pdf_text(pdf_bytes: bytes) -> str:
+    """Concatenated text of every page (pypdf)."""
+    import pypdf
+
+    reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
+    return "".join(page.extract_text() for page in reader.pages)
+
+
+class TestCluster15h_PdfExport(_CalcLogTestCase):
+    """GET api/download-pdf/<pk>/ — the exported PDF mirrors the log view."""
+
+    def _download(self, pk) -> bytes:
+        url = self._url("download-markdown-pdf", pk=pk)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        return b"".join(response.streaming_content) if getattr(
+            response, "streaming", False
+        ) else response.content
+
+    # -- 15.32 ---------------------------------------------------------
+    def test_15_32_endpoint_returns_a_real_pdf(self) -> None:
+        """Scenario 15.32: the endpoint returns an actual PDF document
+        (magic bytes + attachment disposition), not an error page."""
+        log = CalculationLog.objects.create(calculation_log="# Title\n\nBody.")
+        url = self._url("download-markdown-pdf", pk=log.pk)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertTrue(
+            response.content.startswith(b"%PDF"),
+            "Response body is not a PDF document",
+        )
+
+    # -- 15.33 ---------------------------------------------------------
+    def test_15_33_markdown_is_rendered_not_raw(self) -> None:
+        """Scenario 15.33: markdown STRUCTURE never leaks into the PDF as
+        raw syntax. A customer reading the file must see formatted
+        content — a ``###`` or ``|---|`` in the text means the export is
+        a text dump, exactly the reported bug."""
+        log = CalculationLog.objects.create(calculation_log=FULL_SURFACE_MD)
+        text = _extract_pdf_text(self._download(log.pk))
+
+        for raw_token in ("###", "|---", "**", "~~", "```", "](https"):
+            self.assertNotIn(
+                raw_token, text,
+                f"Raw markdown syntax {raw_token!r} leaked into the PDF text — "
+                f"the markdown was not rendered.",
+            )
+
+    # -- 15.34 ---------------------------------------------------------
+    def test_15_34_every_log_view_feature_survives_into_the_pdf(self) -> None:
+        """Scenario 15.34: every content element the log view renders is
+        present in the PDF — headings, emphasis bodies, table cells
+        (all three rows), list items, the quote, code (fenced + inline),
+        and the link text. A missing table row or a dropped code block is
+        the 'does not look like the log view' bug."""
+        log = CalculationLog.objects.create(calculation_log=FULL_SURFACE_MD)
+        text = _extract_pdf_text(self._download(log.pk))
+
+        expected_contents = [
+            "Investor Track Record",         # h1
+            "DataFrame Example",             # h2
+            "Additional Features",           # h3
+            "enhanced Markdown logger",      # **bold**
+            "DataFrames",                    # __bold__ (log view renders this)
+            "plain text only",               # ~~strike~~ body text
+            "Alice", "Bob", "Charlie",       # all table rows
+            "New York", "Los Angeles", "Chicago",
+            "simple and elegant",            # blockquote
+            "Hello, Markdown",               # fenced code
+            "code_span",                     # inline code
+            "documentation link",            # link text
+        ]
+        for content in expected_contents:
+            self.assertIn(
+                content, text,
+                f"Log-view content {content!r} missing from the exported PDF.",
+            )


### PR DESCRIPTION
## What & why

Customer report: the **Download PDF** of a calculation log produced a document that did not look like the on-screen log view — markdown structure was lost.

## Root causes

1. `xhtml2pdf`'s minimal CSS support plus a bare-bones stylesheet (tables only).
2. The markdown parser surface silently diverged from the log view's markdown-it: the `code-friendly` extra **disables** `__bold__` (which the log view renders), and `~~strike~~` was never enabled.

## Fix

- Render via **WeasyPrint** (near-browser CSS fidelity; already declared in `requirements.txt`) with a GitHub-style stylesheet mirroring the frontend log view: bordered headings, shaded pre-wrap code blocks, bordered tables with tinted header rows, blockquote rail, links, images.
- Markdown extras now `tables, fenced-code-blocks, strike`.
- `xhtml2pdf` kept as a **runtime fallback** — if WeasyPrint's system libs (pango/cairo) are missing on a target, the endpoint degrades in styling instead of 500ing.

## Contract pinned — cluster 15h (E-tier, 3 pass)

`lex/test_project/tests/calculation_logging/test_15h_pdf_export.py`

- **15.32** the endpoint returns a real PDF (magic bytes, content-type, attachment disposition)
- **15.33** raw markdown syntax (`###`, `|---`, `**`, `~~`, ``` ``` ```, `](https`) never leaks into the extracted text
- **15.34** every log-view feature's content survives into the PDF — headings, both bold forms, strike bodies, all table rows, quote, fenced + inline code, link text (pypdf extraction)

Cluster-15 local environmental baseline unchanged (the known 9 failures in 15b–15e predate this change — memory-documented A/B baseline).

## Frontend twin

No frontend change needed for the download itself (`CalculationLogFieldView` downloads what this endpoint produces). The paired log-view typography polish is on process-admin-general-client PR #442 (batch F3f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)