### PR TITLE
feat(recovery): dispatch-time claims, queue-verified recovery, age-gated startup reset, boot watchdog

### DIFF
--- a/lex/lex_app/celery.py
+++ b/lex/lex_app/celery.py
@@ -9,7 +9,13 @@ from typing import Optional
 
 from celery import Celery
 from celery.app.control import Control
-from celery.signals import task_postrun, task_revoked, worker_ready, worker_shutting_down
+from celery.signals import (
+    task_postrun,
+    task_revoked,
+    worker_init,
+    worker_ready,
+    worker_shutting_down,
+)
 from celery.worker import state as worker_state
 from celery.worker.control import Panel
 from django.apps import apps
@@ -259,10 +265,69 @@ def _idle_watchdog_loop(
         sleep(poll_interval)
 
 
+def _boot_timeout_seconds() -> float:
+    """Grace for a booting worker to become ready (broker connected).
+
+    A worker that starts while the broker is unreachable — Redis evicted or
+    flushed, the 2026-07-14 incident — loops in connection-retry BEFORE
+    ``worker_ready`` fires, so the idle watchdog (armed on ``worker_ready``)
+    never starts and the pod idles forever. This boot watchdog is armed on
+    ``worker_init`` instead: if the worker has not become ready within the
+    timeout, it is warm-shut so KEDA/the Job can replace it. ``0`` disables.
+    """
+    try:
+        return float(os.getenv("LEX_WORKER_BOOT_TIMEOUT_SECONDS", "300"))
+    except (TypeError, ValueError):
+        return 300.0
+
+
+_worker_became_ready = threading.Event()
+_boot_timer = None
+
+
+def _boot_watchdog_fire():
+    """Boot timeout elapsed without worker_ready: terminate the worker.
+
+    Uses the same warm-shutdown primitive as the idle paths — a worker that
+    never became ready has no active/reserved tasks, so the idle check passes
+    and a graceful SIGTERM is scheduled.
+    """
+    if _worker_became_ready.is_set():
+        return
+    logger.warning(
+        "boot watchdog: worker not ready after %ss (broker unreachable?); "
+        "requesting warm shutdown",
+        _boot_timeout_seconds(),
+    )
+    _warm_shutdown_if_idle()
+
+
+@worker_init.connect
+def arm_boot_watchdog(sender=None, **extra):
+    """Arm the never-became-ready watchdog as early as the process allows."""
+    global _boot_timer
+    if not _is_non_local_deployment_target() or not _idle_shutdown_enabled():
+        return
+    timeout = _boot_timeout_seconds()
+    if timeout <= 0:
+        return
+    if _boot_timer is not None:
+        return
+    _worker_became_ready.clear()
+    _boot_timer = threading.Timer(timeout, _boot_watchdog_fire)
+    _boot_timer.daemon = True
+    _boot_timer.start()
+
+
 @worker_ready.connect
 def start_idle_watchdog(sender=None, **extra):
     """Start the single idle-watchdog daemon thread on worker startup."""
     global _watchdog_thread
+    # The worker became ready: disarm the boot watchdog before anything else
+    # (from here on, the idle watchdog owns liveness).
+    _worker_became_ready.set()
+    if _boot_timer is not None:
+        _boot_timer.cancel()
     if not _is_non_local_deployment_target() or not _idle_shutdown_enabled():
         return
     if _watchdog_thread is not None and _watchdog_thread.is_alive():

--- a/lex/lex_app/celery_recovery/registry.py
+++ b/lex/lex_app/celery_recovery/registry.py
@@ -22,8 +22,10 @@ unaffected.
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import pickle
+import time
 from typing import Any, Dict, List, Optional
 
 from . import redis_keys
@@ -136,12 +138,109 @@ def register(
             "kwargs": kwargs,
             "queue": queue,
             "retries": retries,
+            # A worker is executing this task right now — the heartbeat is
+            # the liveness signal from here on (vs. "dispatched", where the
+            # message is still on the broker and no heartbeat exists yet).
+            "status": "running",
         }
         client.set(redis_keys.payload_key(task_id), _encode(payload), ex=_payload_ttl())
         client.sadd(redis_keys.index_key(), task_id)
         client.set(redis_keys.heartbeat_key(task_id), "1", ex=_heartbeat_ttl())
     except Exception:
         logger.warning("Celery recovery: register failed for %s", task_id, exc_info=True)
+
+
+def claim_dispatched(
+    task_id: str,
+    name: str,
+    args: Any,
+    kwargs: Any,
+    queue: Optional[str],
+) -> None:
+    """Claim ``task_id`` at DISPATCH time, before any worker exists.
+
+    Closes the dispatch-to-start ownership gap (incident 2026-07-14, instance
+    1410): a calculation row goes ``IN_PROGRESS`` when its task is dispatched,
+    but registration used to happen only in ``task_prerun`` — so a task whose
+    worker pod was still Pending was invisible to the recovery machinery and
+    the startup reset blind-aborted its healthy, merely-queued row.
+
+    The claim is a normal registry entry with ``status="dispatched"``,
+    ``claimed_at`` (epoch seconds) and **no heartbeat** — the message sitting
+    on the broker is its liveness story, which the supervisor verifies via
+    :func:`task_id_in_queue` instead of a heartbeat. ``task_prerun`` upgrades
+    the entry to ``status="running"`` when a worker picks the task up.
+
+    Written with ``SET NX``: if a payload already exists (the worker won the
+    race and registered first, or this is a supervisor requeue) the claim
+    never clobbers it. Best-effort no-op like every registry operation.
+    """
+    if not task_id:
+        return
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        payload = {
+            "name": name,
+            "args": args,
+            "kwargs": kwargs,
+            "queue": queue,
+            "retries": 0,
+            "status": "dispatched",
+            "claimed_at": time.time(),
+        }
+        # NX: never overwrite an existing payload (prerun/requeue owns it).
+        if client.set(
+            redis_keys.payload_key(task_id), _encode(payload),
+            ex=_payload_ttl(), nx=True,
+        ):
+            client.sadd(redis_keys.index_key(), task_id)
+        else:
+            # Payload exists — still make sure the id is indexed.
+            client.sadd(redis_keys.index_key(), task_id)
+    except Exception:
+        logger.warning(
+            "Celery recovery: claim_dispatched failed for %s", task_id, exc_info=True
+        )
+
+
+def task_id_in_queue(task_id: str, queue: str) -> Optional[bool]:
+    """Whether the broker queue still holds the message for ``task_id``.
+
+    Inspects the Redis list backing ``queue`` (Kombu's storage for
+    unconsumed messages) and matches the Celery message id in ``headers.id``
+    (protocol v2) or ``properties.correlation_id``. Used by the supervisor to
+    decide whether a long-dispatched-but-never-started task is merely waiting
+    for capacity (leave it alone) or has vanished from the broker entirely —
+    e.g. Redis was evicted or flushed — in which case a same-task-id requeue
+    is safe because no duplicate message can exist.
+
+    Returns ``True``/``False`` on a definitive scan, ``None`` when the queue
+    cannot be read — callers must treat ``None`` as "assume still queued"
+    (never double-dispatch on uncertainty).
+    """
+    if not task_id or not queue:
+        return None
+    client = _get_client()
+    if client is None:
+        return None
+    try:
+        for raw in client.lrange(queue, 0, -1) or []:
+            try:
+                message = json.loads(raw)
+            except Exception:
+                continue
+            headers = message.get("headers") or {}
+            properties = message.get("properties") or {}
+            if task_id in (headers.get("id"), properties.get("correlation_id")):
+                return True
+        return False
+    except Exception:
+        logger.warning(
+            "Celery recovery: queue inspection failed for %s", task_id, exc_info=True
+        )
+        return None
 
 
 def refresh_heartbeat(task_id: str) -> None:

--- a/lex/lex_app/celery_recovery/supervisor.py
+++ b/lex/lex_app/celery_recovery/supervisor.py
@@ -55,6 +55,14 @@ def _requeue_grace_seconds() -> int:
     return max(1, int(getattr(_settings(), "LEX_TASK_REQUEUE_GRACE_SECONDS", 60)))
 
 
+def _dispatch_grace_seconds() -> int:
+    """How long a dispatched-but-never-started claim is left alone before the
+    supervisor starts verifying it against the broker queue. Generous by
+    design: a scheduling backlog (full cluster, node-group max) is a normal
+    condition, not a failure."""
+    return max(1, int(getattr(_settings(), "LEX_TASK_DISPATCH_GRACE_SECONDS", 300)))
+
+
 def _default_queue() -> str:
     s = _settings()
     return getattr(s, "CELERY_TASK_DEFAULT_QUEUE", None) or "celery"
@@ -82,6 +90,10 @@ def _requeue(app, task_id: str, payload: Dict[str, Any]) -> None:
     """
     incremented = dict(payload)
     incremented["retries"] = int(incremented.get("retries", 0)) + 1
+    if incremented.get("status") == "dispatched":
+        # The re-dispatched message goes back on the queue unconsumed — reset
+        # the claim clock so the next scans judge it against a fresh window.
+        incremented["claimed_at"] = time.time()
     queue = incremented.get("queue") or _default_queue()
 
     # Grant the grace window *before* dispatching so the task can never be
@@ -352,6 +364,7 @@ def scan_and_recover(app=None) -> Dict[str, int]:
         "cancelled": 0,
         "already_finished": 0,
         "skipped_locked": 0,
+        "dispatched_waiting": 0,
     }
 
     for task_id in registry.list_tracked():
@@ -366,6 +379,37 @@ def scan_and_recover(app=None) -> Dict[str, int]:
             registry.deregister(task_id)
             stats["orphaned"] += 1
             continue
+
+        # ── Dispatched-but-never-started claims ──────────────────────
+        # No heartbeat has ever existed for these: the message on the broker
+        # queue IS the liveness story. A missing heartbeat therefore proves
+        # nothing — only the queue does. While the message is still queued
+        # (or the queue is unreadable) the task is merely waiting for
+        # capacity and MUST be left alone: a same-task-id requeue would put
+        # a second copy of the message on the broker and run the work twice.
+        # Only when the message has verifiably vanished (Redis evicted or
+        # flushed — exactly the 2026-07-14 incident) does it fall through to
+        # the lock + requeue path below, where recovery is safe and exactly
+        # what this subsystem is for. These skips happen BEFORE the recovery
+        # lock so a waiting claim never burns a lock window.
+        if payload.get("status") == "dispatched":
+            age = time.time() - float(payload.get("claimed_at") or 0)
+            if age < _dispatch_grace_seconds():
+                stats["dispatched_waiting"] += 1
+                continue
+            queue = payload.get("queue") or _default_queue()
+            still_queued = registry.task_id_in_queue(task_id, queue)
+            if still_queued is not False:
+                # True → backlog; None → unknown: never double-dispatch on
+                # uncertainty. Either way, leave it for a later pass.
+                stats["dispatched_waiting"] += 1
+                continue
+            logger.warning(
+                "Celery recovery: dispatched task %s vanished from queue %s "
+                "without ever starting (broker flushed/evicted?); recovering",
+                task_id,
+                queue,
+            )
 
         # Multi-supervisor safety: claim this dead task before acting on it.
         # If another replica already holds the lock, skip it this pass — that

--- a/lex/lex_app/celery_tasks.py
+++ b/lex/lex_app/celery_tasks.py
@@ -129,6 +129,42 @@ class CallbackTask(Task):
     with special handling for the initial_data_upload task.
     """
 
+    def apply_async(self, args=None, kwargs=None, task_id=None, **options):
+        """Dispatch, then claim the task in the recovery registry.
+
+        Every async dispatch in the framework goes through this base class
+        (``lex_shared_task`` sets ``base=CallbackTask``), so this is the single
+        choke point where a task can be claimed at DISPATCH time — before any
+        worker exists. Without the claim, a task whose worker pod never got
+        scheduled (full cluster, node-group max) is invisible to the recovery
+        registry, and the startup reset blind-aborts its healthy, queued
+        calculation row (incident 2026-07-14, instance 1410).
+
+        The claim happens strictly AFTER ``super().apply_async`` returns: a
+        failed dispatch must not leave a claim for a message that never
+        reached the broker. Best-effort — a claim failure never fails the
+        dispatch itself.
+        """
+        result = super().apply_async(args=args, kwargs=kwargs, task_id=task_id, **options)
+        try:
+            from lex.lex_app.celery_recovery.heartbeat import _UNTRACKED_TASK_NAMES
+            from lex.lex_app.celery_recovery import registry as recovery_registry
+
+            if self.name not in _UNTRACKED_TASK_NAMES:
+                recovery_registry.claim_dispatched(
+                    task_id=result.id,
+                    name=self.name,
+                    args=args,
+                    kwargs=kwargs,
+                    queue=options.get("queue"),
+                )
+        except Exception:
+            logger.warning(
+                "Celery recovery: dispatch claim failed for %s", getattr(result, "id", None),
+                exc_info=True,
+            )
+        return result
+
     def on_success(self, retval: Any, task_id: str, args: Tuple, kwargs: Dict) -> None:
         """Handle successful task completion."""
         try:

--- a/lex/process_admin/utils/model_registration.py
+++ b/lex/process_admin/utils/model_registration.py
@@ -428,6 +428,23 @@ class ModelRegistration:
                 ensure_terminal_calculation_audit,
             )
 
+            from lex.core.models.LexModel import lex_datetime_now
+
+            # Age-gate (defense-in-depth for the 2026-07-14 incident class):
+            # when the recovery registry is unreadable — Redis evicted or
+            # flushed, exactly the moments this sweep tends to run — every
+            # row looks untracked and the sweep degrades to a blind abort.
+            # A recently-started calculation is far more likely to be queued
+            # or running than orphaned, so young rows are spared regardless
+            # of tracking. 0 disables the gate (legacy behavior).
+            try:
+                min_age_seconds = float(
+                    os.getenv("LEX_STARTUP_ABORT_MIN_AGE_SECONDS", "1800")
+                )
+            except (TypeError, ValueError):
+                min_age_seconds = 1800.0
+            now = lex_datetime_now()
+
             stuck = list(
                 model.objects.filter(is_calculated=CalculationModel.IN_PROGRESS)
             )
@@ -438,6 +455,20 @@ class ModelRegistration:
                     # would, via the terminal-outcome guard, block that resume
                     # and permanently lose recoverable calculation state.
                     continue
+                if min_age_seconds > 0:
+                    stamp = getattr(instance, "edited_at", None) or getattr(
+                        instance, "created_at", None
+                    )
+                    if stamp is not None and (now - stamp).total_seconds() < min_age_seconds:
+                        logger.info(
+                            "Startup reset: sparing young IN_PROGRESS row %s "
+                            "(%.0fs old < %.0fs gate) — likely queued or "
+                            "running with tracking unavailable.",
+                            instance,
+                            (now - stamp).total_seconds(),
+                            min_age_seconds,
+                        )
+                        continue
                 instance.is_calculated = CalculationModel.ABORTED
                 instance._history_change_reason = (
                     "Startup reset: calculation was still IN_PROGRESS"

--- a/lex/test_project/test-plan/clusters/08-celery_async/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/08-celery_async/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 8
 slug: celery_async
 title: Celery & Async
-max_scenario: 144
+max_scenario: 156
 letters:
   a:
     title: a — Post-task warm shutdown honours the idle-shutdown master switch (Session 85 — June 26)
@@ -137,3 +137,15 @@ letters:
       xfail: 0
     note: 'scenarios 8.116–8.122; pins the three silent-failure invariants of the `lex-recovery-beat`
       driver: the beat schedule names the registered `sweep_dead_workers` task and excludes it '
+  z:
+    title: Dispatch-time claims, queue-verified recovery, age-gated startup reset, boot watchdog
+    scenarios: 8.145-8.156
+    status: complete
+    tests:
+      pass: 12
+      skip: 0
+      xfail: 0
+    note: incident 2026-07-14 hardening — ownership starts at dispatch (CallbackTask.apply_async →
+      claim_dispatched, NX), supervisor leaves queued claims alone and only requeues verifiably
+      vanished messages, startup reset spares young untracked rows, boot watchdog reaps workers
+      that never become ready; 8x's _run_sweep now pins ownership with the age-gate disabled

--- a/lex/test_project/test-plan/clusters/08-celery_async/batches.md
+++ b/lex/test_project/test-plan/clusters/08-celery_async/batches.md
@@ -178,3 +178,21 @@
 | Status | ✅ Complete — source fix + paired tests + plan sync in one change. Allocated `8ad` (next free letter after `8ac`); 8.142 picks up after cluster-8 scenario max 8.141. Companion: Batch 7r withdrawn (inline guard + 7.199 flip + test file removed), 7q restored to committed assertions |
 
 ---
+
+---
+
+### Batch 8z — Dispatch-time claims, queue-verified recovery, age-gated startup reset, boot watchdog ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 8.145 – 8.156 |
+| Type | U (+ one E sweep class) |
+| Files covered | `lex_app/celery_recovery/registry.py` (`claim_dispatched`, `task_id_in_queue`, `status` field), `lex_app/celery_recovery/supervisor.py` (dispatched lane, `LEX_TASK_DISPATCH_GRACE_SECONDS`), `lex_app/celery_tasks.py` (`CallbackTask.apply_async` claim choke point), `process_admin/utils/model_registration.py` (`LEX_STARTUP_ABORT_MIN_AGE_SECONDS` age-gate), `lex_app/celery.py` (boot watchdog, `LEX_WORKER_BOOT_TIMEOUT_SECONDS`) |
+| Test file | `lex/test_project/tests/celery_async/test_8z_dispatch_claim_and_boot_guard.py` |
+| Test classes | `TestCluster08z_DispatchClaim`, `TestCluster08z_SupervisorDispatchedLane`, `TestCluster08z_StartupAgeGate`, `TestCluster08z_BootWatchdog` |
+| Fixtures | reuses `CelerySyncCalc`; mocked redis clients per the 8v/8w pattern |
+| Est. tests | 12 |
+| Coverage gain | dispatch-to-start ownership gap + degraded-broker self-termination |
+| Prereqs | 8w/8x semantics (extended, not changed: tracked→skip is untouched) |
+| Status | ✅ Complete — 12 pass / 0 fail |
+| Note | Incident 2026-07-14 (instance 1410): a healthy calculation whose worker pod was still Pending was blind-aborted by a recovery-beat restart, because registry ownership began only at `task_prerun`. Ownership now starts at dispatch (`status="dispatched"`, `claimed_at`, no heartbeat — the broker message is the liveness story). The supervisor never requeues a claim that is (or might be) still queued — a same-task-id double dispatch is impossible by construction — and recovers only verifiably vanished messages (Redis flushed/evicted), the exact incident remediation that used to strand work. Startup reset spares untracked rows younger than the age-gate (default 1800s; 0 = legacy) so blind-abort degradation can't race a scheduling backlog. Boot watchdog (armed on `worker_init`, default 300s) terminates workers that boot into an unreachable broker and never fire `worker_ready`. **Deliberate 8x edit:** its `_run_sweep` pins ownership semantics with the age-gate disabled (`LEX_STARTUP_ABORT_MIN_AGE_SECONDS=0`); the gate has its own scenario 8.155. |

--- a/lex/test_project/test-plan/clusters/08-celery_async/cluster.md
+++ b/lex/test_project/test-plan/clusters/08-celery_async/cluster.md
@@ -141,3 +141,11 @@
 **Scenario range:** 8.142 – 8.144. **Test file:** `lex/test_project/tests/celery_async/test_8ad_dispatched_task_cancel_marker.py`. **Type:** U. **Status:** ✅ Complete (Session 91 — July 2). Allocated `8ad` (next free letter after `8ac`); 8.142 picks up after cluster-8 scenario max 8.141. Source: `lex/lex_app/celery_tasks.py` (`lex_shared_task` wrapper). 8.142 dispatched run + marker set ⇒ raises `CalculationCancelled` before the wrapped function runs; 8.143 dispatched run + no marker ⇒ marker consulted, function runs normally; 8.144 synchronous run (no context) ⇒ cancel index never consulted, function runs. 3 pass / 0 fail.
 
 ---
+
+### 8z. Dispatch-time claims, queue-verified recovery, age-gated startup reset, boot watchdog ✅
+
+**What it tests:** the four hardening pieces from the 2026-07-14 instance-1410 incident. Recovery ownership begins at dispatch (`CallbackTask.apply_async` → `registry.claim_dispatched`, NX, no heartbeat), so dispatched-but-not-yet-started calculations are visible to the startup reset and the supervisor. The supervisor's dispatched lane treats the broker queue as the liveness signal: still-queued (or unreadable) → wait; verifiably vanished → same-task-id requeue under the normal budget. The startup reset spares young untracked rows (`LEX_STARTUP_ABORT_MIN_AGE_SECONDS`). The boot watchdog (`worker_init`, `LEX_WORKER_BOOT_TIMEOUT_SECONDS`) reaps workers that never become ready.
+
+**Why a regression matters:** each gap independently strands or destroys healthy work during infra turbulence — the incident aborted a live customer calculation and left 15 zombie worker jobs.
+
+**Scenario range:** 8.145 – 8.156. **Test file:** `lex/test_project/tests/celery_async/test_8z_dispatch_claim_and_boot_guard.py`. **Type:** U (+ E sweep). **Status:** ✅ Complete — 12 pass.

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -17,7 +17,7 @@
 | 5. History & Bitemporal | 12 | 103 | 15 | 6 | 3 |
 | 6. Audit Logging | 17 | 118 | 21 | 3 | 0 |
 | 7. Calculation State Machine | 18 | 204 | 61 | 0 | 0 |
-| 8. Celery & Async | 14 | 144 | 80 | 12 | 0 |
+| 8. Celery & Async | 15 | 156 | 92 | 12 | 0 |
 | 9. Signals & WebSocket | 6 | 42 | 14 | 0 | 0 |
 | 10. API Layer | 13 | 71 | 21 | 0 | 0 |
 | 11. Stress & Performance | 9 | 22 | 0 | 0 | 0 |
@@ -177,6 +177,7 @@
 | 8w | Worker-recovery terminal-outcome guard: no ERROR→SUCCESS resurrection | 8.90-8.102 | complete | 8 | 5 | 0 | scenarios 8.90–8.102; `scan_and_recover` consults the result backend (ready `AsyncResult`) + the calc rows (every row out of `IN_PROGRESS`) before requeueing a dead task, deregiste |
 | 8x | Liveness-aware startup reset: recovery hand-off (no live-calc abort) | 8.103-8.115 | complete | 6 | 7 | 0 | scenarios 8.103–8.115; the boot-time `IN_PROGRESS → ABORTED` sweep now defers to the recovery registry — a row owned by a tracked task (alive **or** expired-but-tracked) is left `I |
 | 8y | Embedded-beat recovery driver: schedule wiring, queue isolation, entrypoint | 8.116-8.122 | complete | 7 | 0 | 0 | scenarios 8.116–8.122; pins the three silent-failure invariants of the `lex-recovery-beat` driver: the beat schedule names the registered `sweep_dead_workers` task and excludes it  |
+| 8z | Dispatch-time claims, queue-verified recovery, age-gated startup reset, boot watchdog | 8.145-8.156 | complete | 12 | 0 | 0 | incident 2026-07-14 hardening — ownership starts at dispatch (CallbackTask.apply_async → claim_dispatched, NX), supervisor leaves queued claims alone and only requeues verifiably vanished messages, startup reset spares young untracked rows, boot watchdog reaps workers that never become ready; 8x's _run_sweep now pins ownership with the age-gate disabled |
 
 ## 9. Signals & WebSocket (`signals_ws`)
 

--- a/lex/test_project/test-plan/progress/sessions/2026-07-15-recovery-dispatch-claim.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-07-15-recovery-dispatch-claim.md
@@ -1,0 +1,34 @@
+---
+date: 2026-07-15
+clusters: [8z]
+tests_added: "12 (8.145–8.156) + source in 5 files; deliberate 8x _run_sweep edit (age-gate off)"
+suite_tally: "8z 12 pass / 0 fail; regression: celery_async+init+calculations = 606 pass / 20 skip / 0 fail"
+---
+
+**Batch 8z landed — recovery hardening from the 2026-07-14 instance-1410
+incident.** Root cause chain (verified in cluster logs + code): a ~20-way
+fan-out hit a full cluster, most worker Jobs sat Pending; the autoscaler
+independently evicted the node hosting the instance's redis + recovery-beat;
+the rescheduled recovery-beat's Django startup ran the blind startup reset,
+which aborted a healthy, merely-queued calculation — because registry
+ownership only began at `task_prerun`, so a dispatched-but-unstarted task was
+invisible. Meanwhile the idle watchdog (armed on `worker_ready`) could not
+reap workers that booted into the dead broker, and flushing redis as
+remediation destroyed queue and recovery tracking together.
+
+Hardening: (1) ownership starts at dispatch — `CallbackTask.apply_async` is
+the single dispatch choke point and claims the task NX with
+`status="dispatched"`/`claimed_at` and no heartbeat; (2) the supervisor's
+dispatched lane uses the broker queue itself as the liveness signal — waiting
+claims are skipped BEFORE the recovery lock, and only a verifiably vanished
+message (flush/eviction) is requeued with the same task id, making double
+dispatch impossible by construction; (3) the startup reset spares young
+untracked rows (`LEX_STARTUP_ABORT_MIN_AGE_SECONDS`, default 1800, 0=legacy)
+so registry-unreadable degradation can't race a scheduling backlog; (4) a
+boot watchdog armed on `worker_init` (`LEX_WORKER_BOOT_TIMEOUT_SECONDS`,
+default 300, 0=off) terminates workers that never become ready. Design
+respects the founding PRs (#596/#603/#605): visibility_timeout untouched,
+best-effort everywhere, budget-split around dispatch, never resurrect settled
+work. Infra companions (redis safe-to-evict annotation, ScaledJob
+activeDeadlineSeconds) tracked separately in LEX_TERRAFORM_MODULES.
+See [batch 8z](../../clusters/08-celery_async/batches.md).

--- a/lex/test_project/tests/celery_async/test_8x_startup_reset_recovery_handoff.py
+++ b/lex/test_project/tests/celery_async/test_8x_startup_reset_recovery_handoff.py
@@ -195,7 +195,14 @@ class TestCluster08x_StartupSweepDefersToOwnership(E2ETestCase):
         return {(CelerySyncCalc._meta.label_lower, r.pk) for r in rows}
 
     def _run_sweep(self, tracked_record_ids):
-        with mock.patch.dict(os.environ, {"CALLED_FROM_START_COMMAND": "1"}):
+        # These scenarios pin the OWNERSHIP semantics (tracked → skip,
+        # untracked → abort). The age-gate added with batch 8z would spare
+        # every freshly-created test row regardless of ownership, so it is
+        # disabled here; the gate has its own scenario (8.155).
+        with mock.patch.dict(os.environ, {
+            "CALLED_FROM_START_COMMAND": "1",
+            "LEX_STARTUP_ABORT_MIN_AGE_SECONDS": "0",
+        }):
             ModelRegistration._handle_calculation_model_reset(
                 CelerySyncCalc, tracked_record_ids=tracked_record_ids,
             )

--- a/lex/test_project/tests/celery_async/test_8z_dispatch_claim_and_boot_guard.py
+++ b/lex/test_project/tests/celery_async/test_8z_dispatch_claim_and_boot_guard.py
@@ -1,0 +1,472 @@
+"""Cluster 8z — dispatch-time recovery claims, queue-verified recovery, age-gated startup reset, boot watchdog.
+
+Intent: the recovery subsystem's promise is "no calculation gets stuck or
+lost, whatever dies". Incident 2026-07-14 (instance 1410) showed four gaps in
+that promise, all rooted in one asymmetry: a row goes ``IN_PROGRESS`` at
+DISPATCH, but recovery ownership only began at task START (``task_prerun``).
+A task whose worker pod was still Pending (full cluster, node-group max) was
+invisible to the registry, so a recovery-beat pod restart blind-aborted its
+healthy, merely-queued row — while the idle watchdog, armed only on
+``worker_ready``, could not reap workers that booted into the evicted broker.
+
+The hardening under test:
+- ``registry.claim_dispatched`` — ownership starts at dispatch
+  (``CallbackTask.apply_async`` is the single choke point), with
+  ``status="dispatched"``, ``claimed_at``, NO heartbeat, written NX so a
+  racing ``task_prerun`` registration is never clobbered;
+- the supervisor's dispatched lane — a claim is left alone while its message
+  is still on (or possibly on) the broker queue; only a verifiably vanished
+  message (Redis flushed/evicted) is requeued, so a same-task-id
+  double-dispatch is impossible;
+- the startup reset's age-gate — young untracked rows are spared even when
+  the registry is unreadable (blind-abort degradation);
+- the boot watchdog — armed on ``worker_init`` so "never became ready" is
+  itself a termination condition.
+Cluster 8z — scenarios 8.145–8.156. Type: U (+ one E sweep class).
+Covers: lex/lex_app/celery_recovery/registry.py (claim_dispatched,
+        task_id_in_queue), lex/lex_app/celery_recovery/supervisor.py
+        (dispatched lane), lex/lex_app/celery_tasks.py
+        (CallbackTask.apply_async), lex/process_admin/utils/
+        model_registration.py (age-gate), lex/lex_app/celery.py
+        (boot watchdog).
+Run: python -m lex pytest lex/test_project/tests/celery_async/test_8z_dispatch_claim_and_boot_guard.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest import mock
+
+import nest_asyncio
+import pytest
+from asgiref.sync import sync_to_async
+from django.db import connections
+from django.test import SimpleTestCase
+
+from lex.core.models.CalculationModel import CalculationModel
+from lex.core.models.LexModel import lex_datetime_now
+from lex.lex_app.celery_recovery import registry, supervisor
+from lex.process_admin.utils.model_registration import ModelRegistration
+from lex.test_project.tests._e2e_test_case import E2ETestCase
+
+from .models import CelerySyncCalc
+
+pytestmark = pytest.mark.celery_async
+
+
+class TestCluster08z_DispatchClaim(SimpleTestCase):
+    """Cluster 8z: ownership starts at dispatch, without racing prerun."""
+
+    def setUp(self):
+        registry.reset_client_cache()
+        self.addCleanup(registry.reset_client_cache)
+
+    def _client(self, *, set_returns=True):
+        client = mock.MagicMock()
+        client.set.return_value = set_returns
+        client.get.return_value = None
+        return client
+
+    def test_8_145_claim_writes_dispatched_payload_without_heartbeat(self):
+        """
+        Scenario 8.145: a dispatch claim is a tracked payload with
+        status='dispatched', a claimed_at stamp, and NO heartbeat key.
+        Given: an enabled registry with a mocked redis client
+        When: claim_dispatched(task_id, ...) runs
+        Then: the payload key is written NX with status/claimed_at, the id is
+              indexed, and the heartbeat key is never touched — the broker
+              message, not a heartbeat, is the liveness story
+        """
+        client = self._client()
+        with mock.patch.object(registry, "_get_client", return_value=client):
+            registry.claim_dispatched("tid-1", "calc_and_save", ("a",), {"k": 1}, "celery")
+
+        from lex.lex_app.celery_recovery import redis_keys
+
+        set_calls = client.set.call_args_list
+        self.assertEqual(len(set_calls), 1, "Exactly one SET (the payload, NX) is expected.")
+        args, kwargs = set_calls[0]
+        self.assertEqual(
+            args[0], redis_keys.payload_key("tid-1"),
+            "The single SET must target the payload key.",
+        )
+        self.assertTrue(kwargs.get("nx"), "The claim must be written NX — never clobber prerun.")
+        payload = registry._decode(args[1])
+        self.assertEqual(payload["status"], "dispatched", "Claims carry status=dispatched.")
+        self.assertLessEqual(
+            abs(payload["claimed_at"] - time.time()), 5,
+            "claimed_at must be a fresh epoch stamp.",
+        )
+        client.sadd.assert_called_once()
+        heartbeat_sets = [
+            c for c in set_calls if c[0][0] == redis_keys.heartbeat_key("tid-1")
+        ]
+        self.assertEqual(
+            heartbeat_sets, [],
+            "A claim must NOT stamp a heartbeat — a missing heartbeat proves "
+            "nothing for a queued task.",
+        )
+
+    def test_8_146_claim_never_clobbers_existing_payload(self):
+        """
+        Scenario 8.146: when a payload already exists (prerun won the race, or
+        a supervisor requeue owns it), the claim leaves it untouched.
+        Given: redis SET NX returns False (key exists)
+        When: claim_dispatched runs
+        Then: the id is still indexed, but the existing payload survives
+        """
+        client = self._client(set_returns=False)
+        with mock.patch.object(registry, "_get_client", return_value=client):
+            registry.claim_dispatched("tid-1", "calc_and_save", (), {}, None)
+
+        client.sadd.assert_called_once()
+        # Only one SET attempt (the NX one) — no unconditional overwrite.
+        self.assertEqual(
+            client.set.call_count, 1,
+            "A lost NX race must not be followed by an unconditional SET.",
+        )
+
+    def test_8_147_prerun_register_upgrades_claim_to_running(self):
+        """
+        Scenario 8.147: task_prerun's register() upgrades a claim in place.
+        Given: an existing dispatched payload with an accumulated retry count
+        When: register() runs for the same task id
+        Then: the stored payload has status='running' and the retries survive
+        """
+        existing = registry._encode(
+            {"name": "t", "args": (), "kwargs": {}, "queue": None,
+             "retries": 2, "status": "dispatched", "claimed_at": 1.0}
+        )
+        client = self._client()
+        client.get.return_value = existing
+        with mock.patch.object(registry, "_get_client", return_value=client):
+            registry.register("tid-1", "t", (), {}, None)
+
+        payload_write = client.set.call_args_list[0]
+        payload = registry._decode(payload_write[0][1])
+        self.assertEqual(
+            payload["status"], "running",
+            "prerun registration must upgrade the claim to running.",
+        )
+        self.assertEqual(
+            payload["retries"], 2,
+            "The requeue budget must survive the dispatched→running upgrade.",
+        )
+
+    def test_8_148_apply_async_claims_after_dispatch(self):
+        """
+        Scenario 8.148: CallbackTask.apply_async claims the task AFTER the
+        message reached the broker, and skips untracked task names.
+        Given: a CallbackTask whose base dispatch returns a task id
+        When: apply_async runs for a normal task and for the recovery sweep
+        Then: claim_dispatched is called once with the dispatch's identity for
+              the normal task, and never for the untracked sweep task
+        """
+        from celery import Task
+
+        from lex.lex_app.celery_tasks import CallbackTask
+
+        fake_result = SimpleNamespace(id="tid-99")
+        with mock.patch.object(
+            Task, "apply_async", return_value=fake_result
+        ), mock.patch.object(registry, "claim_dispatched") as claim:
+            task = CallbackTask()
+            task.name = "calc_and_save"
+            result = task.apply_async(args=(1,), kwargs={"a": 2}, queue="celery")
+            self.assertIs(result, fake_result, "The dispatch result must pass through.")
+            claim.assert_called_once_with(
+                task_id="tid-99",
+                name="calc_and_save",
+                args=(1,),
+                kwargs={"a": 2},
+                queue="celery",
+            )
+
+            claim.reset_mock()
+            sweep = CallbackTask()
+            sweep.name = "lex.lex_app.celery_recovery.supervisor.sweep_dead_workers"
+            sweep.apply_async(args=(), kwargs={})
+            claim.assert_not_called()
+
+    def test_8_149_queue_introspection_finds_ids_and_degrades_safely(self):
+        """
+        Scenario 8.149: task_id_in_queue reads the broker list definitively
+        when it can and returns None (assume-queued) when it cannot.
+        Given: a queue holding protocol-v2 and correlation-id messages
+        When: probing for present ids, absent ids, and with a broken client
+        Then: True / False / None respectively
+        """
+        message_v2 = json.dumps({"headers": {"id": "tid-1"}, "properties": {}})
+        message_v1 = json.dumps({"headers": {}, "properties": {"correlation_id": "tid-2"}})
+        client = mock.MagicMock()
+        client.lrange.return_value = [message_v2, message_v1, "not-json"]
+        with mock.patch.object(registry, "_get_client", return_value=client):
+            self.assertIs(registry.task_id_in_queue("tid-1", "celery"), True)
+            self.assertIs(registry.task_id_in_queue("tid-2", "celery"), True)
+            self.assertIs(registry.task_id_in_queue("tid-3", "celery"), False)
+
+        broken = mock.MagicMock()
+        broken.lrange.side_effect = RuntimeError("redis down")
+        with mock.patch.object(registry, "_get_client", return_value=broken):
+            self.assertIsNone(
+                registry.task_id_in_queue("tid-1", "celery"),
+                "An unreadable queue must be 'unknown', never 'absent' — "
+                "callers must not double-dispatch on uncertainty.",
+            )
+
+
+class TestCluster08z_SupervisorDispatchedLane(SimpleTestCase):
+    """Cluster 8z: the scan leaves queued claims alone, recovers vanished ones."""
+
+    def _scan(self, payload, *, in_queue, lock_ok=True):
+        """Run one scan pass over a single dispatched claim."""
+        app = mock.MagicMock()
+        app.AsyncResult.return_value.ready.return_value = False
+        patches = [
+            mock.patch.object(supervisor.registry, "list_tracked", return_value=["tid-1"]),
+            mock.patch.object(supervisor.registry, "is_alive", return_value=False),
+            mock.patch.object(supervisor.registry, "get_payload", return_value=payload),
+            mock.patch.object(supervisor.registry, "task_id_in_queue", return_value=in_queue),
+            mock.patch.object(
+                supervisor.registry, "try_acquire_recovery_lock", return_value=lock_ok
+            ) ,
+            mock.patch.object(supervisor.registry, "grant_grace"),
+            mock.patch.object(supervisor.registry, "persist_payload"),
+            mock.patch.object(supervisor.registry, "deregister"),
+            mock.patch.object(supervisor, "_is_cancelled", return_value=False),
+            mock.patch.object(supervisor, "_rows_already_settled", return_value=False),
+            mock.patch.object(supervisor, "_abort_calculation_rows"),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        stats = supervisor.scan_and_recover(app)
+        return stats, app
+
+    def _claim(self, *, age_seconds, retries=0):
+        return {
+            "name": "calc_and_save",
+            "args": (),
+            "kwargs": {},
+            "queue": "celery",
+            "retries": retries,
+            "status": "dispatched",
+            "claimed_at": time.time() - age_seconds,
+        }
+
+    def test_8_150_young_claim_is_left_alone_without_locking(self):
+        """
+        Scenario 8.150: a claim within the dispatch grace is not touched.
+        Given: a dispatched claim younger than LEX_TASK_DISPATCH_GRACE_SECONDS
+        When: the scan runs
+        Then: counted dispatched_waiting; nothing dispatched; the recovery
+              lock is never taken (a waiting claim must not burn lock windows)
+        """
+        stats, app = self._scan(self._claim(age_seconds=1), in_queue=False)
+        self.assertEqual(stats["dispatched_waiting"], 1)
+        self.assertEqual(stats["requeued"], 0)
+        app.send_task.assert_not_called()
+        supervisor.registry.try_acquire_recovery_lock.assert_not_called()
+
+    def test_8_151_queued_claim_is_left_alone_beyond_grace(self):
+        """
+        Scenario 8.151: past the grace, a claim whose message is still on the
+        broker queue is a scheduling backlog — never a recovery case.
+        Given: an old dispatched claim; task_id_in_queue → True
+        When: the scan runs
+        Then: dispatched_waiting; no requeue (same-task-id double dispatch
+              would run the work twice)
+        """
+        stats, app = self._scan(self._claim(age_seconds=10_000), in_queue=True)
+        self.assertEqual(stats["dispatched_waiting"], 1)
+        app.send_task.assert_not_called()
+
+    def test_8_152_unreadable_queue_never_double_dispatches(self):
+        """
+        Scenario 8.152: queue unreadable → 'unknown' → treated as queued.
+        Given: an old dispatched claim; task_id_in_queue → None
+        When: the scan runs
+        Then: dispatched_waiting; no requeue — uncertainty must never produce
+              a second message
+        """
+        stats, app = self._scan(self._claim(age_seconds=10_000), in_queue=None)
+        self.assertEqual(stats["dispatched_waiting"], 1)
+        app.send_task.assert_not_called()
+
+    def test_8_153_vanished_claim_is_requeued_with_same_id(self):
+        """
+        Scenario 8.153: the message verifiably vanished (broker flushed or
+        evicted) — the one case where recovery must act, and the same-task-id
+        requeue is safe because no duplicate can exist.
+        Given: an old dispatched claim under budget; task_id_in_queue → False
+        When: the scan runs
+        Then: requeued once with the original task id; the persisted payload
+              keeps status=dispatched with a refreshed claim clock
+        """
+        stats, app = self._scan(self._claim(age_seconds=10_000, retries=0), in_queue=False)
+        self.assertEqual(stats["requeued"], 1)
+        app.send_task.assert_called_once()
+        self.assertEqual(
+            app.send_task.call_args.kwargs.get("task_id"), "tid-1",
+            "Recovery must reuse the task id so blocked waiters still resolve.",
+        )
+        persisted = supervisor.registry.persist_payload.call_args[0][1]
+        self.assertEqual(persisted["status"], "dispatched")
+        self.assertLessEqual(
+            abs(persisted["claimed_at"] - time.time()), 5,
+            "The requeued claim must get a fresh grace window.",
+        )
+
+    def test_8_154_vanished_claim_beyond_budget_gives_up(self):
+        """
+        Scenario 8.154: a vanished claim that exhausted the retry budget is
+        finalized, exactly like a dead running task.
+        Given: an old dispatched claim with retries == LEX_TASK_MAX_RETRIES;
+               task_id_in_queue → False
+        When: the scan runs
+        Then: gave_up; the row-finalize path (ABORTED) is invoked and the
+              task is deregistered
+        """
+        retries = supervisor._max_retries()
+        stats, app = self._scan(
+            self._claim(age_seconds=10_000, retries=retries), in_queue=False
+        )
+        self.assertEqual(stats["gave_up"], 1)
+        app.send_task.assert_not_called()
+        supervisor._abort_calculation_rows.assert_called_once()
+        supervisor.registry.deregister.assert_called_once_with("tid-1")
+
+
+class TestCluster08z_StartupAgeGate(E2ETestCase):
+    """Cluster 8z: the startup reset spares young untracked rows."""
+
+    e2e_models = [CelerySyncCalc]
+
+    def tearDown(self):
+        # Same asgiref executor-connection cleanup as 8x (see that module).
+        try:
+            nest_asyncio.apply()
+            asyncio.get_event_loop().run_until_complete(
+                sync_to_async(connections.close_all)()
+            )
+        except Exception:  # pragma: no cover — best-effort connection cleanup
+            pass
+        super().tearDown()
+
+    def _make_in_progress(self, name, *, age_seconds=0):
+        row = CelerySyncCalc.objects.create(name=name)
+        row.is_calculated = CalculationModel.IN_PROGRESS
+        row.save(skip_hooks=True)
+        if age_seconds:
+            backdated = lex_datetime_now() - timedelta(seconds=age_seconds)
+            CelerySyncCalc.objects.filter(pk=row.pk).update(edited_at=backdated)
+        return row
+
+    def _run_sweep(self, *, min_age=None):
+        env = {"CALLED_FROM_START_COMMAND": "1"}
+        if min_age is not None:
+            env["LEX_STARTUP_ABORT_MIN_AGE_SECONDS"] = str(min_age)
+        with mock.patch.dict(os.environ, env):
+            ModelRegistration._handle_calculation_model_reset(
+                CelerySyncCalc, tracked_record_ids=set(),
+            )
+
+    def _status(self, row):
+        return (
+            CelerySyncCalc.objects.filter(pk=row.pk)
+            .values_list("is_calculated", flat=True)
+            .first()
+        )
+
+    def test_8_155_age_gate_spares_young_rows_and_aborts_old_ones(self):
+        """
+        Scenario 8.155: with tracking unavailable (empty ownership set — the
+        blind-abort degradation), the sweep spares young rows and still
+        aborts genuinely old ones; gate=0 restores the legacy abort-all.
+        Given: one fresh IN_PROGRESS row and one backdated 2h
+        When: the sweep runs with the default gate, then with gate=0
+        Then: young survives / old aborts; with gate=0 the young row aborts too
+        """
+        young = self._make_in_progress("young")
+        old = self._make_in_progress("old", age_seconds=7200)
+
+        self._run_sweep()
+        self.assertEqual(
+            self._status(young), CalculationModel.IN_PROGRESS,
+            "A young untracked row is more likely queued than orphaned — the "
+            "startup reset must spare it (the FYF_2026_26 incident class).",
+        )
+        self.assertEqual(
+            self._status(old), CalculationModel.ABORTED,
+            "Rows older than the gate keep the legacy orphan-abort behavior.",
+        )
+
+        self._run_sweep(min_age=0)
+        self.assertEqual(
+            self._status(young), CalculationModel.ABORTED,
+            "Gate=0 must restore the legacy blind-abort semantics exactly.",
+        )
+
+
+class TestCluster08z_BootWatchdog(SimpleTestCase):
+    """Cluster 8z: 'never became ready' is itself a termination condition."""
+
+    def setUp(self):
+        from lex.lex_app import celery as worker
+
+        self.worker = worker
+        # Reset module state between scenarios.
+        self.worker._worker_became_ready.clear()
+        if self.worker._boot_timer is not None:
+            self.worker._boot_timer.cancel()
+        self.worker._boot_timer = None
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self):
+        if self.worker._boot_timer is not None:
+            self.worker._boot_timer.cancel()
+        self.worker._boot_timer = None
+        self.worker._worker_became_ready.clear()
+
+    def test_8_156_boot_watchdog_arms_fires_and_disarms(self):
+        """
+        Scenario 8.156: the boot watchdog is armed on worker_init, terminates
+        a worker that never becomes ready, and is disarmed by worker_ready.
+        Given: a non-local deployment with the watchdog enabled
+        When: worker_init fires, then either the timeout elapses or
+              worker_ready arrives first
+        Then: fire-without-ready requests a warm shutdown; ready-first makes
+              the fire a no-op and cancels the timer
+        """
+        env = {"DEPLOYMENT_TARGET": "prod", "LEX_WORKER_IDLE_SHUTDOWN_ENABLED": "true"}
+        with mock.patch.dict(os.environ, env):
+            self.worker.arm_boot_watchdog()
+            self.assertIsNotNone(
+                self.worker._boot_timer,
+                "worker_init must arm the boot watchdog in deployed environments.",
+            )
+
+            # Timeout elapses before the worker ever became ready.
+            with mock.patch.object(self.worker, "_warm_shutdown_if_idle") as shutdown:
+                self.worker._boot_watchdog_fire()
+                shutdown.assert_called_once()
+
+            # worker_ready arrived: the fire must become a no-op.
+            self.worker._worker_became_ready.set()
+            with mock.patch.object(self.worker, "_warm_shutdown_if_idle") as shutdown:
+                self.worker._boot_watchdog_fire()
+                shutdown.assert_not_called()
+
+        # Disabled environments never arm.
+        self._cleanup()
+        with mock.patch.dict(os.environ, {"DEPLOYMENT_TARGET": "local"}):
+            self.worker.arm_boot_watchdog()
+            self.assertIsNone(
+                self.worker._boot_timer,
+                "Local execution must not self-terminate.",
+            )


### PR DESCRIPTION
## Incident

2026-07-14, instance 1410 (`pfe-clone-1007-09-prod-1410`): a ~20-way calculation fan-out met a full cluster (node group at max), so most worker Jobs sat `Pending`. Independently, the cluster autoscaler scaled down the node hosting the instance's **redis + recovery-beat**. The rescheduled recovery-beat's Django startup ran the blind startup reset — which **aborted a healthy, merely-queued calculation** (`FYF_2026_26`), while its sibling calculations (whose workers had already started) survived. The idle watchdog also could not reap the workers that booted into the dead broker, and flushing redis as remediation destroyed queue and recovery tracking together.

## Root cause

One asymmetry: a calculation row goes `IN_PROGRESS` at **dispatch**, but recovery-registry ownership only began at **task start** (`task_prerun`). A dispatched-but-not-yet-started task was invisible to every protection the recovery subsystem offers.

## Hardening (4 pieces)

1. **Ownership starts at dispatch.** `CallbackTask.apply_async` — the single dispatch choke point (`lex_shared_task` sets `base=CallbackTask`) — claims the task via new `registry.claim_dispatched`: `status="dispatched"`, `claimed_at`, **no heartbeat**, written `SET NX` so a racing prerun registration is never clobbered. `task_prerun` upgrades the claim to `running`, preserving the retry budget. The startup reset's ownership lookup (`tracked_calculation_record_ids`) covers claims automatically.
2. **Queue-verified recovery for claims.** For a dispatched claim, the broker message *is* the liveness story — a missing heartbeat proves nothing. The supervisor's new lane (before the recovery lock, so waiting claims never burn lock windows): within `LEX_TASK_DISPATCH_GRACE_SECONDS` (default 300) → wait; past grace but the message is still on the queue **or the queue is unreadable** → wait (never double-dispatch on uncertainty); message **verifiably vanished** (redis flushed/evicted — the exact incident remediation) → same-task-id requeue under the normal budget, safe by construction because no duplicate message can exist.
3. **Age-gated startup reset.** Untracked `IN_PROGRESS` rows younger than `LEX_STARTUP_ABORT_MIN_AGE_SECONDS` (default 1800, `0` = legacy blind abort) are spared — when the registry is unreadable, the sweep can no longer race a scheduling backlog and eat healthy work.
4. **Boot watchdog.** Armed on `worker_init` (`LEX_WORKER_BOOT_TIMEOUT_SECONDS`, default 300, `0` = off): a worker that never fires `worker_ready` (broker unreachable at boot) warm-shuts instead of idling forever — the gap that left 15 zombie worker jobs.

Design constraints respected from the founding PRs (#596, #603, #605): `visibility_timeout` untouched, best-effort no-op on every Redis failure, retry budget committed only after a successful dispatch, settled work never resurrected. Existing 8w/8x semantics are extended, not changed — tracked→skip and the terminal-outcome guard are byte-identical paths.

## Tests

Batch **8z** (scenarios 8.145–8.156, 12 pass): claim shape + NX race semantics, prerun upgrade, `apply_async` choke point (+ untracked-name skip), queue introspection (protocol v2 + correlation-id, degrade-to-unknown), the full supervisor lane matrix (young / queued / unknown wait without locking; vanished requeues same-id under budget; exhausted gives up ABORTED), the startup age-gate E2E (young spared / old aborted / `0` restores legacy), and boot-watchdog arm/fire/disarm. **Deliberate 8x edit:** its `_run_sweep` now pins ownership semantics with the age-gate disabled — the gate has its own scenario.

Regression: `celery_async` + `init` + `calculations` = **606 pass / 20 skip / 0 fail**. Plan shards, session fragment, and dashboard synced (`validate` OK).

## Infra companions (separate, LEX_TERRAFORM_MODULES)

`safe-to-evict: "false"` on the instance redis pod (prevents the trigger) and `activeDeadlineSeconds` on the ScaledJob job template (bounds Pending-pod debris — nothing in-pod can ever reap an unscheduled pod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
