### PR TITLE
feat(recovery): scale metric for on-demand recovery-beat (batch 8c)

### DIFF
--- a/lex/api/views/calculations/RecoveryScaleMetric.py
+++ b/lex/api/views/calculations/RecoveryScaleMetric.py
@@ -1,0 +1,75 @@
+"""Scale signal for the on-demand recovery-beat pod.
+
+The recovery-beat pod (embedded Celery beat that fires the dead-worker sweep)
+used to run always-on. It only has work to do while calculations are in flight,
+so it now runs **on demand**: KEDA polls this endpoint (a ``metrics-api``
+trigger) and keeps the ``recovery-beat`` Deployment at one replica while the
+returned ``count`` is greater than zero, scaling it back to zero when there is
+nothing left to sweep.
+
+The count is the number of calculation tasks the recovery machinery still needs
+to watch for this instance, taken as the **union** of two independent signals so
+a single one being briefly unavailable never scales the sweeper away from work
+that still needs it:
+
+* the recovery **registry** index (Redis, cross-process) — populated the moment
+  a task is dispatched and cleared when it reaches a terminal state; this is
+  exactly the set the sweep operates on, including dead-but-not-yet-recovered
+  tasks whose heartbeat has expired;
+* the in-process **active-calculation store** — reconciled against the database
+  on read (terminal rows are pruned), so it still reports live work even during
+  a transient Redis blip that would momentarily empty the registry read.
+
+Fail-safe: any unexpected error reports a positive count, so the sweeper stays
+up rather than scaling down and abandoning work it cannot currently see.
+"""
+
+from django.http import JsonResponse
+from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework_api_key.permissions import HasAPIKey
+
+from lex.api.utils.api_key_requests import is_instance_api_key_request
+
+
+class HasInstanceAPIKey(BasePermission):
+    def has_permission(self, request, view):
+        return is_instance_api_key_request(request)
+
+
+def active_recovery_count() -> int:
+    """Union of the two "work still in flight" signals (see module docstring)."""
+    registry_count = 0
+    store_count = 0
+    try:
+        from lex.lex_app.celery_recovery import registry
+
+        registry_count = len(registry.list_tracked())
+    except Exception:
+        # list_tracked already degrades to [] internally; this guards the import.
+        registry_count = 0
+    try:
+        from lex.core.signals.ActiveCalculationStateStore import (
+            ActiveCalculationStateStore,
+        )
+
+        store_count = len(ActiveCalculationStateStore.snapshot())
+    except Exception:
+        store_count = 0
+    return max(registry_count, store_count)
+
+
+class RecoveryScaleMetric(APIView):
+    """KEDA scale metric for the on-demand recovery-beat pod."""
+
+    http_method_names = ["get"]
+    permission_classes = [HasInstanceAPIKey | HasAPIKey | IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        try:
+            count = active_recovery_count()
+        except Exception:
+            # Never let a scale-metric error scale the sweeper down onto work
+            # it can't see — report a positive count and keep beat up.
+            count = 1
+        return JsonResponse({"count": count})

--- a/lex/lex_app/urls.py
+++ b/lex/lex_app/urls.py
@@ -19,6 +19,7 @@ import re
 from django.contrib.staticfiles.views import serve as staticfiles_serve
 from django.urls import path, include, re_path
 from lex.api.views.calculations.ActiveCalculations import ActiveCalculations
+from lex.api.views.calculations.RecoveryScaleMetric import RecoveryScaleMetric
 from lex.authentication.views.user_api import CurrentUser
 from lex.lex_app import settings
 from lex.process_admin.settings import processAdminSite, adminSite
@@ -35,6 +36,8 @@ urlpatterns = [
     path("health", views.HealthCheck.as_view(), name="health_view"),
     path("api/health", views.HealthCheck.as_view(), name="api_health_view"),
     path("api/active-calculations", ActiveCalculations.as_view(), name="active-calculations"),
+    # Scale signal for the on-demand recovery-beat pod (KEDA metrics-api trigger).
+    path("api/recovery-scale-metric", RecoveryScaleMetric.as_view(), name="recovery-scale-metric"),
     path("api/user/", CurrentUser.as_view(), name="current-user"),
     path("api/quackback-widget-token", views.quackback_widget_token),
     path("api/quackback-widget-token/", views.quackback_widget_token, name="quackback-widget-token"),

--- a/lex/test_project/test-plan/clusters/08-celery_async/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/08-celery_async/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 8
 slug: celery_async
 title: Celery & Async
-max_scenario: 144
+max_scenario: 159
 letters:
   a:
     title: a — Post-task warm shutdown honours the idle-shutdown master switch (Session 85 — June 26)
@@ -137,3 +137,14 @@ letters:
       xfail: 0
     note: 'scenarios 8.116–8.122; pins the three silent-failure invariants of the `lex-recovery-beat`
       driver: the beat schedule names the registered `sweep_dead_workers` task and excludes it '
+  c:
+    title: On-demand recovery-beat scale metric
+    scenarios: 8.157-8.159
+    status: complete
+    tests:
+      pass: 3
+      skip: 0
+      xfail: 0
+    note: KEDA scale signal for making recovery-beat on-demand — active_recovery_count() unions the
+      recovery registry (redis) with the DB-reconciled active-calc store; fails safe upward. Scenarios
+      start at 8.157 to stack cleanly above the dispatch-claim batch (8z, 8.145-156, PR #653)

--- a/lex/test_project/test-plan/clusters/08-celery_async/batches.md
+++ b/lex/test_project/test-plan/clusters/08-celery_async/batches.md
@@ -178,3 +178,22 @@
 | Status | ✅ Complete — source fix + paired tests + plan sync in one change. Allocated `8ad` (next free letter after `8ac`); 8.142 picks up after cluster-8 scenario max 8.141. Companion: Batch 7r withdrawn (inline guard + 7.199 flip + test file removed), 7q restored to committed assertions |
 
 ---
+
+
+---
+
+### Batch 8c — On-demand recovery-beat scale metric ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 8.157 – 8.159 |
+| Type | U |
+| Files covered | `lex/api/views/calculations/RecoveryScaleMetric.py` (`active_recovery_count`, `RecoveryScaleMetric` view), `lex/lex_app/urls.py` (`api/recovery-scale-metric` route) |
+| Test file | `lex/test_project/tests/celery_async/test_8c_recovery_scale_metric.py` |
+| Test classes | `TestCluster08c_RecoveryScaleMetric` |
+| Fixtures | none (registry + active-store mocked) |
+| Est. tests | 3 |
+| Coverage gain | scale-signal path for the on-demand recovery-beat pod |
+| Prereqs | none |
+| Status | ✅ Complete — 3 pass / 0 fail |
+| Note | Lex-app half of making the recovery-beat pod **on-demand**: KEDA polls `api/recovery-scale-metric` (a `metrics-api` trigger) and runs the pod at one replica while `count > 0`, scaling to zero when idle. `count = max(registry cardinality, active-calc store size)` — the registry (Redis, cross-process, dispatch→terminal) and the DB-reconciled in-process store, unioned so neither alone can scale the sweeper off live work; any error fails safe to a positive count. Scenarios start at 8.157 to sit above the dispatch-claim batch (8z, 8.145–156, PR #653) so the two branches don't collide on scenario ids. **Infra companion (LEX_TERRAFORM_MODULES):** convert `celery_beat_recovery.yaml` to a KEDA ScaledObject (min 0 / max 1) with a `metrics-api` trigger on this endpoint. **Sequencing:** the recovery-beat also drives bitemporal future-activation clocked schedules today — those must move to the planned global scheduler before (or with) this, or future activations won't fire while the pod is scaled to zero. |

--- a/lex/test_project/test-plan/clusters/08-celery_async/cluster.md
+++ b/lex/test_project/test-plan/clusters/08-celery_async/cluster.md
@@ -141,3 +141,12 @@
 **Scenario range:** 8.142 – 8.144. **Test file:** `lex/test_project/tests/celery_async/test_8ad_dispatched_task_cancel_marker.py`. **Type:** U. **Status:** ✅ Complete (Session 91 — July 2). Allocated `8ad` (next free letter after `8ac`); 8.142 picks up after cluster-8 scenario max 8.141. Source: `lex/lex_app/celery_tasks.py` (`lex_shared_task` wrapper). 8.142 dispatched run + marker set ⇒ raises `CalculationCancelled` before the wrapped function runs; 8.143 dispatched run + no marker ⇒ marker consulted, function runs normally; 8.144 synchronous run (no context) ⇒ cancel index never consulted, function runs. 3 pass / 0 fail.
 
 ---
+
+
+### 8c. On-demand recovery-beat scale metric ✅
+
+**What it tests:** `active_recovery_count()` / `RecoveryScaleMetric` — the metric a KEDA `metrics-api` trigger polls to run the recovery-beat pod on demand (one replica while calculation work is in flight, zero when idle). The count is the **union** of the cross-process recovery registry (Redis) and the in-process, DB-reconciled active-calculation store, and fails safe upward so a metric error keeps the sweeper up.
+
+**Why a regression matters:** if the metric reads zero while work still needs watching, KEDA scales the sweeper away from a calculation that may yet need recovering.
+
+**Scenario range:** 8.157 – 8.159. **Test file:** `lex/test_project/tests/celery_async/test_8c_recovery_scale_metric.py`. **Type:** U. **Status:** ✅ 3 pass. Scenarios: 8.157 metric is the union (max) of both signals; 8.158 zero only when both are empty; 8.159 the view reports a positive count on error.

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -17,7 +17,7 @@
 | 5. History & Bitemporal | 12 | 103 | 15 | 6 | 3 |
 | 6. Audit Logging | 17 | 118 | 21 | 3 | 0 |
 | 7. Calculation State Machine | 18 | 204 | 61 | 0 | 0 |
-| 8. Celery & Async | 14 | 144 | 80 | 12 | 0 |
+| 8. Celery & Async | 15 | 159 | 83 | 12 | 0 |
 | 9. Signals & WebSocket | 6 | 42 | 14 | 0 | 0 |
 | 10. API Layer | 13 | 71 | 21 | 0 | 0 |
 | 11. Stress & Performance | 9 | 22 | 0 | 0 | 0 |
@@ -165,6 +165,7 @@
 |---|---|---|---|---|---|---|---|
 | 8a | a — Post-task warm shutdown honours the idle-shutdown master switch (Session 85 — June 26) | 8.1-8.5 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 8b |  | 8.5-8.6 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
+| 8c | On-demand recovery-beat scale metric | 8.157-8.159 | complete | 3 | 0 | 0 | KEDA scale signal for making recovery-beat on-demand — active_recovery_count() unions the recovery registry (redis) with the DB-reconciled active-calc store; fails safe upward. Scenarios start at 8.157 to stack cleanly above the dispatch-claim batch (8z, 8.145-156, PR |
 | 8g | Task infrastructure — `lex/lex_app/celery_tasks.py` | 8.7-8.15 | complete | 9 | 0 | 0 | Redis-free (`celery_tasks.py` |
 | 8h | Dispatcher & local scheduler | 8.16-8.21 | complete | 6 | 0 | 0 | 8.16–8.21; broker-free eager (`celery_tasks.py` 46%→55%, `CeleryTaskDispatcher` 0%→45% |
 | 8i | `celery.py` app config | 8.22-8.30 | complete | 9 | 0 | 0 | 8.22–8.30 (priority/nesting/filters/no-op/propagation |

--- a/lex/test_project/test-plan/progress/sessions/2026-07-15-recovery-beat-scale-metric.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-07-15-recovery-beat-scale-metric.md
@@ -1,0 +1,26 @@
+---
+date: 2026-07-15
+clusters: [8c]
+tests_added: "3 (8.157–8.159)"
+suite_tally: "8c 3 pass / 0 fail"
+---
+
+**Batch 8c landed — the lex-app half of making the recovery-beat pod on-demand.**
+Today the recovery-beat pod (embedded beat firing the dead-worker sweep) runs
+always-on, but it only has work while calculations are in flight. This adds the
+scale signal KEDA needs to run it on demand: `GET api/recovery-scale-metric`
+returns `{"count": N}` where `N = max(recovery-registry cardinality,
+active-calculation store size)` — the cross-process Redis registry unioned with
+the in-process DB-reconciled store, so neither alone can scale the sweeper off
+live work, and any error fails safe upward. KEDA keeps the pod at one replica
+while `count > 0` and scales to zero when idle.
+
+Infra companion (LEX_TERRAFORM_MODULES, drafted for Marco's review): convert
+`celery_beat_recovery.yaml` from an always-on Deployment to a KEDA ScaledObject
+(min 0 / max 1) with a `metrics-api` trigger on this endpoint. **Open sequencing
+decision:** the recovery-beat also drives bitemporal future-activation clocked
+schedules — those must move to the planned global scheduler (Marco + team, end of
+next week) before or alongside this change, or future activations won't fire
+while the pod is at zero replicas. Scenarios start at 8.157 to avoid colliding
+with the unmerged dispatch-claim batch (8z, 8.145–156, PR #653).
+See [batch 8c](../../clusters/08-celery_async/batches.md).

--- a/lex/test_project/tests/celery_async/test_8c_recovery_scale_metric.py
+++ b/lex/test_project/tests/celery_async/test_8c_recovery_scale_metric.py
@@ -1,0 +1,115 @@
+"""Cluster 8c — the on-demand recovery-beat scale metric.
+
+Intent: the recovery-beat pod (embedded beat that fires the dead-worker sweep)
+runs on demand — KEDA polls a metric endpoint and keeps the pod at one replica
+while calculation work is in flight, scaling it to zero when there is nothing to
+sweep. The metric must never read zero while work still needs watching, or the
+sweeper scales away from a calculation that may yet need recovering. It is the
+**union** of two independent signals — the cross-process recovery registry
+(Redis) and the in-process, DB-reconciled active-calculation store — so a
+transient outage of one never zeroes the metric on its own.
+Cluster 8c — scenarios 8.157–8.159. Type: U.
+Covers: lex/api/views/calculations/RecoveryScaleMetric.py
+        (active_recovery_count, RecoveryScaleMetric view).
+Run: python -m lex pytest lex/test_project/tests/celery_async/test_8c_recovery_scale_metric.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+from django.test import SimpleTestCase
+
+from lex.api.views.calculations import RecoveryScaleMetric as metric_module
+from lex.api.views.calculations.RecoveryScaleMetric import (
+    RecoveryScaleMetric,
+    active_recovery_count,
+)
+
+pytestmark = pytest.mark.celery_async
+
+
+class TestCluster08c_RecoveryScaleMetric(SimpleTestCase):
+    """Cluster 8c: the count that drives on-demand recovery-beat scaling."""
+
+    def _patch_sources(self, *, registry_ids, store_rows):
+        """Patch the registry list and the active-calc store snapshot."""
+        from lex.core.signals.ActiveCalculationStateStore import (
+            ActiveCalculationStateStore,
+        )
+        from lex.lex_app.celery_recovery import registry
+
+        return [
+            mock.patch.object(registry, "list_tracked", return_value=registry_ids),
+            mock.patch.object(ActiveCalculationStateStore, "snapshot", return_value=store_rows),
+        ]
+
+    def _count(self, *, registry_ids, store_rows):
+        patches = self._patch_sources(registry_ids=registry_ids, store_rows=store_rows)
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        return active_recovery_count()
+
+    def test_8_157_count_is_the_union_of_both_signals(self):
+        """
+        Scenario 8.157: the metric is max(registry, active-store), so neither
+        signal alone can scale the sweeper away from work the other still sees.
+        Given: registry and store reporting different amounts of work
+        When: active_recovery_count() runs
+        Then: the larger of the two is returned — including the case where one
+              is empty and the other is not
+        """
+        self.assertEqual(
+            self._count(registry_ids=["a", "b"], store_rows=[]), 2,
+            "The registry alone must keep the sweeper up when the in-process "
+            "store is empty (e.g. work dispatched from another process).",
+        )
+        self.assertEqual(
+            self._count(registry_ids=[], store_rows=[{"r": 1}]), 1,
+            "The DB-reconciled store must keep the sweeper up during a Redis "
+            "blip that momentarily empties the registry read.",
+        )
+        self.assertEqual(
+            self._count(registry_ids=["a", "b", "c"], store_rows=[{"r": 1}]), 3,
+            "With both non-empty the metric is the larger — never their sum, "
+            "which would over-report shared work.",
+        )
+
+    def test_8_158_zero_only_when_nothing_is_in_flight(self):
+        """
+        Scenario 8.158: the metric reads zero exactly when both signals are
+        empty — the one condition under which the pod may scale to zero.
+        Given: both the registry and the store empty
+        When: active_recovery_count() runs
+        Then: 0 (KEDA scales the recovery-beat Deployment to zero replicas)
+        """
+        self.assertEqual(
+            self._count(registry_ids=[], store_rows=[]), 0,
+            "Only a genuinely idle instance — nothing tracked, nothing active — "
+            "may scale the sweeper to zero.",
+        )
+
+    def test_8_159_view_reports_positive_count_on_error(self):
+        """
+        Scenario 8.159: any failure computing the count fails safe upward.
+        Given: active_recovery_count raises
+        When: the endpoint is called
+        Then: it responds 200 with a positive count, so a metric error keeps
+              the sweeper up rather than scaling it onto work it can't see
+        """
+        request = mock.MagicMock()
+        with mock.patch.object(
+            metric_module, "active_recovery_count", side_effect=RuntimeError("boom")
+        ):
+            response = RecoveryScaleMetric().get(request)
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+        self.assertGreater(
+            payload["count"], 0,
+            "A scale-metric error must report positive so the sweeper is never "
+            "scaled down onto work it failed to observe.",
+        )


### PR DESCRIPTION
## What

Backend half of making the **recovery-beat pod on-demand**. The pod (embedded beat that fires the dead-worker sweep) runs always-on today but only has work while calculations are in flight. This adds the signal a KEDA `metrics-api` trigger polls to run it on demand.

New endpoint:

```
GET /api/recovery-scale-metric  ->  {"count": N}
```

KEDA keeps the `recovery-beat` Deployment at **1 replica while `count > 0`** and scales it to **0 when idle**.

## The count

`N = max(recovery-registry cardinality, active-calculation store size)` — a **union** of two independent signals so neither alone can scale the sweeper off live work:

- **Recovery registry** (Redis, cross-process) — populated at dispatch (dispatch-time claim, PR #653), cleared at terminal; this is exactly the set the sweep operates on, including dead-but-not-yet-recovered tasks whose heartbeat has expired.
- **Active-calculation store** (in-process, DB-reconciled on read) — keeps the metric positive during a transient Redis blip that would momentarily empty the registry read.

Any error computing the count **fails safe upward** (positive count) so a metric failure keeps beat up rather than scaling it onto work it can't see.

## Tests

Batch **8c** (scenarios 8.157–8.159, type U, 3 pass): the metric is the union (max) of both signals; reads zero only when both are empty; the view reports a positive count on error. Plan shards + session fragment synced.

> Scenarios start at 8.157 to stack above the still-unmerged dispatch-claim batch (8z, 8.145–156, PR #653) so the two branches don't collide on scenario ids.

## Companion + open decisions

Infra companion: **LEX_TERRAFORM_MODULES** — `recovery-beat` → KEDA ScaledObject (min 0 / max 1) on this endpoint, feature-flagged `workers.recoveryBeatOnDemand` (default off).

**Draft** because two decisions must close first (both on the infra PR):
1. KEDA API-key auth mode + header (confirm against `API_KEY_CUSTOM_HEADER`).
2. **Sequencing** — recovery-beat also drives bitemporal future-activation clocked schedules; those must move to the planned global scheduler before on-demand is enabled, or future activations won't fire at 0 replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
