### PR TITLE
feat(recovery): in-flight Redis LIST mirror — scale signal for the recovery pod (batch 8d)

### DIFF
--- a/lex/lex_app/celery_recovery/redis_keys.py
+++ b/lex/lex_app/celery_recovery/redis_keys.py
@@ -29,3 +29,9 @@ def payload_key(task_id: str) -> str:
 def index_key() -> str:
     """SET of every task_id currently tracked for recovery."""
     return f"{key_prefix()}lex:recover:index"
+
+
+def inflight_list_key() -> str:
+    """LIST mirror of :func:`index_key`; KEDA reads its length (``LLEN``) to
+    scale the recovery pod 0↔1 while calculation work is in flight."""
+    return f"{key_prefix()}lex:recover:inflight"

--- a/lex/lex_app/celery_recovery/registry.py
+++ b/lex/lex_app/celery_recovery/registry.py
@@ -137,9 +137,17 @@ def register(
             "queue": queue,
             "retries": retries,
         }
-        client.set(redis_keys.payload_key(task_id), _encode(payload), ex=_payload_ttl())
-        client.sadd(redis_keys.index_key(), task_id)
-        client.set(redis_keys.heartbeat_key(task_id), "1", ex=_heartbeat_ttl())
+        # Single round trip for the payload/index/heartbeat writes, and the
+        # SADD result tells us whether the id is NEW to the index — only then
+        # is it mirrored onto the in-flight LIST (KEDA scale signal), so a
+        # requeue re-register of a still-tracked id never double-counts.
+        pipe = client.pipeline()
+        pipe.set(redis_keys.payload_key(task_id), _encode(payload), ex=_payload_ttl())
+        pipe.sadd(redis_keys.index_key(), task_id)
+        pipe.set(redis_keys.heartbeat_key(task_id), "1", ex=_heartbeat_ttl())
+        results = pipe.execute()
+        if results[1]:  # SADD returned 1 → newly tracked
+            client.lpush(redis_keys.inflight_list_key(), task_id)
     except Exception:
         logger.warning("Celery recovery: register failed for %s", task_id, exc_info=True)
 
@@ -175,8 +183,38 @@ def deregister(task_id: str) -> None:
         client.srem(redis_keys.index_key(), task_id)
         client.delete(redis_keys.payload_key(task_id))
         client.delete(redis_keys.heartbeat_key(task_id))
+        # Drain every occurrence from the in-flight LIST mirror (count 0 =
+        # all) so the KEDA scale signal returns to zero with the index.
+        client.lrem(redis_keys.inflight_list_key(), 0, task_id)
     except Exception:
         logger.warning("Celery recovery: deregister failed for %s", task_id, exc_info=True)
+
+
+def reconcile_inflight_list() -> int:
+    """Rebuild the in-flight LIST mirror from current index-SET membership.
+
+    Rollout / crash safety: a pod that starts with a non-empty index — tasks
+    registered before the list existed (mid-cutover), or a leaked entry from
+    a crash between the SET and LIST writes — must expose the true amount of
+    in-flight work to KEDA. Called once at recovery-supervisor startup.
+
+    Returns the number of entries in the rebuilt list (0 on any failure —
+    best-effort like every registry operation).
+    """
+    client = _get_client()
+    if client is None:
+        return 0
+    try:
+        members = list(client.smembers(redis_keys.index_key()) or [])
+        pipe = client.pipeline()
+        pipe.delete(redis_keys.inflight_list_key())
+        if members:
+            pipe.lpush(redis_keys.inflight_list_key(), *members)
+        pipe.execute()
+        return len(members)
+    except Exception:
+        logger.warning("Celery recovery: reconcile_inflight_list failed", exc_info=True)
+        return 0
 
 
 def list_tracked() -> List[str]:

--- a/lex/lex_app/management/commands/run_recovery_supervisor.py
+++ b/lex/lex_app/management/commands/run_recovery_supervisor.py
@@ -106,6 +106,23 @@ class Command(BaseCommand):
                 "run_recovery_supervisor: enable(app) failed; continuing"
             )
 
+        # Rebuild the in-flight LIST mirror (the KEDA scale signal) from the
+        # index SET so a pod starting mid-cutover — or after a crash between
+        # the SET and LIST writes — exposes the true in-flight work to KEDA.
+        # Best-effort: a failure only degrades the scale signal, never recovery.
+        try:
+            from lex.lex_app.celery_recovery import registry
+
+            reconciled = registry.reconcile_inflight_list()
+            logger.info(
+                "run_recovery_supervisor: in-flight list reconciled (%s entries)",
+                reconciled,
+            )
+        except Exception:  # pragma: no cover - never block startup on wiring
+            logger.exception(
+                "run_recovery_supervisor: reconcile_inflight_list failed; continuing"
+            )
+
         if run_once:
             stats = supervisor.scan_and_recover(app)
             self.stdout.write(f"Recovery sweep stats: {stats}")

--- a/lex/test_project/test-plan/clusters/08-celery_async/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/08-celery_async/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 8
 slug: celery_async
 title: Celery & Async
-max_scenario: 144
+max_scenario: 160
 letters:
   a:
     title: a — Post-task warm shutdown honours the idle-shutdown master switch (Session 85 — June 26)
@@ -137,3 +137,15 @@ letters:
       xfail: 0
     note: 'scenarios 8.116–8.122; pins the three silent-failure invariants of the `lex-recovery-beat`
       driver: the beat schedule names the registered `sweep_dead_workers` task and excludes it '
+  d:
+    title: In-flight LIST mirror (recovery-pod scale signal)
+    scenarios: 8.157-8.160
+    status: complete
+    tests:
+      pass: 4
+      skip: 0
+      xfail: 0
+    note: parallel Redis LIST mirroring the recovery index SET so KEDA's native redis scaler
+      (LLEN) can scale the recovery pod 0<->1; SADD-guarded LPUSH (no requeue double-count),
+      LREM-all on deregister, startup reconcile. Scenarios start at 8.157 to stack above the
+      unmerged dispatch-claim batch (8z, 8.145-156, PR #653)

--- a/lex/test_project/test-plan/clusters/08-celery_async/batches.md
+++ b/lex/test_project/test-plan/clusters/08-celery_async/batches.md
@@ -178,3 +178,22 @@
 | Status | ✅ Complete — source fix + paired tests + plan sync in one change. Allocated `8ad` (next free letter after `8ac`); 8.142 picks up after cluster-8 scenario max 8.141. Companion: Batch 7r withdrawn (inline guard + 7.199 flip + test file removed), 7q restored to committed assertions |
 
 ---
+
+
+---
+
+### Batch 8d — In-flight LIST mirror (recovery-pod scale signal) ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 8.157 – 8.160 |
+| Type | U |
+| Files covered | `lex_app/celery_recovery/redis_keys.py` (`inflight_list_key`), `lex_app/celery_recovery/registry.py` (register/deregister mirror, `reconcile_inflight_list`), `lex_app/management/commands/run_recovery_supervisor.py` (startup reconcile) |
+| Test file | `lex/test_project/tests/celery_async/test_8d_inflight_list_mirror.py` |
+| Test classes | `TestCluster08d_InflightListMirror` |
+| Fixtures | `FakeRedis` (in-file: strings/sets/lists/pipeline — real LLEN/LREM semantics) |
+| Est. tests | 4 |
+| Coverage gain | scale-signal path for scaling the recovery pod to zero |
+| Prereqs | none (behaviourally inert until KEDA points at the list) |
+| Status | ✅ Complete — 4 pass / 0 fail |
+| Note | Lex-app half of scaling the recovery pod to zero (design locked as **Option A — parallel Redis list**, chosen over an HTTP metrics endpoint: KEDA's native `redis` scaler reads `LLEN`, reuses the existing worker TriggerAuthentication, and shares the work's failure domain — a leaked entry keeps recovery *up*, wasteful not unsafe). The registry maintains `<id>:lex:recover:inflight` as an exact mirror of the index SET: SADD-guarded LPUSH in `register()` (a requeue re-register never double-counts), LREM count-0 in `deregister()`, and a startup `reconcile_inflight_list()` in the supervisor command for mid-cutover/crash safety. 8.157 mirror-once across requeues; 8.158 deregister drains all occurrences; 8.159 reconcile rebuilds from the SET; 8.160 the sweep's give-up path drains the signal to zero. **Interaction note:** if the dispatch-claim batch (8z, PR #653) merges, `claim_dispatched()` must gain the same SADD-guarded LPUSH — one-line follow-up in whichever lands second. **Infra companion (blocked):** recovery pod → KEDA ScaledObject on `LLEN inflight`; blocked on relocating the bitemporal future-activation clock to the global scheduler. |

--- a/lex/test_project/test-plan/clusters/08-celery_async/cluster.md
+++ b/lex/test_project/test-plan/clusters/08-celery_async/cluster.md
@@ -141,3 +141,12 @@
 **Scenario range:** 8.142 – 8.144. **Test file:** `lex/test_project/tests/celery_async/test_8ad_dispatched_task_cancel_marker.py`. **Type:** U. **Status:** ✅ Complete (Session 91 — July 2). Allocated `8ad` (next free letter after `8ac`); 8.142 picks up after cluster-8 scenario max 8.141. Source: `lex/lex_app/celery_tasks.py` (`lex_shared_task` wrapper). 8.142 dispatched run + marker set ⇒ raises `CalculationCancelled` before the wrapped function runs; 8.143 dispatched run + no marker ⇒ marker consulted, function runs normally; 8.144 synchronous run (no context) ⇒ cancel index never consulted, function runs. 3 pass / 0 fail.
 
 ---
+
+
+### 8d. In-flight LIST mirror (recovery-pod scale signal) ✅
+
+**What it tests:** the parallel Redis LIST (`lex:recover:inflight`) that mirrors the recovery index SET so KEDA's native `redis` scaler can scale the recovery pod to zero when no calculation is in flight. Mirror-exactness at every transition: register (once, even across requeues), deregister (drain all), startup reconcile (rebuild from SET), and the sweep's terminal path returning the signal to zero.
+
+**Why a regression matters:** an under-counting mirror scales the recovery pod away from live work (a dead worker's task never recovers); an over-counting one keeps a pod running forever.
+
+**Scenario range:** 8.157 – 8.160. **Test file:** `lex/test_project/tests/celery_async/test_8d_inflight_list_mirror.py`. **Type:** U. **Status:** ✅ 4 pass.

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -17,7 +17,7 @@
 | 5. History & Bitemporal | 12 | 103 | 15 | 6 | 3 |
 | 6. Audit Logging | 17 | 118 | 21 | 3 | 0 |
 | 7. Calculation State Machine | 18 | 204 | 61 | 0 | 0 |
-| 8. Celery & Async | 14 | 144 | 80 | 12 | 0 |
+| 8. Celery & Async | 15 | 160 | 84 | 12 | 0 |
 | 9. Signals & WebSocket | 6 | 42 | 14 | 0 | 0 |
 | 10. API Layer | 13 | 71 | 21 | 0 | 0 |
 | 11. Stress & Performance | 9 | 22 | 0 | 0 | 0 |
@@ -165,6 +165,7 @@
 |---|---|---|---|---|---|---|---|
 | 8a | a — Post-task warm shutdown honours the idle-shutdown master switch (Session 85 — June 26) | 8.1-8.5 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 8b |  | 8.5-8.6 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
+| 8d | In-flight LIST mirror (recovery-pod scale signal) | 8.157-8.160 | complete | 4 | 0 | 0 | parallel Redis LIST mirroring the recovery index SET so KEDA's native redis scaler (LLEN) can scale the recovery pod 0<->1; SADD-guarded LPUSH (no requeue double-count), LREM-all on deregister, startup reconcile. Scenarios start at 8.157 to stack above the unmerged dispatch-claim batch (8z, 8.145-156, PR |
 | 8g | Task infrastructure — `lex/lex_app/celery_tasks.py` | 8.7-8.15 | complete | 9 | 0 | 0 | Redis-free (`celery_tasks.py` |
 | 8h | Dispatcher & local scheduler | 8.16-8.21 | complete | 6 | 0 | 0 | 8.16–8.21; broker-free eager (`celery_tasks.py` 46%→55%, `CeleryTaskDispatcher` 0%→45% |
 | 8i | `celery.py` app config | 8.22-8.30 | complete | 9 | 0 | 0 | 8.22–8.30 (priority/nesting/filters/no-op/propagation |

--- a/lex/test_project/test-plan/progress/sessions/2026-07-15-inflight-list-mirror.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-07-15-inflight-list-mirror.md
@@ -1,0 +1,24 @@
+---
+date: 2026-07-15
+clusters: [8d]
+tests_added: "4 (8.157–8.160)"
+suite_tally: "8d 4 pass / 0 fail; regression: full celery_async = 144 pass / 7 skip / 0 fail"
+---
+
+**Batch 8d landed — the lex-app half of scaling the recovery pod to zero
+(design locked as Option A: parallel Redis list).** The recovery pod only has
+work while the registry index SET is non-empty, but KEDA's native `redis`
+scaler reads list length, not set cardinality — so the registry now maintains
+`<id>:lex:recover:inflight` as an exact LIST mirror of the index: SADD-guarded
+LPUSH in `register()` (requeue re-registers never double-count), LREM count-0
+in `deregister()`, and `reconcile_inflight_list()` at supervisor startup for
+mid-cutover/crash safety. Chosen over the earlier HTTP metrics-endpoint draft
+(superseded, PR #654 closed): the native scaler reuses the worker ScaledJob's
+existing TriggerAuthentication (no new auth wiring) and shares the work's
+failure domain — a leaked entry keeps recovery up, wasteful not unsafe.
+Behaviourally inert until the infra half points KEDA at the list; that half
+(recovery pod as ScaledObject, min 0 / max 1) is drafted but **blocked** on
+relocating the bitemporal future-activation clock to the planned global
+scheduler. Interaction note: if the dispatch-claim batch (8z, PR #653) merges,
+`claim_dispatched()` needs the same SADD-guarded LPUSH — one-line follow-up in
+whichever lands second. See [batch 8d](../../clusters/08-celery_async/batches.md).

--- a/lex/test_project/tests/celery_async/test_8d_inflight_list_mirror.py
+++ b/lex/test_project/tests/celery_async/test_8d_inflight_list_mirror.py
@@ -1,0 +1,228 @@
+"""Cluster 8d — the in-flight LIST mirror that scales the recovery pod.
+
+Intent: the recovery pod only has work while calculations are in flight — the
+window in which the recovery registry's index SET is non-empty. KEDA's native
+``redis`` scaler reads list length (``LLEN``), not set cardinality, so the
+registry maintains a parallel LIST (``<id>:lex:recover:inflight``) that mirrors
+index membership; KEDA points at its length to scale the pod 0↔1. The mirror
+must track the SET exactly: a requeue re-register never double-counts, a
+deregister drains every occurrence, and a supervisor booting mid-cutover (or
+after a crash between the SET and LIST writes) rebuilds the list from the SET.
+The signal fails safe by construction — a leaked list entry keeps the recovery
+pod *up* (wasteful), never down (unsafe).
+Cluster 8d — scenarios 8.157–8.160. Type: U.
+Covers: lex/lex_app/celery_recovery/redis_keys.py (inflight_list_key),
+        lex/lex_app/celery_recovery/registry.py (register/deregister mirror,
+        reconcile_inflight_list),
+        lex/lex_app/management/commands/run_recovery_supervisor.py
+        (startup reconcile).
+Run: python -m lex pytest lex/test_project/tests/celery_async/test_8d_inflight_list_mirror.py -v
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from django.test import SimpleTestCase
+
+from lex.lex_app.celery_recovery import redis_keys, registry, supervisor
+
+pytestmark = pytest.mark.celery_async
+
+
+class FakeRedis:
+    """Just enough redis-py surface for the registry's key/set/list ops."""
+
+    def __init__(self):
+        self.kv = {}
+        self.sets = {}
+        self.lists = {}
+
+    # -- strings ------------------------------------------------------
+    def set(self, key, value, ex=None, nx=None):
+        if nx and key in self.kv:
+            return None
+        self.kv[key] = value
+        return True
+
+    def get(self, key):
+        return self.kv.get(key)
+
+    def delete(self, key):
+        self.kv.pop(key, None)
+        self.sets.pop(key, None)
+        self.lists.pop(key, None)
+
+    def exists(self, key):
+        return int(key in self.kv)
+
+    def expire(self, key, ttl):
+        return key in self.kv
+
+    # -- sets ---------------------------------------------------------
+    def sadd(self, key, *members):
+        target = self.sets.setdefault(key, set())
+        added = sum(1 for m in members if m not in target)
+        target.update(members)
+        return added
+
+    def srem(self, key, *members):
+        target = self.sets.get(key, set())
+        removed = sum(1 for m in members if m in target)
+        target.difference_update(members)
+        return removed
+
+    def smembers(self, key):
+        return set(self.sets.get(key, set()))
+
+    # -- lists --------------------------------------------------------
+    def lpush(self, key, *values):
+        target = self.lists.setdefault(key, [])
+        for value in values:
+            target.insert(0, value)
+        return len(target)
+
+    def lrem(self, key, count, value):
+        target = self.lists.get(key, [])
+        removed = target.count(value)
+        self.lists[key] = [v for v in target if v != value]
+        return removed
+
+    def llen(self, key):
+        return len(self.lists.get(key, []))
+
+    def lrange(self, key, start, end):
+        target = self.lists.get(key, [])
+        end = len(target) if end == -1 else end + 1
+        return target[start:end]
+
+    # -- pipeline (sequential; good enough for these semantics) --------
+    def pipeline(self):
+        fake = self
+
+        class _Pipe:
+            def __init__(self):
+                self._queued = []
+
+            def __getattr__(self, name):
+                def _queue(*args, **kwargs):
+                    self._queued.append((name, args, kwargs))
+                    return self
+
+                return _queue
+
+            def execute(self):
+                return [getattr(fake, n)(*a, **k) for n, a, k in self._queued]
+
+        return _Pipe()
+
+
+class TestCluster08d_InflightListMirror(SimpleTestCase):
+    """Cluster 8d: LIST length == index membership, at every transition."""
+
+    def setUp(self):
+        self.fake = FakeRedis()
+        patcher = mock.patch.object(registry, "_get_client", return_value=self.fake)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _llen(self):
+        return self.fake.llen(redis_keys.inflight_list_key())
+
+    def _index(self):
+        return self.fake.smembers(redis_keys.index_key())
+
+    def test_8_157_register_mirrors_once_even_across_requeues(self):
+        """
+        Scenario 8.157: registration adds the id to the LIST exactly once.
+        Given: an empty registry
+        When: register() runs for a task, then runs AGAIN for the same id
+              (a requeue re-register keeps the id in the SET)
+        Then: the id is in the index and LLEN == 1 after both — the mirror
+              never double-counts a still-tracked task
+        """
+        registry.register("tid-1", "calc_and_save", (), {}, "celery")
+        self.assertIn("tid-1", self._index())
+        self.assertEqual(self._llen(), 1, "First registration mirrors onto the list.")
+
+        registry.register("tid-1", "calc_and_save", (), {}, "celery")
+        self.assertEqual(
+            self._llen(), 1,
+            "A requeue-style re-register of a tracked id must not grow the "
+            "list — KEDA would over-scale and the drain would under-count.",
+        )
+
+    def test_8_158_deregister_drains_every_occurrence(self):
+        """
+        Scenario 8.158: deregister removes the id from SET and LIST entirely.
+        Given: a tracked task, plus a duplicated list entry (leaked by a
+               hypothetical crash between writes)
+        When: deregister() runs
+        Then: index empty and LLEN == 0 — LREM count 0 removes all occurrences,
+              so the scale signal returns to zero with the index
+        """
+        registry.register("tid-1", "calc_and_save", (), {}, "celery")
+        # Simulate a leaked duplicate.
+        self.fake.lpush(redis_keys.inflight_list_key(), "tid-1")
+        self.assertEqual(self._llen(), 2)
+
+        registry.deregister("tid-1")
+        self.assertEqual(self._index(), set(), "The index entry is gone.")
+        self.assertEqual(
+            self._llen(), 0,
+            "Deregister must drain every list occurrence, or the recovery pod "
+            "would stay scaled up forever on a leaked duplicate.",
+        )
+
+    def test_8_159_reconcile_rebuilds_list_from_index(self):
+        """
+        Scenario 8.159: startup reconcile makes the LIST reflect the SET.
+        Given: an index with three tracked ids and a stale/patchy list
+        When: reconcile_inflight_list() runs
+        Then: the list holds exactly the index members (count returned), so a
+              pod booting mid-cutover exposes the true in-flight work to KEDA
+        """
+        for tid in ("a", "b", "c"):
+            self.fake.sadd(redis_keys.index_key(), tid)
+        self.fake.lpush(redis_keys.inflight_list_key(), "stale-junk")
+
+        rebuilt = registry.reconcile_inflight_list()
+
+        self.assertEqual(rebuilt, 3)
+        self.assertEqual(self._llen(), 3)
+        self.assertEqual(
+            set(self.fake.lrange(redis_keys.inflight_list_key(), 0, -1)),
+            {"a", "b", "c"},
+            "The rebuilt list must contain exactly the index members.",
+        )
+
+    def test_8_160_recovery_give_up_drains_the_scale_signal(self):
+        """
+        Scenario 8.160: the sweep's terminal path drives the mirror to zero.
+        Given: a tracked task whose heartbeat expired and whose retry budget
+               is exhausted
+        When: scan_and_recover() runs
+        Then: the task is given up (ABORTED path), deregistered, and the
+              in-flight list is empty — the recovery pod may scale back to 0
+        """
+        registry.register("tid-1", "calc_and_save", (), {}, "celery")
+        # Exhaust the budget and kill the heartbeat.
+        payload = registry.get_payload("tid-1")
+        payload["retries"] = supervisor._max_retries()
+        registry.persist_payload("tid-1", payload)
+        self.fake.kv.pop(redis_keys.heartbeat_key("tid-1"), None)
+
+        app = mock.MagicMock()
+        app.AsyncResult.return_value.ready.return_value = False
+        with mock.patch.object(supervisor, "_is_cancelled", return_value=False), \
+             mock.patch.object(supervisor, "_rows_already_settled", return_value=False), \
+             mock.patch.object(supervisor, "_abort_calculation_rows"):
+            stats = supervisor.scan_and_recover(app)
+
+        self.assertEqual(stats["gave_up"], 1, "The exhausted task must be finalized.")
+        self.assertEqual(self._index(), set())
+        self.assertEqual(
+            self._llen(), 0,
+            "Give-up must drain the scale signal so the pod can scale to 0.",
+        )


### PR DESCRIPTION
## What

Repo A of the scale-recovery-to-zero plan (**design locked: Option A — parallel Redis list**). The recovery pod only has work while a calculation is in flight — exactly the window in which the recovery registry's index SET is non-empty. KEDA's native `redis` scaler reads list length (`LLEN`), not set cardinality, so the registry now maintains **`<id>:lex:recover:inflight`** as an exact LIST mirror of the index. Behaviourally inert until the infra half points KEDA at it.

## How the mirror stays exact

- **`register()`** — payload/index/heartbeat writes go through one pipeline; the `SADD` result gates the `LPUSH`, so a requeue re-register of a still-tracked id never double-counts.
- **`deregister()`** — `LREM` count 0 drains every occurrence, so the scale signal returns to zero with the index (covers leaked duplicates too).
- **`reconcile_inflight_list()`** — rebuilds the list from SET membership; called once at recovery-supervisor startup so a pod booting mid-cutover (or after a crash between the SET and LIST writes) exposes the true in-flight work.

Fails safe by construction: a leaked entry keeps the recovery pod **up** (wasteful), never down (unsafe).

## Why this supersedes #654

The earlier draft exposed an HTTP `metrics-api` endpoint. The native redis scaler is better on all three axes that matter here: no new KEDA auth wiring (reuses the worker ScaledJob's existing `TriggerAuthentication`), the signal shares the work's failure domain, and no backend/DB dependency per poll. #654 is closed in favour of this.

## Tests

Batch **8d** (scenarios 8.157–8.160, type U, 4 pass, in-file `FakeRedis` with real LLEN/LREM semantics): mirror-once across requeues; deregister drains all occurrences; reconcile rebuilds from the SET; the sweep's give-up path drains the signal to zero. Full `celery_async` regression: **144 pass / 7 skip / 0 fail**. Plan shards + session fragment synced.

## Interactions & sequencing

- **PR #653 (dispatch-time claims):** if it merges, `claim_dispatched()` must gain the same SADD-guarded `LPUSH` — a one-line follow-up in whichever lands second (noted in both places).
- **Infra half (blocked):** recovery pod → KEDA ScaledObject on `LLEN inflight` (LEX_TERRAFORM_MODULES `feat/recovery-supervisor-scale-to-zero`), **blocked** on relocating the bitemporal future-activation clock to the global scheduler. This lex-app change ships independently.
- Scenarios start at 8.157 to stack above #653's 8.145–156 so the branches don't collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
