### PR TITLE
fix(timezone): restore the pre-rc212 naive convention behind LEX_TIME_ZONE (batch 12j)

### DIFF
--- a/lex/api/serializers/base_serializers.py
+++ b/lex/api/serializers/base_serializers.py
@@ -5,6 +5,7 @@ from django.apps import apps
 from django.db import models
 from django.db.models import Model, ForeignKey
 from django.db.models.fields import DateTimeField, DateField, TimeField
+from django.utils import timezone
 from lex.api.utils.helpers import can_read_with_default_permission_scope
 from lex.audit_logging.utils.content_types import safe_get_content_type
 from lex.core.models.LexModel import LexModel, UserContext
@@ -207,6 +208,36 @@ def _resolve_fk_names(remote_model, referenced_pks) -> dict:
     return names
 
 
+class LexAwareDateTimeField(serializers.DateTimeField):
+    """DateTimeField that labels naive values with the instance's real offset.
+
+    Under ``USE_TZ=False`` the framework stores NAIVE datetimes whose meaning
+    is defined by ``TIME_ZONE`` (the PostgreSQL connection timezone). When that
+    convention is UTC, the static ``DATETIME_FORMAT`` suffix ('Z') in settings
+    labels values correctly and this field falls through to the default. When
+    an instance restores the pre-rc212 local convention
+    (``LEX_TIME_ZONE=Europe/Berlin``), a static suffix cannot be truthful —
+    the offset is +01:00 or +02:00 depending on DST — so this field attaches
+    the zone per value and emits a full ISO string with the correct offset.
+    Clients then render the intended wall-clock time in any timezone.
+    """
+
+    def to_representation(self, value):
+        from django.conf import settings as dj_settings
+
+        if (
+            value is not None
+            and not getattr(dj_settings, "USE_TZ", False)
+            and dj_settings.TIME_ZONE != "UTC"
+            and timezone.is_naive(value)
+        ):
+            import zoneinfo
+
+            aware = value.replace(tzinfo=zoneinfo.ZoneInfo(dj_settings.TIME_ZONE))
+            return aware.isoformat()
+        return super().to_representation(value)
+
+
 class LexClearableFileField(serializers.FileField):
     """FileField that accepts an empty string as an explicit "clear" marker.
 
@@ -255,6 +286,7 @@ class LexSerializer(serializers.ModelSerializer):
         **serializers.ModelSerializer.serializer_field_mapping,
         models.FileField: LexClearableFileField,
         models.ImageField: LexClearableImageField,
+        models.DateTimeField: LexAwareDateTimeField,
     }
 
     # ------------------------------------------------------------------

--- a/lex/api/utils/temporal.py
+++ b/lex/api/utils/temporal.py
@@ -37,4 +37,9 @@ def parse_as_of_datetime(raw_value: str | None) -> Optional[datetime]:
     if settings.USE_TZ:
         return parsed_utc
 
-    return timezone.make_naive(parsed_utc, dt_timezone.utc)
+    # Naive storage: the ORM compares against naive values whose meaning is
+    # the TIME_ZONE convention (UTC by default; Europe/Berlin on instances
+    # that restored the pre-rc212 local convention via LEX_TIME_ZONE). The
+    # parsed instant must be expressed in that same convention or every
+    # comparison shifts by the UTC offset.
+    return timezone.make_naive(parsed_utc, timezone.get_default_timezone())

--- a/lex/audit_logging/serializers/CalculationLogSerializer.py
+++ b/lex/audit_logging/serializers/CalculationLogSerializer.py
@@ -6,6 +6,18 @@ from rest_framework import serializers
 class CalculationLogDefaultSerializer(serializers.ModelSerializer):
     calculation_record = serializers.SerializerMethodField()
 
+    # Same timezone-aware datetime rendering as LexSerializer, so log
+    # timestamps stay truthful when an instance runs a non-UTC naive
+    # convention (LEX_TIME_ZONE).
+    from django.db import models as _models
+
+    from lex.api.serializers.base_serializers import LexAwareDateTimeField as _LexAwareDT
+
+    serializer_field_mapping = {
+        **serializers.ModelSerializer.serializer_field_mapping,
+        _models.DateTimeField: _LexAwareDT,
+    }
+
     class Meta:
         model = CalculationLog
         fields = [

--- a/lex/lex_app/settings.py
+++ b/lex/lex_app/settings.py
@@ -762,7 +762,14 @@ USE_TZ = True if DATABASE_DEPLOYMENT_TARGET not in ("default", "GCP") else False
 # hours late). Forcing UTC here makes the naive-as-UTC assumption correct.
 # When USE_TZ is True, datetimes are tz-aware and the display zone is free to be
 # Europe/Berlin without affecting scheduling.
-TIME_ZONE = "Europe/Berlin" if USE_TZ else "UTC"
+# LEX_TIME_ZONE restores per-instance control now that the beat constraint is
+# being retired (recovery moves to the always-on supervisor and future-edit
+# activations to the global scheduler — neither reads naive datetimes as UTC).
+# Instances that predate v2.0.0rc212 stored naive datetimes as Europe/Berlin
+# wall-clock; pinning them back via LEX_TIME_ZONE=Europe/Berlin restores that
+# original convention. ONLY set it once the instance is beat-free AND rows
+# written in the UTC era have been rebased (see `lex rebase_datetimes`).
+TIME_ZONE = os.getenv("LEX_TIME_ZONE") or ("Europe/Berlin" if USE_TZ else "UTC")
 
 # BUG-025: when USE_TZ is False every stored datetime is NAIVE UTC (the
 # TIME_ZONE coupling above guarantees it), but DRF's default ISO-8601
@@ -775,7 +782,10 @@ TIME_ZONE = "Europe/Berlin" if USE_TZ else "UTC"
 # normalized back to naive UTC by DRF's enforce_timezone). When USE_TZ is
 # True DRF keeps its default rendering with real offsets ("…+02:00") and
 # needs no help.
-if not USE_TZ:
+# The static 'Z' suffix is only truthful when the naive convention IS UTC.
+# Under a non-UTC LEX_TIME_ZONE the DST-aware offset is attached per value by
+# LexAwareDateTimeField (base_serializers) instead.
+if not USE_TZ and TIME_ZONE == "UTC":
     REST_FRAMEWORK["DATETIME_FORMAT"] = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 # Static files (CSS, JavaScript, Images)

--- a/lex/test_project/test-plan/clusters/12-serializers/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/12-serializers/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 12
 slug: serializers
 title: Serializer Contract
-max_scenario: 45
+max_scenario: 48
 letters:
   a:
     title: Read contract — field visibility & framework-managed fields
@@ -95,3 +95,14 @@ letters:
       ModelExport._apply_foreign_key_display_names), detail resolves per-instance; raw id untouched so
       filtering/editing unaffected; null FK → null companion. Resolves the backend root cause of
       frontend BUG-F-003 (FK columns rendered as bare ids)
+  j:
+    title: Local naive-convention datetimes (LEX_TIME_ZONE)
+    scenarios: 12.46-12.48
+    status: complete
+    tests:
+      pass: 3
+      skip: 0
+      xfail: 0
+    note: env-gated restore of the pre-rc212 Berlin naive convention (f622c9c fallout, customer
+      ticket 2026-07-16) — DST-aware offset rendering via LexAwareDateTimeField, as_of parsing
+      normalized to the instance convention; UTC default byte-identical (12g/5m gates green)

--- a/lex/test_project/test-plan/clusters/12-serializers/batches.md
+++ b/lex/test_project/test-plan/clusters/12-serializers/batches.md
@@ -55,3 +55,22 @@
 | Prereqs | none |
 | Status | ✅ Complete — 4 pass / 0 fail |
 | Note | Resolves the **backend root cause of frontend BUG-F-003** (FK columns render as bare ids like `79`). Every serialized row now carries an **additive** companion key `<fk>__short_description` = `str(related)` (the model author's `__str__`/`short_description` — the documented customization point) alongside the untouched raw id, so filtering/editing on the id are unaffected. The list path resolves the whole page's names in **one `pk__in` query per FK** (mirrors `ModelExport._apply_foreign_key_display_names`); the detail path resolves per-instance (one query, fine) so list-row shape ⊆ detail shape (the 12c invariant holds). Null FK → null companion (stable row shape). Permission-hidden FK columns get no companion (the key is emitted only when the raw column survived visibility filtering). Frontend twin: the grid/detail render the companion instead of the raw id (F3/F9.6). |
+
+
+---
+
+### Batch 12j — Local naive-convention datetimes (LEX_TIME_ZONE) ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 12.46 – 12.48 |
+| Type | U |
+| Files covered | `lex_app/settings.py` (`LEX_TIME_ZONE` override, conditional 'Z'), `api/serializers/base_serializers.py` (`LexAwareDateTimeField` + mapping), `audit_logging/serializers/CalculationLogSerializer.py` (mapping), `api/utils/temporal.py` (`parse_as_of_datetime` convention) |
+| Test file | `lex/test_project/tests/serializers/test_12j_local_convention_datetimes.py` |
+| Test classes | `TestCluster12j_LocalConventionDatetimes` |
+| Fixtures | none (override_settings) |
+| Est. tests | 3 |
+| Coverage gain | the whole naive-convention chain under a non-UTC TIME_ZONE |
+| Prereqs | 12g (the UTC 'Z' contract these scenarios must not regress) |
+| Status | ✅ Complete — 3 pass / 0 fail |
+| Note | Customer ticket 2026-07-16: v2.0.0rc212 (f622c9c, #635) flipped the naive convention Berlin→UTC on `default`/GCP targets — the PostgreSQL connection timezone — silently reinterpreting all pre-existing data (equality filters on `output_date` broke; ±1/2h shifts on read). With celery-beat being retired the constraint behind #635 disappears, so instances can restore the original convention via `LEX_TIME_ZONE=Europe/Berlin` — **default unchanged (UTC)** until an instance flips deliberately. 12.46 DST-aware per-value offsets (+01:00 winter / +02:00 summer — a static 'Z' would mislabel); 12.47 UTC default keeps the 12g 'Z' contract byte-identical + both framework serializers wired to the field; 12.48 `as_of` anchors normalize to the instance's convention so time-travel never shifts. Regression: serializers+history+audit_logging+crud_api = 277 pass / 0 fail. |

--- a/lex/test_project/test-plan/clusters/12-serializers/cluster.md
+++ b/lex/test_project/test-plan/clusters/12-serializers/cluster.md
@@ -119,3 +119,12 @@ cluster-2 models are too shallow; we need a model with one of every
 **Why a regression matters:** users must be able to remove attachments; a removal that silently un-does itself corrupts the record's document trail.
 
 **Scenario range:** 12.39 – 12.41. **Test file:** `lex/test_project/tests/serializers/test_12h_filefield_clear.py`. **Type:** E. **Status:** ✅ Complete. Scenarios: 12.39 empty value clears; 12.40 omit keeps; 12.41 upload replaces.
+
+
+### 12j. Local naive-convention datetimes (LEX_TIME_ZONE) ✅
+
+**What it tests:** the datetime chain under a restored pre-rc212 Berlin naive convention (`LEX_TIME_ZONE`): serialized values carry real, DST-aware offsets; `as_of` anchors normalize into the same convention the ORM compares against; and the UTC default keeps the 12g 'Z' contract unchanged.
+
+**Why a regression matters:** mislabeling naive Berlin wall-clock as 'Z' re-creates the customer-visible time shift (BUG-025 class); a convention-mismatched `as_of` silently time-travels to the wrong snapshot.
+
+**Scenario range:** 12.46 – 12.48. **Test file:** `lex/test_project/tests/serializers/test_12j_local_convention_datetimes.py`. **Type:** U. **Status:** ✅ 3 pass.

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -21,7 +21,7 @@
 | 9. Signals & WebSocket | 6 | 42 | 14 | 0 | 0 |
 | 10. API Layer | 13 | 71 | 21 | 0 | 0 |
 | 11. Stress & Performance | 9 | 22 | 0 | 0 | 0 |
-| 12. Serializer Contract | 9 | 45 | 13 | 0 | 0 |
+| 12. Serializer Contract | 10 | 48 | 16 | 0 | 0 |
 | 13. Export Endpoint | 5 | 30 | 0 | 0 | 0 |
 | 14. AG Grid Query Endpoint | 6 | 33 | 0 | 0 | 0 |
 | 15. Calculation Logging Surface | 8 | 34 | 13 | 0 | 0 |
@@ -234,6 +234,7 @@
 | 12g | Datetime timezone ambiguity (BUG-025, fixed) | 12.36-12.38 | complete | 3 | 0 | 0 | live regression gates — BUG-025 fixed in the same change (explicit 'Z' rendering for naive-UTC datetimes on USE_TZ=False targets via REST_FRAMEWORK DATETIME_FORMAT) |
 | 12h | Clearing a FileField through the REST update path | 12.39-12.41 | complete | 3 | 0 | 0 | LexClearableFileField/-ImageField — an explicit empty multipart value clears the stored file (omit still keeps, upload still replaces); frontend twin F9 batch 9d sends the marker |
 | 12i | Foreign-key display names in the read contract (BUG-F-003 backend fix) | 12.42-12.45 | complete | 4 | 0 | 0 | additive companion `<fk>__short_description` = str(related) emitted alongside the raw FK id on both list and detail paths; list resolves names in one batched pk__in query per FK (mirrors ModelExport._apply_foreign_key_display_names), detail resolves per-instance; raw id untouched so filtering/editing unaffected; null FK → null companion. Resolves the backend root cause of frontend BUG-F-003 (FK columns rendered as bare ids) |
+| 12j | Local naive-convention datetimes (LEX_TIME_ZONE) | 12.46-12.48 | complete | 3 | 0 | 0 | env-gated restore of the pre-rc212 Berlin naive convention (f622c9c fallout, customer ticket 2026-07-16) — DST-aware offset rendering via LexAwareDateTimeField, as_of parsing normalized to the instance convention; UTC default byte-identical (12g/5m gates green) |
 
 ## 13. Export Endpoint (`exports`)
 

--- a/lex/test_project/test-plan/progress/sessions/2026-07-16-local-convention-datetimes.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-07-16-local-convention-datetimes.md
@@ -1,0 +1,24 @@
+---
+date: 2026-07-16
+clusters: [12j]
+tests_added: "3 (12.46–12.48)"
+suite_tally: "12j 3 pass / 0 fail; regression: serializers+history+audit_logging+crud_api = 277 pass / 1 skip / 3 xfail / 0 fail"
+---
+
+**Batch 12j landed — env-gated restore of the pre-rc212 naive-datetime
+convention.** Customer ticket 2026-07-16 (output_date values shifted 1h,
+equality filters broken, revert shifts the other way): root cause is
+v2.0.0rc212 (f622c9c, #635), which flipped TIME_ZONE Berlin→UTC on
+USE_TZ=False targets to satisfy django_celery_beat's naive==UTC assumption —
+but TIME_ZONE is also the PostgreSQL connection timezone, so the change
+silently reinterpreted every stored naive timestamp. With celery-beat being
+retired (supervisor + global scheduler), the constraint disappears:
+`LEX_TIME_ZONE=Europe/Berlin` restores the original convention per instance,
+default unchanged (UTC). Truthfulness pieces in the same change:
+`LexAwareDateTimeField` renders naive values with the real DST-aware offset
+(a static 'Z' would mislabel Berlin wall-clock), wired into LexSerializer and
+the calculation-log serializer; `parse_as_of_datetime` normalizes anchors to
+the instance's convention. No data migration shipped — rows written during an
+instance's UTC era are a bounded set handled operationally at flip time
+(documented in the incident report). Frontend needs no change (ISO offsets
+parse identically to 'Z'). See [batch 12j](../../clusters/12-serializers/batches.md).

--- a/lex/test_project/tests/serializers/test_12j_local_convention_datetimes.py
+++ b/lex/test_project/tests/serializers/test_12j_local_convention_datetimes.py
@@ -1,0 +1,123 @@
+"""Cluster 12j — datetime rendering & as_of parsing under a local naive convention.
+
+Intent: under ``USE_TZ=False`` the meaning of every stored naive datetime is
+``TIME_ZONE`` (the PostgreSQL connection timezone). v2.0.0rc212 (f622c9c,
+#635) switched that convention from Europe/Berlin to UTC to satisfy
+django_celery_beat's naive==UTC assumption — silently reinterpreting all
+pre-existing data (customer ticket 2026-07-16: ``output_date`` values shifted
+by 1h, equality filters broken). With beat being retired, instances can
+restore the original convention via ``LEX_TIME_ZONE=Europe/Berlin``. That is
+only sound if the whole chain honors the convention:
+
+- serialized datetimes must carry the *real, DST-aware* offset (a static 'Z'
+  would mislabel Berlin wall-clock as UTC and re-create the display shift);
+- ``as_of`` query values must normalize to the *same* naive convention the
+  ORM compares against, or every time-travel query shifts by the UTC offset.
+
+Cluster 12j — scenarios 12.46–12.48. Type: U.
+Covers: lex/api/serializers/base_serializers.py (LexAwareDateTimeField),
+        lex/audit_logging/serializers/CalculationLogSerializer.py (mapping),
+        lex/api/utils/temporal.py (parse_as_of_datetime convention),
+        lex/lex_app/settings.py (LEX_TIME_ZONE override, conditional 'Z').
+Run: python -m lex pytest lex/test_project/tests/serializers/test_12j_local_convention_datetimes.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from django.test import SimpleTestCase, override_settings
+
+from lex.api.serializers.base_serializers import LexAwareDateTimeField, LexSerializer
+from lex.api.utils.temporal import parse_as_of_datetime
+
+pytestmark = pytest.mark.serializers
+
+
+class TestCluster12j_LocalConventionDatetimes(SimpleTestCase):
+    """Cluster 12j: the naive convention is honored end to end."""
+
+    def test_12_46_naive_values_get_the_dst_aware_offset(self):
+        """
+        Scenario 12.46: under a Berlin naive convention, serialized datetimes
+        carry the real offset — +01:00 in winter, +02:00 in summer.
+        Given: USE_TZ=False and TIME_ZONE=Europe/Berlin (LEX_TIME_ZONE mode)
+        When: LexAwareDateTimeField renders naive December and June values
+        Then: the ISO strings end in +01:00 / +02:00 respectively — the
+              instant a browser reconstructs equals the wall time the author
+              wrote (a static 'Z' would shift it by the offset)
+        """
+        field = LexAwareDateTimeField()
+        with override_settings(USE_TZ=False, TIME_ZONE="Europe/Berlin"):
+            winter = field.to_representation(datetime(2026, 12, 31, 0, 0, 0))
+            summer = field.to_representation(datetime(2026, 6, 30, 12, 0, 0))
+
+        self.assertEqual(
+            winter, "2026-12-31T00:00:00+01:00",
+            "December Berlin wall-clock must carry the winter (+01:00) offset.",
+        )
+        self.assertEqual(
+            summer, "2026-06-30T12:00:00+02:00",
+            "June Berlin wall-clock must carry the summer (+02:00) offset — "
+            "the offset is per-value, never a static suffix.",
+        )
+
+    def test_12_47_utc_convention_keeps_the_existing_z_contract(self):
+        """
+        Scenario 12.47: under the UTC convention (today's default) nothing
+        changes — values keep the established 'Z' rendering (12g contract),
+        and the field is wired into the framework serializer mappings.
+        Given: USE_TZ=False and TIME_ZONE=UTC (the current default target)
+        When: LexAwareDateTimeField renders a naive value
+        Then: it falls through to the default path (settings' DATETIME_FORMAT
+              applies → trailing 'Z'), and both LexSerializer and the
+              calculation-log serializer map DateTimeField to this class
+        """
+        from django.db import models
+
+        from lex.audit_logging.serializers.CalculationLogSerializer import (
+            CalculationLogDefaultSerializer,
+        )
+
+        field = LexAwareDateTimeField()
+        with override_settings(USE_TZ=False, TIME_ZONE="UTC"):
+            rendered = field.to_representation(datetime(2026, 12, 31, 0, 0, 0))
+        self.assertTrue(
+            str(rendered).endswith("Z"),
+            f"UTC-convention rendering must keep the 12g 'Z' contract, got {rendered!r}.",
+        )
+
+        for serializer_cls in (LexSerializer, CalculationLogDefaultSerializer):
+            self.assertIs(
+                serializer_cls.serializer_field_mapping[models.DateTimeField],
+                LexAwareDateTimeField,
+                f"{serializer_cls.__name__} must render datetimes via "
+                f"LexAwareDateTimeField or non-UTC instances mislabel values.",
+            )
+
+    def test_12_48_as_of_parses_into_the_instance_convention(self):
+        """
+        Scenario 12.48: an as_of query value is normalized to the SAME naive
+        convention the ORM compares against.
+        Given: a UTC-instant query value 2026-12-30T23:00:00Z
+        When: parsed under the Berlin convention and under the UTC convention
+        Then: Berlin yields naive 2026-12-31 00:00 (matches Berlin-wall
+              storage); UTC yields naive 2026-12-30 23:00 (today's behavior,
+              unchanged) — so time-travel never shifts by the UTC offset
+        """
+        with override_settings(USE_TZ=False, TIME_ZONE="Europe/Berlin"):
+            berlin = parse_as_of_datetime("2026-12-30T23:00:00Z")
+        with override_settings(USE_TZ=False, TIME_ZONE="UTC"):
+            utc = parse_as_of_datetime("2026-12-30T23:00:00Z")
+
+        self.assertEqual(
+            berlin, datetime(2026, 12, 31, 0, 0, 0),
+            "Under the Berlin convention the parsed anchor must be Berlin "
+            "wall-clock, matching how the rows themselves read.",
+        )
+        self.assertIsNone(berlin.tzinfo, "USE_TZ=False comparisons need naive values.")
+        self.assertEqual(
+            utc, datetime(2026, 12, 30, 23, 0, 0),
+            "Under the UTC convention behavior is unchanged (5m/12g contract).",
+        )


### PR DESCRIPTION
## What

Fixes the naive-datetime convention break behind the customer ticket of 2026-07-16 (`output_date` values shifted by 1h after upgrading across rc212; equality filters broken; reverting shifts the other way) — **with zero behavior change by default**.

## Root cause

**`f622c9c` (#635, shipped v2.0.0rc212)** flipped `TIME_ZONE` from `Europe/Berlin` to `UTC` on `USE_TZ=False` targets to satisfy django_celery_beat's naive==UTC assumption. Under `USE_TZ=False`, `TIME_ZONE` is also the **PostgreSQL connection timezone** (Django datetime columns are `timestamptz`), so the flip silently reinterpreted every already-stored naive timestamp. All four customer observations reproduce exactly from this, including the ±1h (winter) magnitude.

## Why now

Celery-beat is being retired (recovery → always-on supervisor; future-edit activations → global scheduler). Neither replacement reads naive datetimes as UTC, so the constraint behind #635 disappears — the original convention can be restored.

## The fix (opt-in, per instance)

- **`LEX_TIME_ZONE` env override** — `TIME_ZONE = os.getenv("LEX_TIME_ZONE") or (existing coupling)`. Default is byte-identical to today (UTC on `default`/GCP). An instance restores the pre-rc212 convention with `LEX_TIME_ZONE=Europe/Berlin` **once it is beat-free**.
- **Truthful serialization in every mode** — the static `'Z'` suffix (BUG-025 fix) now applies only when the convention IS UTC. Under a non-UTC convention, new `LexAwareDateTimeField` attaches the real, **DST-aware** offset per value (`+01:00` winter / `+02:00` summer), wired into `LexSerializer` and the calculation-log serializer.
- **`as_of` follows the convention** — `parse_as_of_datetime` normalizes anchors into the instance's naive convention (unchanged for UTC), so time-travel comparisons never shift.
- **Frontend: no change needed** — `new Date()` parses `+01:00` offsets identically to `Z`, and the As-Of control already sends UTC.

## What is deliberately NOT here

No data migration. Rows written during an instance's UTC era (rc212 → flip) are a bounded, era-identifiable set; repairing them is a one-off, DST-aware `UPDATE … SET col = (col AT TIME ZONE 'UTC') AT TIME ZONE 'Europe/Berlin'` run operationally at flip time — documented in the incident report, decided per instance.

## Tests

Batch **12j** (12.46–12.48, 3 pass): DST-aware per-value offsets; the UTC default keeps the 12g `'Z'` contract byte-identical (existing 12g + 5m gates all green); `as_of` convention normalization. Regression: serializers + history + audit_logging + crud_api = **277 pass / 0 fail**.

## Rollout (per instance)

1. Instance becomes beat-free (supervisor recovery + global scheduler).
2. One-off era rebase of UTC-window rows (ops, backed up, dry-checked).
3. Set `LEX_TIME_ZONE=Europe/Berlin`, restart.
4. Verify: old rows render original wall-clock; queries match; UI display correct.

Incident report with the full timeline is attached to the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
