### PR TITLE
fix(export): render Excel datetimes in the requester's browser timezone

### DIFF
--- a/lex/api/views/file_operations/ModelExport.py
+++ b/lex/api/views/file_operations/ModelExport.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import datetime as _dt
 import logging
+from zoneinfo import ZoneInfo
 import os
 import re
 import tempfile
@@ -34,24 +35,42 @@ AG_GROUP_HIERARCHY_DEPTH_COLUMN = "__ag_group_hierarchy_depth"
 logger = logging.getLogger(__name__)
 
 
-def _to_excel_naive(df: "pd.DataFrame") -> "pd.DataFrame":
-    """Make datetime cells timezone-naive for Excel.
+def _resolve_export_zone(zone: "str | None"):
+    """Validate an IANA zone name; fall back to settings.TIME_ZONE."""
+    if zone:
+        try:
+            return ZoneInfo(zone)
+        except Exception:  # noqa: BLE001 - bad client input falls back safely
+            logger.warning("export: ignoring invalid timezone %r", zone)
+    try:
+        return ZoneInfo(settings.TIME_ZONE)
+    except Exception:  # noqa: BLE001
+        return ZoneInfo("UTC")
 
-    Under ``USE_TZ=True`` the ORM yields timezone-aware (UTC) datetimes, and
-    ``xlsxwriter`` refuses them (``Excel does not support datetimes with
-    timezones``). Convert any aware value to its wall-clock in the configured
-    display zone (``settings.TIME_ZONE``) so the workbook shows the same instant
-    the API serves. A no-op under ``USE_TZ=False`` (values are already naive).
+
+def _to_excel_naive(df: "pd.DataFrame", zone: "str | None" = None) -> "pd.DataFrame":
+    """Make datetime cells timezone-naive for Excel, in the requester's zone.
+
+    Excel has no timezone type, and ``xlsxwriter`` refuses tz-aware datetimes
+    (``Excel does not support datetimes with timezones``). Under ``USE_TZ=True``
+    the ORM yields aware UTC values, so we render each one as a **local
+    wall-clock** in ``zone`` — the requester's browser timezone, passed on the
+    export request — before dropping the tzinfo. That way the workbook shows the
+    same local time the user sees in the grid, not UTC. When ``zone`` is absent
+    or invalid we fall back to ``settings.TIME_ZONE``. A no-op under
+    ``USE_TZ=False`` (values are already naive).
     """
+    target = _resolve_export_zone(zone)
+
     def _strip(value):
         if isinstance(value, _dt.datetime) and value.tzinfo is not None:
-            return _dj_tz.localtime(value).replace(tzinfo=None)
+            return value.astimezone(target).replace(tzinfo=None)
         return value
 
     for col in df.columns:
         series = df[col]
         if isinstance(series.dtype, pd.DatetimeTZDtype):
-            df[col] = series.dt.tz_convert(settings.TIME_ZONE).dt.tz_localize(None)
+            df[col] = series.dt.tz_convert(target).dt.tz_localize(None)
         elif series.dtype == object:
             df[col] = series.map(_strip)
     return df
@@ -893,7 +912,13 @@ class ModelExportView(GenericAPIView):
         if isinstance(value, (str, int, float, bool)):
             return value
         if isinstance(value, _dt.datetime):
-            return value.replace(tzinfo=None) if value.tzinfo is not None else value
+            # Excel has no timezone: render an aware value as a naive wall-clock
+            # in the requester's browser zone (set on `post`), so the workbook
+            # shows local time, not UTC. Naive values pass through unchanged.
+            if value.tzinfo is not None:
+                target = _resolve_export_zone(getattr(self, "_export_target_zone", None))
+                return value.astimezone(target).replace(tzinfo=None)
+            return value
         if isinstance(value, (_dt.date, _dt.time)):
             return value
         if isinstance(value, (list, tuple, set, dict)):
@@ -1720,6 +1745,12 @@ class ModelExportView(GenericAPIView):
 
         json_data = request.data if isinstance(request.data, dict) else {}
         ag_export_payload = json_data.get("ag_export")
+        # Excel has no timezone; render aware datetimes in the requester's browser
+        # zone (frontend sends `timezone`) so the workbook shows local wall-clock,
+        # not UTC. Falls back to settings.TIME_ZONE when absent/invalid. Stored on
+        # self so the streaming/fast paths' _normalize_cell_value can use it too.
+        export_timezone = request.query_params.get("timezone") or json_data.get("timezone")
+        self._export_target_zone = export_timezone
 
         if isinstance(ag_export_payload, dict) and isinstance(ag_export_payload.get("request"), dict):
             selected_ids = self._extract_selected_ids_for_export(json_data)
@@ -1814,7 +1845,7 @@ class ModelExportView(GenericAPIView):
         sheet_name = re.sub(r'[\[\]:*?/\\]', '_', model.__name__)[:31]
 
         # Excel has no timezone type; strip tz from aware (USE_TZ=True) datetimes.
-        df = _to_excel_naive(df)
+        df = _to_excel_naive(df, export_timezone)
         df.to_excel(writer, sheet_name=sheet_name, merge_cells=False, freeze_panes=(1, 1), index=True)
 
         worksheet = writer.sheets.get(sheet_name)

--- a/lex/test_project/test-plan/clusters/13-exports/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/13-exports/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 13
 slug: exports
 title: Export Endpoint
-max_scenario: 30
+max_scenario: 33
 letters:
   a:
     title: Legacy (non-AG) export path
@@ -52,3 +52,15 @@ letters:
       skip: 0
       xfail: 0
     note: on disk; per-letter tally folded into cluster top-line in pre-migration dashboard
+  f:
+    title: Export renders datetimes in the requester's browser timezone
+    scenarios: 13.31-13.33
+    status: complete
+    tests:
+      pass: 3
+      skip: 0
+      xfail: 0
+    note: Excel has no tz type, so aware-UTC datetimes must be baked as a local wall-clock at export
+      time. Both write paths render in the requester's zone (frontend sends `timezone` on the export
+      request) — legacy pandas (_to_excel_naive) and streaming/fast (_normalize_cell_value) — falling
+      back to settings.TIME_ZONE for absent/invalid. Ships with the USE_TZ=True cutover.

--- a/lex/test_project/test-plan/clusters/13-exports/batches.md
+++ b/lex/test_project/test-plan/clusters/13-exports/batches.md
@@ -15,3 +15,21 @@ writing-plan batch blocks were recorded for this cluster.
 > `## Cluster 13 — Process Admin` block that reused the number 13 for an unrelated,
 > never-opened area. It has been moved to
 > [`../README.md` §6a](../README.md) as a pending decision — it does not belong here.
+
+---
+
+### Batch 13f — Export datetimes in the requester's browser timezone ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 13.31 – 13.33 |
+| Type | U |
+| Files covered | `lex/api/views/file_operations/ModelExport.py` (`_resolve_export_zone`, `_to_excel_naive(zone)`, `ModelExportView._normalize_cell_value` zone rendering, `post` `timezone` param) |
+| Test file | `lex/test_project/tests/exports/test_13f_export_timezone.py` |
+| Test classes | `TestCluster13f_ExportTimezone` (13.31 Berlin → 11:00; 13.32 New York → 05:00; 13.33 no/invalid tz → settings.TIME_ZONE) both on the legacy pandas path and the streaming/fast path |
+| Fixtures | none — pure-function unit test (avoids the export permission-masking confound) |
+| Tests landed | **3 pass / 0 fail** |
+| Coverage gain | timezone-aware Excel export on both write paths |
+| Status | ✅ Complete — Excel has no tz type, so aware-UTC datetimes are baked as a local wall-clock at export time, in the requester's browser zone (frontend sends `timezone` on the export request), falling back to `settings.TIME_ZONE`. Fixes exports showing naive UTC. Ships with the `USE_TZ=True` cutover. |
+
+---

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -22,7 +22,7 @@
 | 10. API Layer | 13 | 71 | 21 | 0 | 0 |
 | 11. Stress & Performance | 9 | 22 | 0 | 0 | 0 |
 | 12. Serializer Contract | 10 | 48 | 16 | 0 | 0 |
-| 13. Export Endpoint | 5 | 30 | 0 | 0 | 0 |
+| 13. Export Endpoint | 6 | 33 | 3 | 0 | 0 |
 | 14. AG Grid Query Endpoint | 6 | 33 | 0 | 0 | 0 |
 | 15. Calculation Logging Surface | 8 | 34 | 13 | 0 | 0 |
 
@@ -246,6 +246,7 @@
 | 13c | AG Grid export path — grouped & selected | 13.9 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 13d | Auth & edge cases | 13.11-13.12 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 13e |  |  | complete | 0 | 0 | 0 | on disk; per-letter tally folded into cluster top-line in pre-migration dashboard |
+| 13f | Export renders datetimes in the requester's browser timezone | 13.31-13.33 | complete | 3 | 0 | 0 | Excel has no tz type, so aware-UTC datetimes must be baked as a local wall-clock at export time. Both write paths render in the requester's zone (frontend sends `timezone` on the export request) — legacy pandas (_to_excel_naive) and streaming/fast (_normalize_cell_value) — falling back to settings.TIME_ZONE for absent/invalid. Ships with the USE_TZ=True cutover. |
 
 ## 14. AG Grid Query Endpoint (`queries`)
 

--- a/lex/test_project/tests/exports/test_13f_export_timezone.py
+++ b/lex/test_project/tests/exports/test_13f_export_timezone.py
@@ -1,0 +1,83 @@
+"""Cluster 13f — Excel export renders datetimes in the requester's browser zone.
+
+Intent: Excel has no timezone type, so an export must bake a wall-clock into each
+datetime cell at generation time. Under USE_TZ=True the ORM holds aware UTC, so a
+naive dump shows the UTC wall-clock (e.g. 09:00 instead of the 11:00 a Berlin user
+sees in the grid). The export accepts the requester's browser timezone and renders
+every datetime in it — on BOTH write paths: the legacy pandas path
+(``_to_excel_naive``) and the streaming/fast xlsxwriter path
+(``_normalize_cell_value``) — falling back to ``settings.TIME_ZONE``. A regression
+here means exported spreadsheets show times shifted by the viewer's offset.
+
+Cluster 13f — scenarios 13.31–13.33. Type: U.
+Covers: lex/api/views/file_operations/ModelExport.py
+        (_resolve_export_zone, _to_excel_naive, ModelExportView._normalize_cell_value).
+Run: python -m lex pytest lex/test_project/tests/exports/test_13f_export_timezone.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone as dt_timezone
+
+import pandas as pd
+import pytest
+from django.test import SimpleTestCase, override_settings
+
+from lex.api.views.file_operations.ModelExport import (
+    ModelExportView,
+    _resolve_export_zone,
+    _to_excel_naive,
+)
+
+pytestmark = pytest.mark.exports
+
+# 09:00Z = 11:00 Berlin (summer, +2) = 05:00 New York (summer, −4)
+INSTANT = datetime(2026, 7, 20, 9, 0, 0, tzinfo=dt_timezone.utc)
+
+
+class TestCluster13f_ExportTimezone(SimpleTestCase):
+    """Cluster 13f: exported datetimes use the requester's browser zone."""
+
+    def _legacy_hour(self, zone) -> int:
+        """Hour the legacy pandas path (_to_excel_naive) writes for INSTANT."""
+        df = pd.DataFrame({"happened_at": [INSTANT], "name": ["x"]})
+        out = _to_excel_naive(df, zone)
+        cell = pd.to_datetime(out["happened_at"].iloc[0])
+        self.assertIsNone(cell.tzinfo, "Excel cell must be tz-naive.")
+        return cell.hour
+
+    def _stream_hour(self, zone) -> int:
+        """Hour the streaming path (_normalize_cell_value) writes for INSTANT."""
+        view = ModelExportView.__new__(ModelExportView)  # no HTTP init needed
+        view._export_target_zone = zone
+        cell = view._normalize_cell_value(INSTANT)
+        self.assertIsNone(cell.tzinfo, "Excel cell must be tz-naive.")
+        return cell.hour
+
+    def test_13_31_export_renders_datetimes_in_requested_berlin_zone(self) -> None:
+        """
+        Scenario 13.31: ?timezone=Europe/Berlin renders 09:00Z as 11:00 — on both
+        the legacy and streaming write paths.
+        """
+        self.assertEqual(self._legacy_hour("Europe/Berlin"), 11, "legacy path → 11:00 Berlin")
+        self.assertEqual(self._stream_hour("Europe/Berlin"), 11, "streaming path → 11:00 Berlin")
+
+    def test_13_32_export_renders_datetimes_in_requested_ny_zone(self) -> None:
+        """
+        Scenario 13.32: the same instant exported for New York shows 05:00 — the
+        zone is per-request, not fixed. Both paths agree.
+        """
+        self.assertEqual(self._legacy_hour("America/New_York"), 5, "legacy path → 05:00 NY")
+        self.assertEqual(self._stream_hour("America/New_York"), 5, "streaming path → 05:00 NY")
+
+    @override_settings(TIME_ZONE="Europe/Berlin")
+    def test_13_33_no_or_invalid_zone_falls_back_to_settings(self) -> None:
+        """
+        Scenario 13.33: no/invalid timezone → settings.TIME_ZONE (Berlin), no error.
+        """
+        self.assertEqual(_resolve_export_zone("Europe/Berlin").key, "Europe/Berlin")
+        self.assertEqual(_resolve_export_zone(None).key, "Europe/Berlin")   # settings fallback
+        self.assertEqual(_resolve_export_zone("Not/AZone").key, "Europe/Berlin")  # invalid → fallback
+        self.assertEqual(self._legacy_hour(None), 11, "legacy: no tz → settings.TIME_ZONE")
+        self.assertEqual(self._stream_hour(None), 11, "streaming: no tz → settings.TIME_ZONE")
+        self.assertEqual(self._legacy_hour("Not/AZone"), 11, "legacy: invalid tz → safe fallback")


### PR DESCRIPTION
## Summary

Follow-up to **#661** (which merged the `USE_TZ=True` / `TIME_ZONE=Berlin` cutover). This carries the one commit that landed on the branch **after** #661 was merged, so it needs its own PR.

Makes the Excel export **timezone-aware** — datetimes render in the requester's browser zone instead of naive UTC.

## Why

Excel has no timezone type, so an export must bake a local wall-clock into each datetime cell at generation time. Under `USE_TZ=True` the ORM holds aware UTC, and the export was writing the **UTC** wall-clock (e.g. `09:00` instead of the `11:00` a Berlin user sees in the grid) — or, on the legacy path, `xlsxwriter` rejected the aware value outright (`Excel does not support datetimes with timezones`).

## Change (`ModelExport.py`)

The export now renders every datetime in the **requester's zone**, sent by the frontend as a `timezone` request param, falling back to `settings.TIME_ZONE`. Applied to **both** write paths:

- **streaming/fast path** — `_normalize_cell_value` converts to `self._export_target_zone` before stripping tzinfo (was: strip only → UTC wall-clock).
- **legacy pandas path** — `_to_excel_naive(df, zone)` converts per column.
- `_resolve_export_zone` validates the zone and falls back safely.

## Tests

Batch **13f** (13.31–13.33, unit) — both write paths render `09:00Z` as `11:00` (Europe/Berlin) and `05:00` (America/New_York), and fall back to `settings.TIME_ZONE` for absent/invalid zones. Exports cluster **24 pass**; plan `validate` OK.

> A unit test (of `_to_excel_naive` / `_normalize_cell_value` / `_resolve_export_zone`) rather than E2E, deliberately — the E2E export path has an unrelated permission-masking quirk on the test model that would confound a full round-trip assertion.

## Companion

Frontend **process-admin-general-client#452** sends the browser zone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) as the `timezone` param on export requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)