### PR TITLE
fix(tz): run the Postgres session in TIME_ZONE so fetched datetimes read local

### DIFF
--- a/lex/lex_app/settings.py
+++ b/lex/lex_app/settings.py
@@ -773,6 +773,17 @@ TIME_ZONE = os.getenv("LEX_TIME_ZONE", "Europe/Berlin")
 # aware datetimes serialize with a real offset natively, so no override is
 # needed.
 
+# Run the PostgreSQL connection session in TIME_ZONE so fetched `timestamptz`
+# values come back as aware datetimes in the display zone (Berlin) instead of
+# UTC. This makes str()/repr, `.date()`/`.hour`, and model `__str__` render local
+# with NO per-field or per-model changes — storage stays UTC and the instant is
+# unchanged (23:30Z reads back as 00:30+01:00 == the original instant). Django's
+# date/time-part lookups already inject an explicit `AT TIME ZONE`, so they are
+# unaffected. Postgres-only: the session zone is what makes psycopg render
+# timestamptz locally; SQLite works in UTC under USE_TZ and is left unset.
+if "postgresql" in DATABASES["default"].get("ENGINE", ""):
+    DATABASES["default"]["TIME_ZONE"] = TIME_ZONE
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 

--- a/lex/test_project/test-plan/clusters/01-init/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/01-init/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 1
 slug: init
 title: Init — Project Bootstrap
-max_scenario: 200
+max_scenario: 202
 letters:
   a:
     title: '`lex setup` — scaffolding'
@@ -229,3 +229,16 @@ letters:
       date — winter −1h vs summer −2h); the ~2 transition hours/year are flagged for review. 1.197
       late-upgrader safety, 1.198 post-fix bound, 1.199 DST-aware winter shift, 1.200 transition-flag.
       Ships with the USE_TZ=True cutover.
+  r:
+    title: Fetched datetimes come back in the DB-session display zone (Berlin)
+    scenarios: 1.201-1.202
+    status: complete
+    tests:
+      pass: 2
+      skip: 0
+      xfail: 0
+    note: DATABASES['default']['TIME_ZONE'] = TIME_ZONE runs the Postgres session in Berlin, so a
+      fetched DateTimeField returns aware in the display zone (11:00+02:00) not UTC — str()/.date()/.hour
+      and model __str__ render local with no per-field/per-model changes; storage + instant unchanged.
+      Postgres-only guard; Django date-part lookups use explicit AT TIME ZONE so bitemporal/as_of raw
+      SQL is unaffected (history+serializers+init+exports 385 pass with it live).

--- a/lex/test_project/test-plan/clusters/01-init/batches.md
+++ b/lex/test_project/test-plan/clusters/01-init/batches.md
@@ -158,3 +158,22 @@
 | Status | ✅ Complete — ships with the `USE_TZ=True` cutover. Corrects only user-entered datetimes created in the **per-instance** window `[--cutoff, --until)` — `--cutoff` (that instance's rc212 upgrade) is **required**, no global default, because too-early over-corrects correct pre-upgrade rows; `--until` (that instance's aware-UTC fix, default now) stops post-fix correct rows being re-shifted. Framework-managed timestamps and out-of-window rows are provably left alone. PostgreSQL-only (`AT TIME ZONE`); not idempotent (run once per instance). |
 
 ---
+
+---
+
+### Batch 1r — Fetched datetimes return in the DB-session display zone ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 1.201 – 1.202 |
+| Type | I |
+| Files covered | `lex/lex_app/settings.py` (`DATABASES['default']['TIME_ZONE'] = TIME_ZONE`, Postgres-guarded) |
+| Test file | `lex/test_project/tests/init/test_1r_fetched_datetime_zone.py` |
+| Test model | reuses `IncidentDatetimeItem` (`event_at`) |
+| Test classes | `TestCluster01r_FetchedDatetimeZone` (1.201 fetched value carries the display-zone offset & preserves the instant; 1.202 Berlin wall-clock reads 11:00 with no `localtime()`) |
+| Fixtures | none |
+| Tests landed | **2 pass / 0 fail** (stable over repeated runs) |
+| Coverage gain | DB-session display zone on reads (the zero-refactor fix for UTC-looking `str()`/labels) |
+| Status | ✅ Complete — running the Postgres session in `TIME_ZONE` makes every fetched `DateTimeField` come back aware-Berlin (`11:00+02:00`) instead of UTC, so `str()`, `.date()`, `.hour`, and model `__str__` render local **with no per-field or per-model changes** — storage stays UTC, instant unchanged. Django's date-part lookups inject an explicit `AT TIME ZONE`, so bitemporal/`as_of` raw SQL is unaffected (verified: history + serializers + init + exports **385 pass** with it live; calc/audit/crud/api **457 pass**, the one api_layer failure is a pre-existing ordering artifact that passes in isolation with or without this change). |
+
+---

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -10,7 +10,7 @@
 
 | Cluster | Batches | Max scenario | Pass | Skip | Xfail |
 |---|---|---|---|---|---|
-| 1. Init — Project Bootstrap | 23 | 200 | 94 | 0 | 0 |
+| 1. Init — Project Bootstrap | 24 | 202 | 96 | 0 | 0 |
 | 2. CRUD via REST API | 10 | 107 | 15 | 0 | 0 |
 | 3. Validation Hooks | 6 | 32 | 0 | 0 | 0 |
 | 4. Permissions | 13 | 74 | 18 | 2 | 0 |
@@ -47,6 +47,7 @@
 | 1o | Lazy imports + sync-exclusion + history-config helpers |  | complete | 15 | 0 | 0 | scenarios 1.110–1.124 |
 | 1p | Settings / config / URLs / top-level views |  | complete | 22 | 0 | 0 | scenarios 1.125–1.146 |
 | 1q | Migration file completeness gate | 1.147 | complete | 1 | 0 | 0 | scenario 1.147; `lex makemigrations ... --check --dry-run` must stay clean for framework apps |
+| 1r | Fetched datetimes come back in the DB-session display zone (Berlin) | 1.201-1.202 | complete | 2 | 0 | 0 | DATABASES['default']['TIME_ZONE'] = TIME_ZONE runs the Postgres session in Berlin, so a fetched DateTimeField returns aware in the display zone (11:00+02:00) not UTC — str()/.date()/.hour and model __str__ render local with no per-field/per-model changes; storage + instant unchanged. Postgres-only guard; Django date-part lookups use explicit AT TIME ZONE so bitemporal/as_of raw SQL is unaffected (history+serializers+init+exports 385 pass with it live). |
 | 1s | Log-noise cleanup + lex-namespace debug control (EXC-1787) |  | complete | 10 | 0 | 0 | scenarios 1.159–1.168; urllib3 InsecureRequestWarning gate + `LEX_LOG_LEVEL` lex-only DEBUG + console-handler level + blanket `LEX_SUPPRESS_WARNINGS` filter |
 | 1t | `DISABLE_SERVER_SIDE_CURSORS` placement (production cursor crash) | 1.169-1.170 | complete | 2 | 0 | 0 | scenarios 1.169–1.170; flag was module-level (ignored by Django) so server-side cursors stayed on behind the pooling proxy → `InvalidCursorName` on every `.iterator()`; now set per |
 | 1u | Fast ASGI health/readiness probes | 1.171-1.175 | complete | 5 | 0 | 0 | scenarios 1.171–1.175; `/health` short-circuits to static liveness, `/readiness` gates on DB readiness, non-probe HTTP falls through to Django |

--- a/lex/test_project/tests/init/test_1r_fetched_datetime_zone.py
+++ b/lex/test_project/tests/init/test_1r_fetched_datetime_zone.py
@@ -1,0 +1,78 @@
+"""Cluster 1r — fetched datetimes come back in the DB-session display zone.
+
+Intent: with the PostgreSQL connection session set to ``TIME_ZONE`` (Berlin) via
+``DATABASES['default']['TIME_ZONE']``, a fetched ``DateTimeField`` is returned as
+an aware datetime in the display zone rather than UTC — so ``str()`` / ``.date()``
+/ ``.hour`` and model ``__str__`` render local with NO per-field or per-model
+changes, while the stored instant is unchanged. This guards the settings wiring
+against a silent revert to UTC reads (which is what shows the confusing UTC
+wall-clock in labels/exports).
+
+Cluster 1r — scenarios 1.201–1.202. Type: I.
+Covers: lex/lex_app/settings.py (DATABASES['default']['TIME_ZONE'] = TIME_ZONE).
+Run: python -m lex pytest lex/test_project/tests/init/test_1r_fetched_datetime_zone.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone as dt_timezone
+
+import pytest
+from django.conf import settings
+from django.utils import timezone
+
+from lex.test_project.tests._e2e_test_case import E2ETestCase
+
+from .models import ALL_MODELS, IncidentDatetimeItem
+
+pytestmark = pytest.mark.init
+
+INSTANT = datetime(2026, 7, 20, 9, 0, 0, tzinfo=dt_timezone.utc)  # 09:00Z = 11:00 Berlin (summer)
+
+
+class TestCluster01r_FetchedDatetimeZone(E2ETestCase):
+    """Cluster 1r: reads return datetimes in the configured display zone."""
+
+    e2e_models = ALL_MODELS
+
+    def test_1_201_fetched_datetime_is_in_the_display_zone(self) -> None:
+        """
+        Scenario 1.201: a fetched DateTimeField is aware in TIME_ZONE, not UTC,
+        and preserves the stored instant.
+        Given: a row whose event_at is the instant 09:00Z
+        When: the row is re-fetched from the DB
+        Then: the value carries the TIME_ZONE offset for that date (not +00:00),
+              and still equals the original 09:00Z instant (storage unchanged)
+        """
+        IncidentDatetimeItem.objects.create(name="tz-read", event_at=INSTANT)
+        fetched = IncidentDatetimeItem.objects.get(name="tz-read").event_at
+
+        # the stored instant is the same absolute moment — nothing corrupted
+        self.assertEqual(
+            fetched, INSTANT,
+            f"the stored instant must be unchanged; got {fetched}.",
+        )
+        # returned in the display zone: its offset matches localtime's for that
+        # instant (== +00:00 only if TIME_ZONE is itself UTC)
+        self.assertEqual(
+            fetched.utcoffset(), timezone.localtime(INSTANT).utcoffset(),
+            f"a fetched datetime should carry the {settings.TIME_ZONE} offset, "
+            f"got {fetched.utcoffset()} (str={fetched}).",
+        )
+
+    def test_1_202_berlin_wall_clock_reads_local_without_localtime(self) -> None:
+        """
+        Scenario 1.202: on a Berlin instance the fetched value's wall-clock reads
+        Berlin directly (str/.hour), with no timezone.localtime() call.
+        Given: the same 09:00Z instant, TIME_ZONE=Europe/Berlin
+        When: re-fetched
+        Then: .hour/.minute read 11:00 (summer) — the local wall-clock
+        """
+        if settings.TIME_ZONE != "Europe/Berlin":
+            self.skipTest(f"display zone is {settings.TIME_ZONE}, not Europe/Berlin")
+        IncidentDatetimeItem.objects.create(name="tz-berlin", event_at=INSTANT)
+        fetched = IncidentDatetimeItem.objects.get(name="tz-berlin").event_at
+        self.assertEqual(
+            (fetched.hour, fetched.minute), (11, 0),
+            f"fetched value should read 11:00 Berlin wall-clock, got {fetched}.",
+        )


### PR DESCRIPTION
## Summary

One-line settings change so fetched `DateTimeField`s come back **in the display zone (Berlin)** instead of UTC — fixing `str()`, `.date()`, `.hour`, model `__str__`, and labels **with no project refactoring** (no custom fields, no `__str__` rewrites, no `DateField` migrations). Follow-up to the merged `USE_TZ=True` cutover (#661).

## The change

```python
# settings.py
if "postgresql" in DATABASES["default"].get("ENGINE", ""):
    DATABASES["default"]["TIME_ZONE"] = TIME_ZONE
```

## Why this is needed (and why it's the clean lever)

Under `USE_TZ=True`, Django sets the Postgres connection session from the **database's** `TIME_ZONE` option — **not** the global `settings.TIME_ZONE` — defaulting to UTC. So even with `TIME_ZONE="Europe/Berlin"`, a fetched value came back UTC:

```
before:  str(obj.when) -> 2026-12-30 23:00:00+00:00     (.date() = Dec 30)
after :  str(obj.when) -> 2026-12-31 00:00:00+01:00     (.date() = Dec 31)  ✓
```

Setting the *database* `TIME_ZONE` runs the session in Berlin, so psycopg returns aware-Berlin datetimes. **Storage stays UTC and the instant is unchanged** (verified: `23:30Z` reads back as `00:30+01:00`, `== the original instant`). Comparisons still work (aware, by instant).

This is the zero-refactor alternative to a per-field `LocalizedDateTimeField` or per-model `__str__` changes.

## Safety — the bitemporal concern, checked

The real risk was raw SQL assuming a UTC session. Django's date/time-part lookups (`__date`, `TruncDate`, …) inject an **explicit** `AT TIME ZONE`, so they're unaffected. Verified with the change live:

- history (bitemporal / `as_of`) + serializers + init + exports: **385 pass**
- calc + audit + crud + api-layer: **457 pass** (the single `test_10_3b` failure is a pre-existing test-ordering artifact — it passes in isolation both **with and without** this change)

Postgres-only guard (matches the existing pattern in the file); SQLite/local dev is left in UTC.

## Test

Batch **1r** (1.201–1.202, cluster init) — a fetched `DateTimeField` carries the display-zone offset and preserves the stored instant; on Berlin it reads `11:00` without a `localtime()` call. Stable over repeated runs.

## Caveats

- Takes effect on **restart** (connection-level) — that's why it can't be shown via `override_settings` in a shell.
- Per-instance overridable via `LEX_TIME_ZONE` (same knob as the global `TIME_ZONE`).
- Fetched values are now aware-**Berlin**, not aware-UTC — still a correct instant; any code doing `value.replace(tzinfo=None)` expecting UTC digits (already wrong under `USE_TZ=True`) should be checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)