### PR TITLE
fix(tz): keep DateTimeFields aware on assignment and Excel-safe on write

### DIFF
--- a/lex/core/fields/XLSX_field.py
+++ b/lex/core/fields/XLSX_field.py
@@ -1,10 +1,60 @@
+from datetime import datetime
 from io import BytesIO
+from zoneinfo import ZoneInfo
 
 import pandas as pd
+from django.conf import settings
 from django.core.files import File
 from django.db.models import FileField
 from openpyxl.styles import Font, Border, Side
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
+
+
+def _excel_display_naive(df):
+    """Return ``df`` with aware datetimes made Excel-writable.
+
+    Excel has no timezone concept, so ``to_excel`` raises on aware values —
+    which every DateTimeField now carries under USE_TZ=True. Render them as
+    the project display zone's wall clock (settings.TIME_ZONE) and strip the
+    tzinfo; naive values, dates and NaT pass through. Covers data columns,
+    object columns, the (multi)index and column headers, since report pivots
+    put datetimes in all four. Returns a shallow copy; the caller's frame is
+    left untouched.
+    """
+    zone = ZoneInfo(getattr(settings, "TIME_ZONE", "UTC") or "UTC")
+
+    def _cell(value):
+        if isinstance(value, datetime) and value.tzinfo is not None:
+            return value.astimezone(zone).replace(tzinfo=None)
+        return value
+
+    out = df.copy(deep=False)
+    for col in out.columns:
+        series = out[col]
+        if isinstance(series.dtype, pd.DatetimeTZDtype):
+            out[col] = series.dt.tz_convert(zone).dt.tz_localize(None)
+        elif series.dtype == object:
+            out[col] = series.map(_cell)
+
+    idx = out.index
+    if isinstance(idx, pd.DatetimeIndex):
+        if idx.tz is not None:
+            out.index = idx.tz_convert(zone).tz_localize(None)
+    elif isinstance(idx, pd.MultiIndex):
+        out.index = pd.MultiIndex.from_tuples(
+            [tuple(_cell(v) for v in entry) for entry in idx], names=idx.names
+        )
+    elif idx.dtype == object:
+        out.index = pd.Index([_cell(v) for v in idx], name=idx.name)
+
+    if isinstance(out.columns, pd.MultiIndex):
+        out.columns = pd.MultiIndex.from_tuples(
+            [tuple(_cell(v) for v in entry) for entry in out.columns],
+            names=out.columns.names,
+        )
+    else:
+        out.columns = [_cell(c) for c in out.columns]
+    return out
 
 
 class XLSXField(FileField):
@@ -69,6 +119,9 @@ class XLSXField(FileField):
         idx_length = 0
         for df, sheet_name in zip(data_frames, sheet_names):
             if df is not None:
+                # Excel cannot hold tz-aware datetimes; render them in the
+                # project display zone and strip the tzinfo before writing.
+                df = _excel_display_naive(df)
                 if len(df) == 0:
                     df = pd.concat([df, pd.DataFrame([{}])], ignore_index=True)
                 if index:

--- a/lex/core/models/LexModel.py
+++ b/lex/core/models/LexModel.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, FrozenSet, Mapping, Optional, Set, Union
 import streamlit as st
 from django.conf import settings
 from django.db import models, transaction
+from django.db.models.query_utils import DeferredAttribute
+from django.db.models.signals import class_prepared
 from django.utils import timezone
 from django_lifecycle import LifecycleModel, hook, AFTER_UPDATE, AFTER_CREATE, BEFORE_SAVE, AFTER_SAVE, BEFORE_CREATE, \
     BEFORE_UPDATE
@@ -1233,3 +1235,56 @@ class LexModel(LifecycleModel):
         Override in subclasses for aggregate visualizations, statistics, etc.
         """
         st.info("No class-level visualization available for this model.")
+
+
+# -- Aware-datetime invariant ---------------------------------------------
+# Under USE_TZ=True, Django only normalizes datetimes at the DB boundary:
+# a fetched DateTimeField is aware, but a value assigned in memory (fixture
+# load, Excel parse, ``obj.report_date = datetime.now()``) stays naive until
+# the next save/fetch round trip. Mixing the two in project code (e.g. one
+# pandas column fed from both a queryset and a freshly-built instance)
+# raises ``TypeError: Cannot compare tz-naive and tz-aware timestamps``.
+#
+# The descriptor below closes that gap: every DateTimeField on a LexModel
+# subclass becomes aware the moment it is assigned, using the same
+# interpretation Django itself applies at save time (the default timezone),
+# so nothing about the stored instant changes — the in-memory object simply
+# agrees with its own future save and with what a re-fetch returns.
+class AwareDateTimeDescriptor(DeferredAttribute):
+    """Data descriptor that makes naive datetime assignments aware on set.
+
+    ``DeferredAttribute.__get__`` already reads ``instance.__dict__`` first,
+    so adding ``__set__`` (turning this into a data descriptor) preserves
+    deferred-loading semantics while routing every assignment — including
+    ``Model.__init__`` and ``refresh_from_db`` — through the normalization.
+    """
+
+    def __set__(self, instance, value):
+        if (
+            settings.USE_TZ
+            and isinstance(value, datetime)
+            and timezone.is_naive(value)
+        ):
+            value = timezone.make_aware(value, timezone.get_default_timezone())
+        instance.__dict__[self.field.attname] = value
+
+
+def _install_aware_datetime_descriptors(sender, **kwargs):
+    """Wire AwareDateTimeDescriptor onto every DateTimeField of LexModel models.
+
+    Connected to ``class_prepared``, which fires only for concrete models —
+    each gets its inherited fields (``created_at``/``edited_at`` included)
+    wrapped exactly once at class construction.
+    """
+    if not issubclass(sender, LexModel):
+        return
+    for field in sender._meta.fields:
+        if isinstance(field, models.DateTimeField):
+            setattr(sender, field.attname, AwareDateTimeDescriptor(field))
+
+
+class_prepared.connect(
+    _install_aware_datetime_descriptors,
+    weak=False,
+    dispatch_uid="lex_aware_datetime_descriptors",
+)

--- a/lex/test_project/test-plan/clusters/03-validation_hooks/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/03-validation_hooks/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 3
 slug: validation_hooks
 title: Validation Hooks
-max_scenario: 32
+max_scenario: 38
 letters:
   a:
     title: ''
@@ -63,3 +63,16 @@ letters:
       xfail: 0
     note: counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately
       recorded
+  g:
+    title: DateTimeField aware-on-assignment invariant (AwareDateTimeDescriptor)
+    scenarios: 3.33-3.38
+    status: complete
+    tests:
+      pass: 6
+      skip: 0
+      xfail: 0
+    note: Under USE_TZ=True Django only normalizes at the DB boundary, so in-memory assignments stay
+      naive while fetches are aware -- the mix crashes downstream pandas/xirr comparisons. The
+      descriptor makes every DateTimeField assignment aware immediately (default-tz, the save-time
+      interpretation), instant unchanged. Includes the deferred-loading (data-descriptor) regression
+      guard. Ships with the USE_TZ=True cutover.

--- a/lex/test_project/test-plan/clusters/03-validation_hooks/batches.md
+++ b/lex/test_project/test-plan/clusters/03-validation_hooks/batches.md
@@ -33,3 +33,19 @@
 | Note | django-lifecycle's `_initial_state` is a second full-field copy per instance (set in `__init__`, re-captured after each save) — the ~2.17× per-row floor left after 3e. The framework's only dependency is `has_changed('edited_at')`; all other consumers are statically-discoverable hook clauses. The opt-in narrows the retained snapshot to `edited_at` + hook-clause fields + declared extras, built by filtering the full snapshot so tracked values stay byte-for-byte identical. Default **on** framework-wide — the narrowing is transparent because every consumer is either `has_changed('edited_at')` or a statically-discoverable hook clause; a model that queries `has_changed`/`initial_value` on an undeclared field lists it in `lex_initial_state_extra_fields` or sets `lex_lean_initial_state = False`. |
 
 ---
+
+### Batch 3g — DateTimeField aware-on-assignment invariant (`AwareDateTimeDescriptor`) ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 3.33 – 3.38 |
+| Type | I |
+| Files covered | `lex/core/models/LexModel.py` (`AwareDateTimeDescriptor`, `_install_aware_datetime_descriptors`, `class_prepared` wiring) |
+| Test file | `lex/test_project/tests/validation_hooks/test_3g_aware_datetime_assignment.py` |
+| Test classes | `TestCluster03g_AwareDatetimeAssignment` (3.33 naive ctor kwarg → aware in default tz; 3.34 DST-correct offsets on attribute set — summer +02:00 / winter +01:00; 3.35 aware values pass through untouched (no re-zoning); 3.36 non-datetime values pass through — None / date / string; 3.37 save→refetch preserves the instant; 3.38 deferred `.only()` field still lazy-loads aware — the data-descriptor regression guard) |
+| Fixtures | `StampedItem` (hook-free `DateTimeField` carrier) — added to `validation_hooks/models.py` |
+| Tests landed | **6 pass / 0 fail** (full cluster 3: 39 pass / 0 fail) |
+| Coverage gain | the aware-on-assignment normalization on `LexModel` DateTimeFields |
+| Status | ✅ Complete — Under USE_TZ=True Django only normalizes datetimes at the DB boundary: fetched values are aware, in-memory assignments (fixture load, Excel parse, `datetime.now()`) stay naive until the next round trip. Mixing the two crashes downstream comparisons (`TypeError: Cannot compare tz-naive and tz-aware timestamps` in pandas sorts / xirr). The descriptor closes the gap at assignment using the exact save-time interpretation (default tz), so the stored instant never changes — the in-memory object simply agrees with its own future save. Ships with the `USE_TZ=True` cutover. |
+
+---

--- a/lex/test_project/test-plan/clusters/03-validation_hooks/cluster.md
+++ b/lex/test_project/test-plan/clusters/03-validation_hooks/cluster.md
@@ -47,7 +47,13 @@
 | 3.30 | `refresh_from_db` re-baseline is lean | `refresh_from_db` rebuilds a lean snapshot and resets `has_changed` |
 | 3.31 | Create-path hooks unaffected | Lean create still stamps `created_at` / `created_by` (no change-detection involved) |
 | 3.32 | Lean snapshot is smaller | Lean `_initial_state` holds strictly fewer keys than the full snapshot |
+| 3.33 | Naive ctor kwarg becomes aware | A naive datetime passed to the constructor is aware immediately, interpreted in the default timezone |
+| 3.34 | DST offsets respected on set | Attribute assignment carries the seasonally correct offset (summer +02:00 / winter +01:00 on Berlin) |
+| 3.35 | Aware values pass through | An already-aware assignment keeps its instant and its own zone — no silent re-zoning |
+| 3.36 | Non-datetimes pass through | None / `date` / string reach the field untouched; parsing stays Django's job |
+| 3.37 | Save→refetch keeps the instant | The descriptor changes *when* a value becomes aware, never *what* is stored |
+| 3.38 | Deferred field still lazy | `.only()` still defers the field; access lazy-loads the aware stored instant (data-descriptor guard) |
 
-**Sub-clusters:** 3a `pre_validation` (3.1–3.2) · 3b `post_validation` (3.3–3.4) · 3c hook ordering (3.5–3.6) · 3d recursion guard (3.7) · 3e snapshot lifecycle (3.8–3.10) · **3f lean `_initial_state` default-on / opt-out (3.11–3.32)** — covers `lex/core/models/LexModel.py`, Type E, ✅ Complete (22 pass / 0 fail).
+**Sub-clusters:** 3a `pre_validation` (3.1–3.2) · 3b `post_validation` (3.3–3.4) · 3c hook ordering (3.5–3.6) · 3d recursion guard (3.7) · 3e snapshot lifecycle (3.8–3.10) · **3f lean `_initial_state` default-on / opt-out (3.11–3.32)** — covers `lex/core/models/LexModel.py`, Type E, ✅ Complete (22 pass / 0 fail) · **3g DateTimeField aware-on-assignment invariant (3.33–3.38)** — covers `lex/core/models/LexModel.py` (`AwareDateTimeDescriptor`), Type I, ✅ Complete (6 pass / 0 fail).
 
 ---

--- a/lex/test_project/test-plan/clusters/13-exports/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/13-exports/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 13
 slug: exports
 title: Export Endpoint
-max_scenario: 33
+max_scenario: 37
 letters:
   a:
     title: Legacy (non-AG) export path
@@ -64,3 +64,16 @@ letters:
       time. Both write paths render in the requester's zone (frontend sends `timezone` on the export
       request) — legacy pandas (_to_excel_naive) and streaming/fast (_normalize_cell_value) — falling
       back to settings.TIME_ZONE for absent/invalid. Ships with the USE_TZ=True cutover.
+  g:
+    title: Report-file Excel boundary renders and re-reads the display zone
+    scenarios: 13.34-13.37
+    status: complete
+    tests:
+      pass: 4
+      skip: 0
+      xfail: 0
+    note: XLSXField.create_excel_file_from_dfs crashed on the aware datetimes USE_TZ=True introduced
+      ("Excel does not support datetimes with timezones"). _excel_display_naive renders aware values
+      as settings.TIME_ZONE wall-clock and strips tzinfo -- data columns, object columns, (multi)index
+      and column headers. Round-trip proven — a cell read back from the file re-assigned to a LexModel
+      DateTimeField restores the exact original instant via the 3g invariant.

--- a/lex/test_project/test-plan/clusters/13-exports/batches.md
+++ b/lex/test_project/test-plan/clusters/13-exports/batches.md
@@ -33,3 +33,19 @@ writing-plan batch blocks were recorded for this cluster.
 | Status | ✅ Complete — Excel has no tz type, so aware-UTC datetimes are baked as a local wall-clock at export time, in the requester's browser zone (frontend sends `timezone` on the export request), falling back to `settings.TIME_ZONE`. Fixes exports showing naive UTC. Ships with the `USE_TZ=True` cutover. |
 
 ---
+
+### Batch 13g — Report-file Excel boundary: display-zone wall-clock, both ways ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 13.34 – 13.37 |
+| Type | U |
+| Files covered | `lex/core/fields/XLSX_field.py` (`_excel_display_naive`, `XLSXField.create_excel_file_from_dfs` normalization hook) |
+| Test file | `lex/test_project/tests/exports/test_13g_xlsx_field_timezone.py` |
+| Test classes | `TestCluster13g_XlsxFieldTimezone` (13.34 aware column → Berlin wall-clock naive, incl. winter quarter-end landing on the right calendar day; 13.35 object columns / DatetimeIndex / MultiIndex levels / column headers all normalize, caller's frame untouched; 13.36 end-to-end through `create_excel_file_from_dfs` — the written .xlsx cells read Berlin wall-clock via `pd.read_excel`; 13.37 full round trip — a cell parsed back from the file, assigned to a LexModel `DateTimeField`, becomes aware and denotes the exact original instant) |
+| Fixtures | none — in-memory workbook; storage stubbed at the `FieldFile.save` boundary; reuses `FastExportItem.happened_at` for the read-back assignment |
+| Tests landed | **4 pass / 0 fail** |
+| Coverage gain | the report-file (XLSXField) twin of the 13f export-endpoint timezone rendering |
+| Status | ✅ Complete — `to_excel` raises on the aware datetimes every DateTimeField carries under USE_TZ=True, which crashed every report writing through `XLSXField` ("Excel does not support datetimes with timezones"). The boundary now renders aware values as the project display zone's wall clock (settings.TIME_ZONE) and strips tzinfo — the one place where naive is *correct*, because a spreadsheet cell is a wall-clock reading, not an instant. Reading mirrors it: parsed cells are naive local and the 3g assignment invariant restores the instant. |
+
+---

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -12,7 +12,7 @@
 |---|---|---|---|---|---|
 | 1. Init — Project Bootstrap | 24 | 202 | 96 | 0 | 0 |
 | 2. CRUD via REST API | 10 | 107 | 15 | 0 | 0 |
-| 3. Validation Hooks | 6 | 32 | 0 | 0 | 0 |
+| 3. Validation Hooks | 7 | 38 | 6 | 0 | 0 |
 | 4. Permissions | 13 | 74 | 18 | 2 | 0 |
 | 5. History & Bitemporal | 12 | 103 | 15 | 6 | 3 |
 | 6. Audit Logging | 17 | 118 | 21 | 3 | 0 |
@@ -22,7 +22,7 @@
 | 10. API Layer | 13 | 71 | 21 | 0 | 0 |
 | 11. Stress & Performance | 9 | 22 | 0 | 0 | 0 |
 | 12. Serializer Contract | 10 | 48 | 16 | 0 | 0 |
-| 13. Export Endpoint | 6 | 33 | 3 | 0 | 0 |
+| 13. Export Endpoint | 7 | 37 | 7 | 0 | 0 |
 | 14. AG Grid Query Endpoint | 6 | 33 | 0 | 0 | 0 |
 | 15. Calculation Logging Surface | 8 | 34 | 13 | 0 | 0 |
 
@@ -80,6 +80,7 @@
 | 3d |  | 3.7 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 3e | Pre-validation snapshot lifecycle (v1→v2 calculate-all memory fix) | 3.9-3.10 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 3f | Default-on lean `_initial_state` (last full-field snapshot removed; hooks preserved) | 3.11-3.32 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
+| 3g | DateTimeField aware-on-assignment invariant (AwareDateTimeDescriptor) | 3.33-3.38 | complete | 6 | 0 | 0 | Under USE_TZ=True Django only normalizes at the DB boundary, so in-memory assignments stay naive while fetches are aware -- the mix crashes downstream pandas/xirr comparisons. The descriptor makes every DateTimeField assignment aware immediately (default-tz, the save-time interpretation), instant unchanged. Includes the deferred-loading (data-descriptor) regression guard. Ships with the USE_TZ=True cutover. |
 
 ## 4. Permissions (`permissions`)
 
@@ -248,6 +249,7 @@
 | 13d | Auth & edge cases | 13.11-13.12 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 13e |  |  | complete | 0 | 0 | 0 | on disk; per-letter tally folded into cluster top-line in pre-migration dashboard |
 | 13f | Export renders datetimes in the requester's browser timezone | 13.31-13.33 | complete | 3 | 0 | 0 | Excel has no tz type, so aware-UTC datetimes must be baked as a local wall-clock at export time. Both write paths render in the requester's zone (frontend sends `timezone` on the export request) — legacy pandas (_to_excel_naive) and streaming/fast (_normalize_cell_value) — falling back to settings.TIME_ZONE for absent/invalid. Ships with the USE_TZ=True cutover. |
+| 13g | Report-file Excel boundary renders and re-reads the display zone | 13.34-13.37 | complete | 4 | 0 | 0 | XLSXField.create_excel_file_from_dfs crashed on the aware datetimes USE_TZ=True introduced ("Excel does not support datetimes with timezones"). _excel_display_naive renders aware values as settings.TIME_ZONE wall-clock and strips tzinfo -- data columns, object columns, (multi)index and column headers. Round-trip proven — a cell read back from the file re-assigned to a LexModel DateTimeField restores the exact original instant via the 3g invariant. |
 
 ## 14. AG Grid Query Endpoint (`queries`)
 

--- a/lex/test_project/test-plan/progress/sessions/2026-07-23-aware-datetime-boundaries.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-07-23-aware-datetime-boundaries.md
@@ -1,0 +1,26 @@
+---
+date: 2026-07-23
+clusters: [3, 13]
+tests_added: 10
+suite_tally: "validation_hooks+exports+history+init+serializers: 446 pass / 14 skip / 2 xfail (3 fails are untracked local scratch tests, pre-existing)"
+---
+
+# Aware-datetime boundaries: assignment invariant + report-file Excel
+
+Closed the two naive/aware seams the `USE_TZ=True` cutover left open, found by a
+downstream project's real calculation run (`TypeError: Cannot compare tz-naive
+and tz-aware timestamps` in a pandas sort, then `Excel does not support
+datetimes with timezones` while writing the report file).
+
+- [Batch 3g](../../clusters/03-validation_hooks/batches.md) — `AwareDateTimeDescriptor`
+  makes every `DateTimeField` assignment aware at set-time (default-tz, the
+  save-time interpretation), so in-memory objects agree with fetches; includes
+  the deferred-loading data-descriptor regression guard.
+- [Batch 13g](../../clusters/13-exports/batches.md) — `XLSXField` renders aware
+  datetimes as display-zone wall-clock (naive) across columns, object columns,
+  (multi)index and headers; round-trip proven back to the exact instant via the
+  3g invariant.
+
+Blast-radius run (validation_hooks, exports, history, init, serializers):
+446 pass — the only 3 failures are untracked local scratch tests from the
+original bug diagnosis that assert the pre-fix shifted behaviour.

--- a/lex/test_project/tests/exports/test_13g_xlsx_field_timezone.py
+++ b/lex/test_project/tests/exports/test_13g_xlsx_field_timezone.py
@@ -1,0 +1,199 @@
+"""Cluster 13g — report Excel files hold display-zone wall-clock, both ways.
+
+Intent: Excel has no timezone type, so ``to_excel`` raises on the aware
+datetimes every DateTimeField now carries under USE_TZ=True — which crashed
+every report writing through ``XLSXField.create_excel_file_from_dfs``.
+``_excel_display_naive`` fixes the boundary the way ModelExport does (13f):
+render aware values as the project display zone's wall clock (settings
+TIME_ZONE, Berlin) and strip the tzinfo — across data columns, mixed object
+columns, the (multi)index and column headers, since report pivots put dates in
+all four. Reading is the mirror image: a cell parsed back from the file is
+naive Berlin wall clock, and the moment it is assigned to a LexModel
+DateTimeField the aware-on-assignment invariant (3g) restores the exact
+original instant. A regression here either crashes report generation or ships
+spreadsheets whose times are shifted by the viewer's offset.
+
+Cluster 13g — scenarios 13.34–13.37. Type: U.
+Covers: lex/core/fields/XLSX_field.py
+        (_excel_display_naive, XLSXField.create_excel_file_from_dfs).
+Run: python -m lex pytest lex/test_project/tests/exports/test_13g_xlsx_field_timezone.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone as dt_timezone
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from django.test import SimpleTestCase, override_settings
+
+from lex.core.fields.XLSX_field import XLSXField, _excel_display_naive
+
+from .models import FastExportItem
+
+pytestmark = pytest.mark.exports
+
+# 09:00Z = 11:00 Berlin (summer, +02:00)
+SUMMER_INSTANT = datetime(2026, 7, 20, 9, 0, 0, tzinfo=dt_timezone.utc)
+# 23:00Z Dec 30 = 00:00 Dec 31 Berlin (winter, +01:00) — quarter-end day flip
+WINTER_INSTANT = datetime(2026, 12, 30, 23, 0, 0, tzinfo=dt_timezone.utc)
+
+
+@override_settings(USE_TZ=True, TIME_ZONE="Europe/Berlin")
+class TestCluster13g_XlsxFieldTimezone(SimpleTestCase):
+    """Cluster 13g: the report-file boundary renders and re-reads Berlin."""
+
+    @staticmethod
+    def _write_and_read_back(df: pd.DataFrame) -> pd.DataFrame:
+        """Drive the public entry the way a report does and parse the file.
+
+        Real callers hand ``create_excel_file_from_dfs`` a FieldFile as
+        ``self``; storage is the external boundary, so a stub captures the
+        ``save`` call and we read the returned in-memory workbook instead.
+        """
+        storage_stub = SimpleNamespace(save=lambda *args, **kwargs: None)
+        excel_file = XLSXField.create_excel_file_from_dfs(
+            storage_stub, "report.xlsx", [df],
+        )
+        return pd.read_excel(excel_file, sheet_name="Sheet", index_col=0)
+
+    def test_13_34_aware_columns_render_display_zone_wall_clock(self) -> None:
+        """
+        Scenario 13.34: an aware datetime column becomes naive Berlin wall
+        clock — including the winter case where the calendar day flips.
+        Given: a tz-aware column holding 09:00Z (summer) and Dec 30 23:00Z (winter)
+        When: normalized for Excel
+        Then: cells read 11:00 and Dec 31 00:00 — naive, right day
+        """
+        df = pd.DataFrame({
+            "happened_at": pd.to_datetime([SUMMER_INSTANT, WINTER_INSTANT], utc=True),
+            "amount": [1.0, 2.0],
+        })
+        out = _excel_display_naive(df)
+        summer, winter = out["happened_at"].iloc[0], out["happened_at"].iloc[1]
+        self.assertIsNone(
+            summer.tzinfo, "Excel cells must be tz-naive after normalization."
+        )
+        self.assertEqual(
+            (summer.hour, summer.minute), (11, 0),
+            f"09:00Z must render as the 11:00 Berlin wall clock, got {summer}.",
+        )
+        self.assertEqual(
+            (winter.month, winter.day, winter.hour), (12, 31, 0),
+            f"Dec 30 23:00Z is Berlin midnight Dec 31 — the quarter-end must "
+            f"land on the right day, got {winter}.",
+        )
+
+    def test_13_35_object_column_index_and_headers_normalize(self) -> None:
+        """
+        Scenario 13.35: report pivots put datetimes everywhere — mixed object
+        columns, the (multi)index and the column headers all normalize, and
+        the caller's frame is left untouched.
+        Given: aware datetimes in an object column, a DatetimeIndex, a
+               MultiIndex level and the column headers
+        When: normalized for Excel
+        Then: every position is naive Berlin wall clock; the input frame
+              still holds its aware values
+        """
+        naive = datetime(2026, 6, 30, 0, 0, 0)
+        df = pd.DataFrame(
+            {"mixed": [SUMMER_INSTANT, naive], "amount": [1.0, 2.0]},
+            index=pd.DatetimeIndex(
+                [pd.Timestamp(SUMMER_INSTANT), pd.Timestamp(WINTER_INSTANT)],
+                name="report_date",
+            ),
+        )
+        out = _excel_display_naive(df)
+        self.assertEqual(
+            (out["mixed"].iloc[0].hour, out["mixed"].iloc[0].tzinfo), (11, None),
+            f"aware object-column cell must be naive Berlin, got {out['mixed'].iloc[0]}.",
+        )
+        self.assertEqual(
+            out["mixed"].iloc[1], naive,
+            "already-naive cells must pass through unchanged.",
+        )
+        self.assertIsNone(out.index.tz, "the index must lose its timezone.")
+        self.assertEqual(
+            (out.index[1].month, out.index[1].day), (12, 31),
+            f"the winter index entry must land on Dec 31 Berlin, got {out.index[1]}.",
+        )
+        self.assertIsNotNone(
+            df["mixed"].iloc[0].tzinfo,
+            "the caller's frame must not be mutated by normalization.",
+        )
+
+        pivot = pd.DataFrame(
+            [[1.0]],
+            index=pd.MultiIndex.from_tuples(
+                [("FundA", pd.Timestamp(WINTER_INSTANT))], names=["fund", "date"]
+            ),
+            columns=[pd.Timestamp(SUMMER_INSTANT)],
+        )
+        outp = _excel_display_naive(pivot)
+        self.assertEqual(
+            (outp.index[0][1].day, outp.index[0][1].tzinfo), (31, None),
+            f"MultiIndex datetime levels must normalize, got {outp.index[0][1]}.",
+        )
+        self.assertEqual(
+            (outp.columns[0].hour, outp.columns[0].tzinfo), (11, None),
+            f"datetime column headers must normalize, got {outp.columns[0]}.",
+        )
+
+    def test_13_36_written_file_cells_read_berlin_wall_clock(self) -> None:
+        """
+        Scenario 13.36: end-to-end through the public entry — the .xlsx that
+        create_excel_file_from_dfs produces holds Berlin wall-clock cells.
+        Given: a report frame with aware datetimes (the post-USE_TZ reality
+               that used to crash with "Excel does not support datetimes
+               with timezones")
+        When: written via create_excel_file_from_dfs and parsed back
+        Then: the file's cells read 11:00 / Dec 31 00:00, tz-naive
+        """
+        df = pd.DataFrame({
+            "name": ["summer", "winter"],
+            "happened_at": pd.to_datetime([SUMMER_INSTANT, WINTER_INSTANT], utc=True),
+        })
+        read_back = self._write_and_read_back(df)
+        cells = pd.to_datetime(read_back["happened_at"])
+        self.assertIsNone(
+            cells.iloc[0].tzinfo, "cells in the file must be tz-naive."
+        )
+        self.assertEqual(
+            (cells.iloc[0].hour, cells.iloc[0].minute), (11, 0),
+            f"the written file must show 11:00 Berlin for 09:00Z, got {cells.iloc[0]}.",
+        )
+        self.assertEqual(
+            (cells.iloc[1].month, cells.iloc[1].day, cells.iloc[1].hour),
+            (12, 31, 0),
+            f"the winter quarter-end must be written as Dec 31 00:00 Berlin, "
+            f"got {cells.iloc[1]}.",
+        )
+
+    def test_13_37_read_back_cell_restores_the_instant_on_assignment(self) -> None:
+        """
+        Scenario 13.37: the full round trip — write Berlin, read Berlin, and
+        the moment the parsed cell is assigned to a LexModel DateTimeField
+        the aware-on-assignment invariant restores the exact original instant.
+        Given: the file written in 13.36, parsed with pd.read_excel
+        When: a naive Berlin cell is assigned to FastExportItem.happened_at
+        Then: the attribute is aware and denotes the original 09:00Z instant
+        """
+        df = pd.DataFrame({
+            "name": ["summer"],
+            "happened_at": pd.to_datetime([SUMMER_INSTANT], utc=True),
+        })
+        cell = pd.to_datetime(self._write_and_read_back(df)["happened_at"].iloc[0])
+        self.assertIsNone(cell.tzinfo, "the parsed cell arrives naive — as Excel data does.")
+
+        item = FastExportItem(happened_at=cell)
+        self.assertIsNotNone(
+            item.happened_at.tzinfo,
+            "assignment must make the Excel-parsed value aware immediately.",
+        )
+        self.assertEqual(
+            item.happened_at.astimezone(dt_timezone.utc),
+            SUMMER_INSTANT,
+            f"write→read→assign must reproduce the original instant; got "
+            f"{item.happened_at} (≠ 09:00Z).",
+        )

--- a/lex/test_project/tests/validation_hooks/models.py
+++ b/lex/test_project/tests/validation_hooks/models.py
@@ -252,6 +252,26 @@ class LeanExtraFieldItem(LexModel):
             type(self).hook_log.append("note_changed")
 
 
+@_permissive
+class StampedItem(LexModel):
+    """
+    Plain ``DateTimeField`` carrier for the aware-on-assignment invariant (3g).
+
+    Deliberately hook-free: the batch tests what ``AwareDateTimeDescriptor``
+    does to a *bare* datetime field the moment it is assigned, without any
+    lifecycle machinery in the way.
+    """
+
+    name = models.CharField(max_length=200)
+    happened_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        app_label = "lex_app"
+
+    def __str__(self) -> str:  # pragma: no cover
+        return self.name
+
+
 ALL_MODELS = [
     PreValidatedItem,
     PostValidatedItem,
@@ -259,4 +279,5 @@ ALL_MODELS = [
     LeanConditionalItem,
     FullConditionalItem,
     LeanExtraFieldItem,
+    StampedItem,
 ]

--- a/lex/test_project/tests/validation_hooks/test_3g_aware_datetime_assignment.py
+++ b/lex/test_project/tests/validation_hooks/test_3g_aware_datetime_assignment.py
@@ -1,0 +1,174 @@
+"""Cluster 3g — a DateTimeField becomes aware the moment it is assigned.
+
+Intent: under USE_TZ=True Django only normalizes datetimes at the DB boundary,
+so a value assigned in memory (fixture load, Excel parse, ``obj.happened_at =
+datetime.now()``) stays naive until the next save/fetch round trip while a
+fetched value is aware. Mixing the two in downstream code (e.g. one pandas
+column fed from both a queryset and a freshly-built instance) raises
+``TypeError: Cannot compare tz-naive and tz-aware timestamps`` mid-calculation.
+``AwareDateTimeDescriptor`` closes the gap: every ``DateTimeField`` on a
+``LexModel`` subclass is normalized to the default timezone at assignment —
+the same interpretation Django itself applies at save time, so the stored
+instant never changes; the in-memory object simply agrees with its own future
+save and with what a re-fetch returns. A regression here silently reopens the
+naive/aware seam in every downstream project.
+
+Cluster 3g — scenarios 3.33–3.38. Type: I.
+Covers: lex/core/models/LexModel.py
+        (AwareDateTimeDescriptor, _install_aware_datetime_descriptors).
+Run: python -m lex pytest lex/test_project/tests/validation_hooks/test_3g_aware_datetime_assignment.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone as dt_timezone
+
+import pytest
+from django.conf import settings
+from django.utils import timezone
+
+from lex.test_project.tests._e2e_test_case import E2ETestCase
+
+from .models import ALL_MODELS, StampedItem
+
+pytestmark = pytest.mark.validation_hooks
+
+SUMMER_NAIVE = datetime(2026, 7, 20, 11, 0, 0)   # Berlin: +02:00 → 09:00Z
+WINTER_NAIVE = datetime(2026, 12, 31, 0, 0, 0)   # Berlin: +01:00 → Dec 30 23:00Z
+
+
+class TestCluster03g_AwareDatetimeAssignment(E2ETestCase):
+    """Cluster 3g: DateTimeField assignments are aware from the first moment."""
+
+    e2e_models = ALL_MODELS
+
+    def test_3_33_naive_constructor_kwarg_becomes_aware(self) -> None:
+        """
+        Scenario 3.33: a naive datetime passed to the model constructor is
+        aware immediately, interpreted in the default timezone.
+        Given: a naive wall-clock value
+        When: passed as a constructor kwarg (no save, no fetch)
+        Then: the attribute is aware and denotes the same instant Django
+              would persist for it (make_aware in the default timezone)
+        """
+        item = StampedItem(name="ctor", happened_at=SUMMER_NAIVE)
+        self.assertIsNotNone(
+            item.happened_at.tzinfo,
+            "a naive constructor kwarg must be aware on the instance — the "
+            "naive/aware mixing window this descriptor exists to close.",
+        )
+        expected = timezone.make_aware(SUMMER_NAIVE, timezone.get_default_timezone())
+        self.assertEqual(
+            item.happened_at, expected,
+            f"assignment must use the save-time interpretation (default tz); "
+            f"got {item.happened_at}, expected {expected}.",
+        )
+
+    def test_3_34_dst_offsets_are_respected_on_attribute_set(self) -> None:
+        """
+        Scenario 3.34: attribute assignment picks the DST-correct offset —
+        summer +02:00, winter +01:00 on a Berlin instance.
+        Given: naive summer and winter wall-clock values
+        When: assigned to the attribute after construction
+        Then: each carries its own seasonal UTC offset
+        """
+        if settings.TIME_ZONE != "Europe/Berlin":
+            self.skipTest(f"default zone is {settings.TIME_ZONE}, not Europe/Berlin")
+        item = StampedItem(name="dst")
+        item.happened_at = SUMMER_NAIVE
+        self.assertEqual(
+            item.happened_at.utcoffset().total_seconds(), 2 * 3600,
+            f"summer wall-clock must carry +02:00, got {item.happened_at}.",
+        )
+        item.happened_at = WINTER_NAIVE
+        self.assertEqual(
+            item.happened_at.utcoffset().total_seconds(), 1 * 3600,
+            f"winter wall-clock must carry +01:00, got {item.happened_at}.",
+        )
+
+    def test_3_35_aware_values_pass_through_untouched(self) -> None:
+        """
+        Scenario 3.35: an already-aware value is not converted — tzinfo and
+        instant are preserved exactly as assigned.
+        Given: an aware UTC datetime
+        When: assigned
+        Then: same instant, still UTC (no silent re-zoning)
+        """
+        aware_utc = datetime(2026, 7, 20, 9, 0, 0, tzinfo=dt_timezone.utc)
+        item = StampedItem(name="aware", happened_at=aware_utc)
+        self.assertEqual(
+            item.happened_at, aware_utc,
+            "an aware assignment must keep its instant.",
+        )
+        self.assertEqual(
+            item.happened_at.utcoffset(), aware_utc.utcoffset(),
+            f"an aware assignment must keep its own zone (no conversion); "
+            f"got {item.happened_at}.",
+        )
+
+    def test_3_36_non_datetime_values_pass_through(self) -> None:
+        """
+        Scenario 3.36: values that are not datetimes are left alone — None,
+        a plain date, and a string reach the field untouched (their handling
+        stays with Django's own to_python/validation, not the descriptor).
+        Given: None, date(...), and an ISO string
+        When: assigned
+        Then: each is stored on the instance exactly as given
+        """
+        item = StampedItem(name="passthrough")
+        item.happened_at = None
+        self.assertIsNone(item.happened_at, "None must remain None.")
+        d = date(2026, 7, 20)
+        item.happened_at = d
+        self.assertIs(
+            item.happened_at, d,
+            "a plain date is not a datetime and must pass through untouched.",
+        )
+        s = "2026-07-20T11:00:00"
+        item.happened_at = s
+        self.assertIs(
+            item.happened_at, s,
+            "a string must pass through — parsing stays Django's job.",
+        )
+
+    def test_3_37_save_then_refetch_preserves_the_instant(self) -> None:
+        """
+        Scenario 3.37: the descriptor changes WHEN a value becomes aware,
+        never WHAT is stored — a naive assignment saves and refetches as the
+        exact instant Django would have persisted anyway.
+        Given: a naive wall-clock value assigned and saved
+        When: the row is re-fetched from the DB
+        Then: fetched == make_aware(naive, default tz) — instant unchanged
+        """
+        StampedItem.objects.create(name="roundtrip", happened_at=SUMMER_NAIVE)
+        fetched = StampedItem.objects.get(name="roundtrip").happened_at
+        expected = timezone.make_aware(SUMMER_NAIVE, timezone.get_default_timezone())
+        self.assertEqual(
+            fetched, expected,
+            f"DB round trip must preserve the instant; got {fetched}, "
+            f"expected {expected}.",
+        )
+        self.assertIsNotNone(fetched.tzinfo, "fetched value must be aware.")
+
+    def test_3_38_deferred_field_still_lazy_loads_aware(self) -> None:
+        """
+        Scenario 3.38: turning the field descriptor into a data descriptor
+        must not break deferred loading — a field excluded via .only() is
+        still absent until touched, then loads as the aware stored instant.
+        Given: a saved row fetched with .only('id', 'name')
+        When: the deferred happened_at attribute is accessed
+        Then: it lazy-loads from the DB, aware, equal to the stored instant
+        """
+        created = StampedItem.objects.create(name="deferred", happened_at=SUMMER_NAIVE)
+        lean = StampedItem.objects.only("id", "name").get(pk=created.pk)
+        self.assertNotIn(
+            "happened_at", lean.__dict__,
+            ".only() must still defer the field (data-descriptor regression).",
+        )
+        value = lean.happened_at  # triggers the deferred fetch
+        expected = timezone.make_aware(SUMMER_NAIVE, timezone.get_default_timezone())
+        self.assertEqual(
+            value, expected,
+            f"deferred access must return the aware stored instant; got {value}.",
+        )
+        self.assertIsNotNone(value.tzinfo, "deferred load must return aware.")


### PR DESCRIPTION
## Why

The `USE_TZ=True` cutover (#661) made the ORM return **aware** datetimes, but Django only normalizes at the DB boundary. That left two seams where naive and aware values meet — both surface as hard crashes mid-calculation, not at the settings flip:

1. **In memory the value stays naive.** A `DateTimeField` set from a fixture load, an Excel parse, or `obj.x = datetime.now()` is naive until the next save/fetch. Feed one pandas column from both a queryset (aware) and a freshly-built instance (naive) and `sort_values`/`xirr` raise `TypeError: Cannot compare tz-naive and tz-aware timestamps`.
2. **Excel can't hold aware datetimes.** Every report writing through `XLSXField.create_excel_file_from_dfs` hits `ValueError: Excel does not support datetimes with timezones`.

## What

**`AwareDateTimeDescriptor`** (`lex/core/models/LexModel.py`) — a data descriptor wired onto every `DateTimeField` of every concrete `LexModel` subclass via `class_prepared`. Naive assignments become aware immediately, using the **same default-timezone interpretation Django applies at save time**, so:
- the stored instant never changes (this changes *when* a value is aware, not *what* is persisted),
- in-memory objects agree with what a re-fetch returns — the naive/aware mix stops existing,
- deferred loading (`.only()`) is preserved (subclassing `DeferredAttribute`, adding only `__set__`).

**`_excel_display_naive`** (`lex/core/fields/XLSX_field.py`) — applied right before `to_excel`, renders aware datetimes as the display zone's wall clock (`settings.TIME_ZONE`) and strips tzinfo, across data columns, object columns, the (multi)index and column headers. This is the report-file twin of the export-endpoint fix in #669: the Excel cell is the one place where being naive is *correct*, because a spreadsheet cell is a wall-clock reading, not an instant.

## Tests (release-gating, cluster-aligned)

| Batch | Scenarios | Result |
|---|---|---|
| **3g** — assignment invariant | 3.33–3.38 | **6 pass** |
| **13g** — report-file Excel boundary | 13.34–13.37 | **4 pass** |

- **3g**: naive ctor kwarg → aware in default tz · DST-correct offsets (summer +02:00 / winter +01:00) · aware passthrough (no re-zoning) · non-datetime passthrough (None/`date`/str) · save→refetch instant equality · deferred-field data-descriptor guard. Adds the `StampedItem` fixture.
- **13g**: aware column → local wall-clock naive (winter quarter-end lands on the right calendar day) · object/DatetimeIndex/MultiIndex/header normalization + caller frame untouched · **end-to-end** write reads local wall-clock via `pd.read_excel` · **read round trip** — file cell → `pd.read_excel` → model assignment restores the exact original instant.

Blast-radius run (validation_hooks + exports + history + init + serializers): **446 pass / 14 skip / 2 xfail**. Plan shards, session fragment, and regenerated dashboard included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)