### PR TITLE
feat(bitemporal): activate overdue records without depending on a timer

### DIFF
--- a/docs/superpowers/specs/2026-08-04-global-scheduler-infra.md
+++ b/docs/superpowers/specs/2026-08-04-global-scheduler-infra.md
@@ -1,0 +1,365 @@
+# Cluster-level scheduling — what each approach costs in infrastructure
+
+**Companion to** `2026-08-04-global-scheduler-options.md`, which argues the
+software design. This one answers the question that document skipped: *what
+actually gets deployed, who holds which credential, and what does on-call see at
+03:00 when it breaks.*
+
+**Status:** decision support. Approach D is implemented (branch
+`feat/bitemporal-activation-reconcile` + `feat/activation-reconcile-retire-beat`);
+A, B and C are described as they would have to be built.
+
+---
+
+## 0. The cluster this has to live in
+
+Every option below is judged against the environment as it actually is, not a
+generic Kubernetes cluster. The relevant facts:
+
+| | |
+|---|---|
+| Cluster | `lex-cluster-2`, GKE, `europe-west3` |
+| Instances | **53**, all in one namespace (`default`) |
+| …of which run Celery workers | **6** (KEDA `ScaledJob`, 0→21 pods) |
+| Per instance | backend + frontend Deployments, own Dragonfly (1 replica, ClusterIP, 1 GiB PVC), own Postgres database on a shared server |
+| Nodes | `e2-standard-4`, **spot**, pool capped at 15 |
+| Backend scaling | optional KEDA `ScaledObject`, min 0, triggered by **nginx ingress request count** (`autoscaling` defaults false) |
+| Recovery supervisor | Deployment, 128Mi request / **256Mi limit** |
+| Deployment path | instance controller → Terraform → Helm, with `module_version` pinned **per instance** |
+
+Three of these shape the answer more than the rest:
+
+**One namespace, 53 tenants.** There is no namespace boundary to lean on. Any
+RBAC grant a cluster-level component receives applies to every instance's
+resources at once. "Read secrets in `default`" is not a scoped permission here —
+it is fleet-wide.
+
+**The backend can be scaled to zero.** On instances with `autoscaling: true`,
+KEDA drops the backend to 0 replicas and the only trigger that brings it back is
+**ingress traffic**. An in-cluster call does not pass through the ingress, so a
+cluster-level component cannot wake a backend by calling it. This kills the
+obvious callback design unless it is worked around explicitly.
+
+**Per-instance pods are already proving fragile at this size.** Instance 1047's
+recovery supervisor — a 256Mi pod doing almost nothing — is `OOMKilled` and has
+restarted 68 times in five hours, because the Django app it boots settles just
+above the limit. That is the empirical argument against "just add another small
+pod per instance," and equally a warning that a single cluster-level pod needs
+its sizing taken seriously rather than assumed trivial.
+
+---
+
+## 1. Approach A — cluster scheduler, instances register, scheduler calls back
+
+### What gets deployed
+
+```
+namespace: default
+  Deployment  lex-scheduler                 replicas: 1   (see HA below)
+  Service     lex-scheduler                 ClusterIP     ← instances register here
+  PVC or DB   lex-scheduler-timers          ← timers must survive a restart
+  Secret      lex-scheduler-callback-keys   ← how it authenticates to 53 instances
+  ServiceAccount + Role                     ← minimal, ideally none
+```
+
+Plus, in lex-app: a registration client (instance → scheduler at schedule time)
+and a callback endpoint (scheduler → instance at fire time).
+
+### The state problem nobody expects
+
+A scheduler that forgets its timers on restart is useless, so it needs
+persistence. That turns a "small stateless service" into a **stateful component
+with a database, backups, and migrations** — the thing everyone assumes they are
+avoiding by not choosing option C.
+
+The alternative is for it to rebuild its timer set at boot by asking all 53
+instances what they are waiting for, which reintroduces an inbound sweep and most
+of option B's coupling.
+
+### The callback problem
+
+At fire time the scheduler has to reach the instance. Both routes have a defect:
+
+**HTTP to the backend Service.** Works for all 53 instances, no broker needed:
+
+```
+http://lex-backend-<instance>.default.svc.cluster.local:7000/api/internal/activate
+```
+
+But on an `autoscaling: true` instance the backend may be at 0 replicas and the
+KEDA trigger is ingress request count — an in-cluster call will not wake it. The
+request fails, and the activation is late until traffic arrives by other means.
+Fixing it means either a second KEDA trigger (a metrics-api scaler the scheduler
+can poke) or pinning those instances to `minReplicas: 1`, which gives back the
+saving that motivated backend autoscaling.
+
+**Enqueue into the instance's broker.** Wakes a worker through the existing KEDA
+`ScaledJob` trigger, so scaling works. But it needs each instance's Redis
+password — 53 credentials — and only works for the **6** instances that run
+Celery. It solves the wrong 11% of the fleet.
+
+### Credentials
+
+The scheduler must prove identity to 53 instances. Practical options, all
+unattractive at this scale:
+
+- **53 API keys mounted from `app-env-<instance>`** — requires `secrets get`
+  across the namespace, which is exactly option B's grant with extra steps;
+- **one shared signing key** — the scheduler signs a callback, instances verify.
+  Better, but now one key compromise authorises calls into every instance;
+- **mTLS / SPIFFE** — correct, and a significantly larger project than the
+  scheduler itself.
+
+### Failure modes
+
+| Failure | Effect |
+|---|---|
+| Scheduler pod down | No activation fires on **any** instance until it returns |
+| Scheduler DB/PVC lost | Every pending timer lost fleet-wide; no way to rebuild without sweeping instances |
+| Callback fails (backend at 0) | That instance's activation is late, silently |
+| Instance deleted | Orphan timers accumulate; needs a TTL or a deregistration hook |
+| Node preempted (spot) | Rescheduled; timers survive only if the PVC does — and RWO on a zonal disk constrains where it can land |
+
+### Ops burden
+
+A new stateful service with its own backups, its own alerts, its own dashboard,
+and a new failure mode for on-call to learn. The registration protocol becomes a
+compatibility surface: an instance on an older lex-app that does not register is
+silently unscheduled, and nothing surfaces that.
+
+**Verdict:** the cleanest of the three cluster-level designs, and still a
+genuinely large project once state, credentials and the scale-to-zero interaction
+are priced in.
+
+---
+
+## 2. Approach B — scheduler polls every instance's database
+
+### What gets deployed
+
+```
+namespace: default
+  Deployment      lex-scheduler       replicas: 1
+  ServiceAccount  lex-scheduler
+  Role/RoleBinding: secrets [get, list]   ← the whole story is in this line
+```
+
+No lex-app change at all. That is the real attraction and it should be stated
+honestly: this is the only option deployable against instances as they are today,
+with no release, no migration, and no coordination.
+
+### Why that RBAC line is the whole story
+
+To reach 53 databases the scheduler needs 53 sets of credentials, which live in
+the per-instance `app-env-<instance>` Secret. Granting `secrets get` in
+`default` does not grant database credentials — it grants **every key in every
+instance's secret**:
+
+```
+DJANGO_SECRET_KEY          POSTGRES_USERNAME / POSTGRES_PASSWORD
+DJANGO_SUPERUSER_PASSWORD  REDIS_USERNAME / REDIS_PASSWORD
+LEX_AI_METAGPT_LLM_CREDENTIALS
+SHAREPOINT_API_CERTIFICATE_THUMBPRINT
+```
+
+A component whose entire job is knowing what time it is would hold the session
+signing key, database superuser credentials, and the SharePoint certificate
+thumbprint for all 53 customers. Any RCE, any dependency compromise, any logging
+mistake that dumps its environment, is a fleet-wide credential incident.
+
+There is no scoped version of this in a single namespace. Kubernetes RBAC cannot
+express "these 53 secrets but not those" without naming each one, and the list
+changes every time an instance is created.
+
+### Operational reality
+
+- 53 idle Postgres connections held against a shared server, from a pod that
+  needs almost nothing from them; connection-pool tuning becomes its problem.
+- A locked or slow instance database stalls the poll loop for everyone unless
+  the loop is carefully concurrent — an easy thing to get wrong and a hard thing
+  to notice.
+- Credential rotation on any instance must be mirrored into the scheduler's
+  refresh path, or that instance silently stops being scheduled.
+- Debugging is cross-tenant by nature: reading the scheduler's logs means seeing
+  identifiers from every customer.
+
+### Failure modes
+
+| Failure | Effect |
+|---|---|
+| Scheduler down | No activations anywhere |
+| One instance DB slow/locked | Poll loop stalls → delays other tenants |
+| Credential rotated | That instance silently unscheduled |
+| Scheduler compromised | **Fleet-wide data and credential exposure** |
+
+**Verdict:** cheapest to ship, most expensive to own. Every incident this quarter
+has been about blast radius; this creates the largest one available and puts it
+in a component that does not need any of that access to do its job.
+
+---
+
+## 3. Approach C — central schedule store
+
+### What gets deployed
+
+```
+namespace: default
+  Deployment  lex-scheduler          replicas: 1
+  Database    scheduler DB (new Cloud SQL DB or a DB on the shared server)
+              + backups, + migrations, + monitoring
+  Secret      per-instance write credentials to that DB (53 roles, or one shared)
+```
+
+Instances write due-times into the shared store instead of their own database.
+
+### The infra objection
+
+This puts a shared component **in the write path of a user action**. Today,
+saving a future-dated record touches one database — the instance's own. Under C
+it touches two, and the second is shared across 53 tenants. If the scheduler
+database is down or slow, users cannot save future-dated records *at all*, on
+every instance simultaneously. A and B degrade firing; C degrades **writing**.
+
+It also creates a second system of record. The instance's meta row and the
+central timer row must agree through cancellation, deletion, instance clone, and
+restore-from-backup. Restore is the one that should worry you: restoring an
+instance's database to an earlier point silently desynchronises it from a central
+store that was never rolled back.
+
+Isolation stops being structural and becomes a discipline — every query must
+filter by tenant, and nothing enforces it. Given 53 tenants in one namespace,
+that is a lot of trust placed in code review.
+
+**Verdict:** a reasonable design for a different requirement — fleet-wide
+operational visibility of scheduled work. If calculation scheduling later needs
+that, revisit it with visibility as the stated goal, not as a side effect of
+needing a clock.
+
+---
+
+## 4. Approach D — reconcile in the backend (implemented)
+
+### What gets deployed
+
+Nothing.
+
+```diff
+  # modules/lex-instance/configmaps.tf — dpag (backend) ConfigMap
++ "LEX_ACTIVATION_RECONCILE_ENABLED"          = "true"
++ "LEX_ACTIVATION_RECONCILE_INTERVAL_SECONDS" = "60"
+```
+
+No new Deployment, no Service, no PVC, no database, no ServiceAccount, no RBAC
+grant, no secret, no network path, no new port, no ingress rule. The work runs on
+a daemon thread inside the backend process that already exists on every instance.
+
+### How it works, in infra terms
+
+The backend queries **its own database** for meta rows still marked `SCHEDULED`
+whose history row's `valid_from` has passed, and applies them. The instance's
+database was already the durable record of what should happen; the timer was
+only ever an optimisation for *when* to look.
+
+Because it needs nothing outside the instance, isolation is not engineered — it
+is structural. There is no component that can reach across tenants because there
+is no new component.
+
+### Why it is set unconditionally
+
+`LEX_ACTIVATION_RECONCILE_*` goes in the **unconditional** part of the backend
+ConfigMap, not the `architecture == "MQ/Worker"` branch that carries the Celery
+flags. The instances that need it most are the **47 without Celery**: their
+timer is an in-process thread queue that is lost on every restart, with nothing
+to rehydrate it. Gating on the worker architecture would skip the entire
+population the change exists for.
+
+### Failure modes
+
+| Failure | Effect |
+|---|---|
+| Backend restarts | Catch-up runs **immediately on boot** — the restart is the trigger, not the problem |
+| Loop thread dies | Next backend restart resumes it; activations are late, never lost |
+| Instance backend at 0 replicas (`autoscaling: true`) | No pass runs while nothing is running. Activation is late until the backend wakes — the same window in which nobody is using the instance. Worth confirming which instances have this set. |
+| A record cannot activate | Retried up to `MAX_ATTEMPTS` per process, then skipped, so one poison row cannot burn every pass |
+| Instance dormant for months | Rows older than `MAX_AGE_DAYS` are reported, not replayed — no silent backdated flood on wake |
+
+### Ops burden
+
+One log line per pass that finds work:
+
+```
+Activation reconcile pass: {'models': 3, 'overdue': 1, 'activated': 1, 'failed': 0, 'gave_up': 0}
+```
+
+Silence when there is nothing to do. Nothing new to deploy, monitor, back up,
+rotate or page on.
+
+### Cost
+
+Interval is worst-case lateness. At the default 60s, a change dated 14:00:00 is
+live by 14:01:00. Sub-minute precision would need a clock — which is exactly what
+approach A becomes if it is ever wanted, with this as the floor beneath it.
+
+---
+
+## 5. Side by side
+
+| | A: register+callback | B: poll instance DBs | C: central store | D: reconcile |
+|---|---|---|---|---|
+| New Deployments | 1 (stateful) | 1 | 1 | **0** |
+| New database / PVC | yes | no | yes + backups | **no** |
+| New Secrets | 53 keys or 1 shared | — | 53 write creds | **0** |
+| RBAC grant | ideally none | **`secrets get` namespace-wide** | none | **none** |
+| lex-app change | registration API + callback endpoint | **none** | write path change | one module |
+| Serves all 53 instances | HTTP variant only | Celery only (6) | yes | **yes** |
+| Shared failure domain | firing | firing | **writing** | **none** |
+| Blast radius if compromised | callbacks into instances | **all customer credentials** | all schedule data | n/a |
+| Precision | seconds | seconds | seconds | interval (60s) |
+| Effort | high | medium | high | **shipped** |
+
+---
+
+## 6. What this unblocks
+
+The per-instance beat pod was retained for one reason: it also ran
+django-celery-beat's clock for these activations, so switching
+`recoveryDriver: beat → supervisor` silently stopped future-dated changes from
+firing. That was the recorded blocker on
+[LEX_TERRAFORM_MODULES#35](https://github.com/ExcellenceCloudGmbH/LEX_TERRAFORM_MODULES/pull/35).
+
+With a catch-up floor, a missed timer costs latency rather than the activation.
+Beat is no longer required for bitemporal, and `values.yaml` now says so where
+the driver is chosen. #35 can proceed on its own merits.
+
+---
+
+## 7. Recommended sequence
+
+1. **Ship D** (done). Fixes a live bug on 47 instances and removes the
+   correctness dependency on any clock.
+2. **Merge #35.** Retire per-instance beat; the blocker is gone.
+3. **Measure.** If nobody reports activation lateness, there is no scheduler to
+   build and this project is finished.
+4. **Only if precision is genuinely required**, build A — as a *nudge*, with D
+   underneath as the floor. That ordering means the shared component is
+   introduced after evidence, and is never load-bearing when it is.
+
+**Do not build B.** "No lex-app change" is a real advantage and the wrong thing
+to optimise for: it purchases a faster rollout with permanent namespace-wide
+access to every customer's credentials, for a component that only needs to know
+what time it is.
+
+---
+
+## 8. Open infra questions
+
+1. **Which instances have `autoscaling: true`?** Decides whether D has a gap
+   (backend at 0 → no pass) and whether A's HTTP callback is viable at all. Small
+   set expected; not yet enumerated.
+2. **Raise the recovery supervisor limit above 256Mi.** Unrelated to this design
+   but adjacent: instance 1047's supervisor is `OOMKilled` 68 times over five
+   hours because a Django boot settles just above the limit. It is also the
+   evidence for why "add a small pod per instance" is not free.
+3. **If A is ever built, where does its state live?** A scheduler that forgets
+   timers on restart is useless; a scheduler with a database is option C wearing
+   a different hat. This is the question that decides whether A is small.

--- a/docs/superpowers/specs/2026-08-04-global-scheduler-infra.md
+++ b/docs/superpowers/specs/2026-08-04-global-scheduler-infra.md
@@ -1,141 +1,164 @@
-# Cluster-level scheduling — what each approach costs in infrastructure
+# Cluster-level scheduling — infra, lex-app, and the seam between them
 
 **Companion to** `2026-08-04-global-scheduler-options.md`, which argues the
-software design. This one answers the question that document skipped: *what
-actually gets deployed, who holds which credential, and what does on-call see at
-03:00 when it breaks.*
+software design. This document answers what that one skipped: what actually gets
+deployed, what changes in lex-app, **what each side assumes about the other**,
+and how each approach fails in practice.
 
-**Status:** decision support. Approach D is implemented (branch
-`feat/bitemporal-activation-reconcile` + `feat/activation-reconcile-retire-beat`);
-A, B and C are described as they would have to be built.
+**Status:** decision support. Approach D is implemented (`feat/bitemporal-activation-reconcile`
++ `feat/activation-reconcile-retire-beat`); A, B and C are described as they would
+have to be built.
 
 ---
 
-## 0. The cluster this has to live in
+## 0. Read this first: the seam is where this system already broke
 
-Every option below is judged against the environment as it actually is, not a
-generic Kubernetes cluster. The relevant facts:
+Every approach below creates a contract between infrastructure and application
+code. This codebase has already demonstrated, in production, that such contracts
+fail **silently**, and the failure is worth stating before any option is judged.
+
+Worker recovery has two halves. Workers write in-flight tasks into a Redis
+registry; a supervisor pod reads that registry and requeues whatever a dead
+worker abandoned. The application gates both halves behind one environment
+variable:
+
+```python
+# lex/lex_app/settings.py
+LEX_TASK_RECOVERY_ENABLED = os.getenv("LEX_TASK_RECOVERY_ENABLED", "false").lower() == "true"
+```
+
+Terraform set that variable on the **supervisor** pod and not on the **workers**.
+The result: a healthy, `1/1 Running` supervisor sweeping an index that nobody
+wrote to. On instance 1410 it executed the sweep **23,625 times over 2.5 days and
+found nothing every single time**. On instance 1050 it meant a calculation that
+died to an OOM kill was never recovered, and a user watched a spinner for two
+hours.
+
+Nothing alerted. The only signal the application emitted was
+`logger.debug("Celery recovery disabled")` — invisible at INFO.
+
+Three properties combined to make it invisible, and they are the lens for the
+rest of this document:
+
+1. **The default was off.** Absence of configuration meant absence of function.
+2. **The two halves were configured separately.** Nothing checked they agreed.
+3. **Neither half could tell.** The supervisor could not know that "empty index"
+   meant "workers are mute" rather than "nothing to do."
+
+When judging the options below, the question is not "does this work when
+configured correctly" — they all do. It is **"what happens when infra and
+lex-app disagree, and would anyone find out."**
+
+---
+
+## 1. The cluster this has to live in
 
 | | |
 |---|---|
 | Cluster | `lex-cluster-2`, GKE, `europe-west3` |
 | Instances | **53**, all in one namespace (`default`) |
-| …of which run Celery workers | **6** (KEDA `ScaledJob`, 0→21 pods) |
-| Per instance | backend + frontend Deployments, own Dragonfly (1 replica, ClusterIP, 1 GiB PVC), own Postgres database on a shared server |
+| …running Celery workers | **6** (KEDA `ScaledJob`, 0→21 pods) |
+| Per instance | backend + frontend Deployments, own Dragonfly (1 replica, 1 GiB PVC), own Postgres database on a shared server |
 | Nodes | `e2-standard-4`, **spot**, pool capped at 15 |
-| Backend scaling | optional KEDA `ScaledObject`, min 0, triggered by **nginx ingress request count** (`autoscaling` defaults false) |
-| Recovery supervisor | Deployment, 128Mi request / **256Mi limit** |
-| Deployment path | instance controller → Terraform → Helm, with `module_version` pinned **per instance** |
+| Backend scaling | optional KEDA `ScaledObject`, min 0, triggered by **nginx ingress request count** |
+| Deployment path | instance controller → Terraform → Helm, `module_version` pinned **per instance** |
 
-Three of these shape the answer more than the rest:
+Three facts drive most conclusions:
 
-**One namespace, 53 tenants.** There is no namespace boundary to lean on. Any
-RBAC grant a cluster-level component receives applies to every instance's
-resources at once. "Read secrets in `default`" is not a scoped permission here —
-it is fleet-wide.
+**One namespace, 53 tenants.** No namespace boundary to lean on. Any RBAC grant
+to a cluster-level component applies to every instance at once.
 
-**The backend can be scaled to zero.** On instances with `autoscaling: true`,
-KEDA drops the backend to 0 replicas and the only trigger that brings it back is
-**ingress traffic**. An in-cluster call does not pass through the ingress, so a
-cluster-level component cannot wake a backend by calling it. This kills the
-obvious callback design unless it is worked around explicitly.
+**The backend can be at 0 replicas**, and only ingress traffic wakes it. An
+in-cluster call does not traverse the ingress, so a cluster-level component
+**cannot wake a backend by calling it**.
 
-**Per-instance pods are already proving fragile at this size.** Instance 1047's
-recovery supervisor — a 256Mi pod doing almost nothing — is `OOMKilled` and has
-restarted 68 times in five hours, because the Django app it boots settles just
-above the limit. That is the empirical argument against "just add another small
-pod per instance," and equally a warning that a single cluster-level pod needs
-its sizing taken seriously rather than assumed trivial.
+**Version skew is the normal state.** `module_version` and the lex-app image are
+pinned per instance. Instance 1050 runs `2.0.0rc220` — 83 commits behind — while
+others run 2.1.x. Any contract between infra and lex-app must hold across every
+version simultaneously deployed, which is not one version.
 
 ---
 
-## 1. Approach A — cluster scheduler, instances register, scheduler calls back
+## 2. Approach A — cluster scheduler, instances register, scheduler calls back
 
-### What gets deployed
+### Infra
 
 ```
 namespace: default
-  Deployment  lex-scheduler                 replicas: 1   (see HA below)
-  Service     lex-scheduler                 ClusterIP     ← instances register here
+  Deployment  lex-scheduler                 replicas: 1
+  Service     lex-scheduler                 ClusterIP  ← instances register here
   PVC or DB   lex-scheduler-timers          ← timers must survive a restart
   Secret      lex-scheduler-callback-keys   ← how it authenticates to 53 instances
-  ServiceAccount + Role                     ← minimal, ideally none
 ```
 
-Plus, in lex-app: a registration client (instance → scheduler at schedule time)
-and a callback endpoint (scheduler → instance at fire time).
+### lex-app
 
-### The state problem nobody expects
+Two new pieces, on opposite sides of the request:
 
-A scheduler that forgets its timers on restart is useless, so it needs
-persistence. That turns a "small stateless service" into a **stateful component
-with a database, backups, and migrations** — the thing everyone assumes they are
-avoiding by not choosing option C.
+```python
+# 1. registration — called from _schedule_future_activation
+def _register_with_scheduler(instance_id, due_at, ref):
+    requests.post(f"{settings.LEX_SCHEDULER_URL}/timers",
+                  json={"instance": instance_id, "due_at": due_at.isoformat(), "ref": ref},
+                  headers={"Authorization": f"Bearer {settings.LEX_SCHEDULER_TOKEN}"})
 
-The alternative is for it to rebuild its timer set at boot by asking all 53
-instances what they are waiting for, which reintroduces an inbound sweep and most
-of option B's coupling.
-
-### The callback problem
-
-At fire time the scheduler has to reach the instance. Both routes have a defect:
-
-**HTTP to the backend Service.** Works for all 53 instances, no broker needed:
-
-```
-http://lex-backend-<instance>.default.svc.cluster.local:7000/api/internal/activate
+# 2. callback endpoint — the scheduler calls this at fire time
+class ActivateView(APIView):
+    permission_classes = [HasSchedulerSignature]
+    def post(self, request):
+        activate_history_version(**request.data["ref"])
 ```
 
-But on an `autoscaling: true` instance the backend may be at 0 replicas and the
-KEDA trigger is ingress request count — an in-cluster call will not wake it. The
-request fails, and the activation is late until traffic arrives by other means.
-Fixing it means either a second KEDA trigger (a metrics-api scaler the scheduler
-can poke) or pinning those instances to `minReplicas: 1`, which gives back the
-saving that motivated backend autoscaling.
+Plus deregistration on cancel and on delete, mirroring the existing
+`PeriodicTask.objects.filter(name=...).delete()` path.
 
-**Enqueue into the instance's broker.** Wakes a worker through the existing KEDA
-`ScaledJob` trigger, so scaling works. But it needs each instance's Redis
-password — 53 credentials — and only works for the **6** instances that run
-Celery. It solves the wrong 11% of the fleet.
+### The seam
 
-### Credentials
-
-The scheduler must prove identity to 53 instances. Practical options, all
-unattractive at this scale:
-
-- **53 API keys mounted from `app-env-<instance>`** — requires `secrets get`
-  across the namespace, which is exactly option B's grant with extra steps;
-- **one shared signing key** — the scheduler signs a callback, instances verify.
-  Better, but now one key compromise authorises calls into every instance;
-- **mTLS / SPIFFE** — correct, and a significantly larger project than the
-  scheduler itself.
-
-### Failure modes
-
-| Failure | Effect |
+| Infra promises lex-app | lex-app promises infra |
 |---|---|
-| Scheduler pod down | No activation fires on **any** instance until it returns |
-| Scheduler DB/PVC lost | Every pending timer lost fleet-wide; no way to rebuild without sweeping instances |
-| Callback fails (backend at 0) | That instance's activation is late, silently |
-| Instance deleted | Orphan timers accumulate; needs a TTL or a deregistration hook |
-| Node preempted (spot) | Rescheduled; timers survive only if the PVC does — and RWO on a zonal disk constrains where it can land |
+| `LEX_SCHEDULER_URL` is set and reachable | it will register every future-dated save |
+| a callback will arrive at `due_at` | the callback endpoint exists at that path |
+| the callback carries a verifiable signature | it will deregister on cancel/delete |
+| the backend will be running to receive it | `ref` stays interpretable across versions |
 
-### Ops burden
+That is **four independent assumptions in each direction**, none of them checked
+at deploy time.
 
-A new stateful service with its own backups, its own alerts, its own dashboard,
-and a new failure mode for on-call to learn. The registration protocol becomes a
-compatibility surface: an instance on an older lex-app that does not register is
-silently unscheduled, and nothing surfaces that.
+### How it goes wrong
 
-**Verdict:** the cleanest of the three cluster-level designs, and still a
-genuinely large project once state, credentials and the scale-to-zero interaction
-are priced in.
+**The 1410 failure, repeated.** `LEX_SCHEDULER_URL` is set on the backend
+ConfigMap for the instances someone remembered. On the rest, registration is a
+no-op or a swallowed exception, and those instances silently have no scheduling
+at all. The scheduler looks healthy — it has timers, it fires them, its metrics
+are green. It simply has no timers *from those instances*, and nothing can tell
+the difference between "instance has nothing scheduled" and "instance never
+called us." This is precisely the shape of the recovery-flag incident, and the
+precedent says it will not be noticed for months.
+
+**Version skew breaks `ref`.** The scheduler stores an opaque reference and hands
+it back. When lex-app changes what it puts in `ref`, the scheduler is holding
+timers created by the old version and returns them to a new one. With 53
+instances on assorted versions, the scheduler must accept every historical
+`ref` shape forever, or timers created before an upgrade fire into a handler
+that cannot read them.
+
+**The callback hits a backend at 0 replicas.** On `autoscaling: true` instances
+the activation is simply late, and nothing distinguishes that from a slow
+instance. The scheduler's retry looks identical to the fleet-wide healthy case.
+
+**The instance is deleted; the timer is not.** Deregistration is a best-effort
+call made by a component that is being torn down. The scheduler keeps calling a
+Service that no longer resolves, forever, until someone notices the error rate.
+
+**Verdict:** the cleanest cluster-level design, and it multiplies the exact
+failure mode this codebase has already suffered — a silent configuration
+disagreement between two independently deployed halves.
 
 ---
 
-## 2. Approach B — scheduler polls every instance's database
+## 3. Approach B — scheduler polls every instance's database
 
-### What gets deployed
+### Infra
 
 ```
 namespace: default
@@ -144,16 +167,52 @@ namespace: default
   Role/RoleBinding: secrets [get, list]   ← the whole story is in this line
 ```
 
-No lex-app change at all. That is the real attraction and it should be stated
-honestly: this is the only option deployable against instances as they are today,
-with no release, no migration, and no coordination.
+### lex-app
 
-### Why that RBAC line is the whole story
+**None.** That is the attraction, and it should be stated honestly: this is the
+only option deployable against instances exactly as they are today — no release,
+no migration, no coordination, no version-skew problem at deploy time.
 
-To reach 53 databases the scheduler needs 53 sets of credentials, which live in
-the per-instance `app-env-<instance>` Secret. Granting `secrets get` in
-`default` does not grant database credentials — it grants **every key in every
-instance's secret**:
+### The seam — and why "no lex-app change" is misleading
+
+There is no code change, but there is still a contract, and it is *larger* than
+in any other option. The scheduler has to reimplement lex-app's scheduling
+semantics from outside:
+
+- which meta rows count (`meta_task_status = 'SCHEDULED'`)
+- that superseded versions do not (`sys_to IS NULL`)
+- which states are terminal (`DONE`, `CANCELLED`)
+- that `valid_from` is timezone-aware and compared in UTC
+- the 5-second grace window `activate_history_version` applies
+- what "activation" means well enough to dispatch it correctly
+
+None of that is an interface. It is a **copy of business logic**, living outside
+the application, coupled to a database schema, with nothing that fails when the
+two diverge — no import, no type, no test that spans both.
+
+### How it goes wrong
+
+**Schema drift, silently.** lex-app adds a state — say `FAILED`, which this very
+project considered adding and rejected only because meta models are generated per
+customer. The scheduler does not know about it and treats those rows as
+outstanding forever, or ignores them entirely. Nothing breaks loudly; the
+behaviour just becomes wrong on some instances.
+
+**Version skew, permanently.** The scheduler queries 53 databases whose schemas
+are pinned to whatever module and image each instance runs. Instance 1050 is 83
+commits behind. The scheduler must satisfy every deployed version *at once*, and
+every future change to the meta model becomes a coordinated release across a
+component that has no idea which version it is talking to.
+
+**The timezone class of bug, reintroduced.** This quarter already produced a
+timezone incident (rc212→2.1.4). The scheduler would compare `valid_from` against
+its own clock in its own timezone, in a process that is not Django and does not
+share `USE_TZ` or `TIME_ZONE`. That is the same bug with a new home, and the
+blast radius is 53 instances rather than one.
+
+**The credential grant is not what it looks like.** Reaching 53 databases means
+reading 53 `app-env-<instance>` Secrets, and in a single namespace that grant is
+not "database credentials" — it is every key in every secret:
 
 ```
 DJANGO_SECRET_KEY          POSTGRES_USERNAME / POSTGRES_PASSWORD
@@ -162,84 +221,80 @@ LEX_AI_METAGPT_LLM_CREDENTIALS
 SHAREPOINT_API_CERTIFICATE_THUMBPRINT
 ```
 
-A component whose entire job is knowing what time it is would hold the session
-signing key, database superuser credentials, and the SharePoint certificate
-thumbprint for all 53 customers. Any RCE, any dependency compromise, any logging
-mistake that dumps its environment, is a fleet-wide credential incident.
+A component whose job is knowing what time it is would hold the session signing
+key, database superuser credentials, and the SharePoint certificate thumbprint
+for all 53 customers. Kubernetes RBAC cannot scope this in one namespace without
+naming each secret, and the list changes on every instance creation.
 
-There is no scoped version of this in a single namespace. Kubernetes RBAC cannot
-express "these 53 secrets but not those" without naming each one, and the list
-changes every time an instance is created.
-
-### Operational reality
-
-- 53 idle Postgres connections held against a shared server, from a pod that
-  needs almost nothing from them; connection-pool tuning becomes its problem.
-- A locked or slow instance database stalls the poll loop for everyone unless
-  the loop is carefully concurrent — an easy thing to get wrong and a hard thing
-  to notice.
-- Credential rotation on any instance must be mirrored into the scheduler's
-  refresh path, or that instance silently stops being scheduled.
-- Debugging is cross-tenant by nature: reading the scheduler's logs means seeing
-  identifiers from every customer.
-
-### Failure modes
-
-| Failure | Effect |
-|---|---|
-| Scheduler down | No activations anywhere |
-| One instance DB slow/locked | Poll loop stalls → delays other tenants |
-| Credential rotated | That instance silently unscheduled |
-| Scheduler compromised | **Fleet-wide data and credential exposure** |
-
-**Verdict:** cheapest to ship, most expensive to own. Every incident this quarter
-has been about blast radius; this creates the largest one available and puts it
-in a component that does not need any of that access to do its job.
+**Verdict:** cheapest to ship, most expensive to own. "No lex-app change" buys a
+faster rollout by replacing a *typed* coupling with an *untyped* one, and pays
+for it with namespace-wide credential access.
 
 ---
 
-## 3. Approach C — central schedule store
+## 4. Approach C — central schedule store
 
-### What gets deployed
+### Infra
 
 ```
 namespace: default
-  Deployment  lex-scheduler          replicas: 1
-  Database    scheduler DB (new Cloud SQL DB or a DB on the shared server)
-              + backups, + migrations, + monitoring
-  Secret      per-instance write credentials to that DB (53 roles, or one shared)
+  Deployment  lex-scheduler       replicas: 1
+  Database    scheduler DB + backups + migrations + monitoring
+  Secret      per-instance write credentials (53 roles, or one shared)
 ```
 
-Instances write due-times into the shared store instead of their own database.
+### lex-app
 
-### The infra objection
+`_schedule_future_activation` writes the timer to the central store instead of
+locally, and cancellation must propagate there too:
 
-This puts a shared component **in the write path of a user action**. Today,
-saving a future-dated record touches one database — the instance's own. Under C
-it touches two, and the second is shared across 53 tenants. If the scheduler
-database is down or slow, users cannot save future-dated records *at all*, on
-every instance simultaneously. A and B degrade firing; C degrades **writing**.
+```python
+# instead of PeriodicTask.objects.create(...)
+scheduler_db.timers.insert(instance=INSTANCE_ID, due_at=valid_from, ref=...)
+# and in on_history_pre_delete__cancel_schedules
+scheduler_db.timers.delete(instance=INSTANCE_ID, ref=...)
+```
 
-It also creates a second system of record. The instance's meta row and the
-central timer row must agree through cancellation, deletion, instance clone, and
-restore-from-backup. Restore is the one that should worry you: restoring an
-instance's database to an earlier point silently desynchronises it from a central
-store that was never rolled back.
+### The seam
 
-Isolation stops being structural and becomes a discipline — every query must
-filter by tenant, and nothing enforces it. Given 53 tenants in one namespace,
-that is a lot of trust placed in code review.
+This is the only option where the shared component sits in the **write path of a
+user action**. Today, saving a future-dated record touches one database — the
+instance's own. Under C it touches two, and the second is shared across 53
+tenants.
+
+### How it goes wrong
+
+**An outage stops users saving, not just firing.** A and B degrade *firing* when
+the scheduler is down. C degrades *writing*: if the central database is slow or
+unavailable, nobody on any instance can save a future-dated record. A component
+that was introduced to improve scheduling latency becomes a dependency of the
+save button.
+
+**Cancellation fails and a withdrawn change fires.** This is the dangerous one.
+A user deletes a future-dated record; the local delete succeeds, the remote
+cancel fails or is lost. The instance believes the change is withdrawn; the
+scheduler still holds the timer and fires it. That is not a delay — it is
+**applying a change the user explicitly retracted**, with the local system
+showing it as cancelled.
+
+**Restore-from-backup desynchronises silently.** Restoring an instance's database
+to an earlier point rolls back its meta rows. The central store was not rolled
+back and still holds timers for records that no longer exist in that state.
+Nothing reconciles them.
+
+**Tenant isolation becomes a code-review discipline.** Every query must filter by
+instance. Nothing structural enforces it, and with 53 tenants in one table a
+missing `WHERE` is a cross-tenant data exposure rather than a bug.
 
 **Verdict:** a reasonable design for a different requirement — fleet-wide
-operational visibility of scheduled work. If calculation scheduling later needs
-that, revisit it with visibility as the stated goal, not as a side effect of
-needing a clock.
+operational visibility of scheduled work. Revisit it if that becomes the goal,
+not as a side effect of needing a clock.
 
 ---
 
-## 4. Approach D — reconcile in the backend (implemented)
+## 5. Approach D — reconcile in the backend (implemented)
 
-### What gets deployed
+### Infra
 
 Nothing.
 
@@ -249,87 +304,120 @@ Nothing.
 + "LEX_ACTIVATION_RECONCILE_INTERVAL_SECONDS" = "60"
 ```
 
-No new Deployment, no Service, no PVC, no database, no ServiceAccount, no RBAC
-grant, no secret, no network path, no new port, no ingress rule. The work runs on
-a daemon thread inside the backend process that already exists on every instance.
+No Deployment, Service, PVC, database, ServiceAccount, RBAC grant, secret,
+network path or ingress rule.
 
-### How it works, in infra terms
+### lex-app
 
-The backend queries **its own database** for meta rows still marked `SCHEDULED`
-whose history row's `valid_from` has passed, and applies them. The instance's
-database was already the durable record of what should happen; the timer was
-only ever an optimisation for *when* to look.
+`lex/core/services/activation_reconcile.py`. The backend queries **its own
+database** for work the timer should have done:
 
-Because it needs nothing outside the instance, isolation is not engineered — it
-is structural. There is no component that can reach across tenants because there
-is no new component.
+```python
+def reconcile_pending_activations(now=None) -> dict:
+    for main_model, history_model, meta_model in iter_bitemporal_models():
+        overdue = _overdue_history_ids(meta_model, history_model, now)
+        for history_id in overdue:
+            outcome = _outcome_of(activate_history_version(app_label, name, history_id))
+            ...
+```
 
-### Why it is set unconditionally
+Overdue means: a meta row still `SCHEDULED`, current (`sys_to IS NULL`), whose
+history row's `valid_from` has passed and is inside the age window. Started from
+`apps.ready()` behind `running_in_uvicorn()`, so only the served backend runs it —
+never a management command or a worker.
 
-`LEX_ACTIVATION_RECONCILE_*` goes in the **unconditional** part of the backend
-ConfigMap, not the `architecture == "MQ/Worker"` branch that carries the Celery
-flags. The instances that need it most are the **47 without Celery**: their
-timer is an in-process thread queue that is lost on every restart, with nothing
-to rehydrate it. Gating on the worker architecture would skip the entire
-population the change exists for.
+### The seam — deliberately one-directional
 
-### Failure modes
-
-| Failure | Effect |
+| Infra promises lex-app | lex-app promises infra |
 |---|---|
-| Backend restarts | Catch-up runs **immediately on boot** — the restart is the trigger, not the problem |
-| Loop thread dies | Next backend restart resumes it; activations are late, never lost |
-| Instance backend at 0 replicas (`autoscaling: true`) | No pass runs while nothing is running. Activation is late until the backend wakes — the same window in which nobody is using the instance. Worth confirming which instances have this set. |
-| A record cannot activate | Retried up to `MAX_ATTEMPTS` per process, then skipped, so one poison row cannot burn every pass |
-| Instance dormant for months | Rows older than `MAX_AGE_DAYS` are reported, not replayed — no silent backdated flood on wake |
+| *nothing* | it will catch up regardless |
 
-### Ops burden
+This is the design property that matters most, and it is a direct response to §0.
+**The code defaults to enabled:**
 
-One log line per pass that finds work:
-
-```
-Activation reconcile pass: {'models': 3, 'overdue': 1, 'activated': 1, 'failed': 0, 'gave_up': 0}
+```python
+LEX_ACTIVATION_RECONCILE_ENABLED = os.getenv("LEX_ACTIVATION_RECONCILE_ENABLED", "true") == "true"
+#                                                                                ^^^^^^
 ```
 
-Silence when there is nothing to do. Nothing new to deploy, monitor, back up,
-rotate or page on.
+Compare `LEX_TASK_RECOVERY_ENABLED`, which defaults to `"false"`. That inversion
+is the whole lesson of the recovery incident applied: **absence of configuration
+must not mean absence of function.** An instance that never receives the
+ConfigMap key still catches up. Terraform setting it is documentation and an
+override, not an enablement.
 
-### Cost
+There is also nothing to disagree *with*. One process reads its own database and
+acts. There is no second half to fall out of sync.
 
-Interval is worst-case lateness. At the default 60s, a change dated 14:00:00 is
-live by 14:01:00. Sub-minute precision would need a clock — which is exactly what
-approach A becomes if it is ever wanted, with this as the floor beneath it.
+### How it goes wrong — the honest list
+
+D is the safest option here, not a safe one. Its real weaknesses:
+
+**1. The query is unindexed.** This is the most concrete flaw. `meta_task_status`
+carries no `db_index`, and `valid_from` is indexed only when `_date_indexing` is
+enabled. So every 60 seconds, for every bitemporal model, the backend runs:
+
+```sql
+SELECT history_object_id FROM <meta_table>
+ WHERE meta_task_status = 'SCHEDULED' AND sys_to IS NULL;
+```
+
+— a **sequential scan**. On instances with small meta tables this is free. On one
+with a large history it is a full scan per model per minute, forever, on the pod
+that also serves user requests. It has not been measured on a large instance.
+
+*Mitigations, in order of preference:* raise
+`LEX_ACTIVATION_RECONCILE_INTERVAL_SECONDS` (a pure latency/cost trade with no
+correctness impact); add `db_index=True` to `meta_task_status` — correct, but
+meta models are generated per customer model, so it forces a migration in every
+customer repository; or invert the query to start from the indexed `valid_from`
+range, which helps only where date indexing is on. **Watch `pg_stat_statements`
+on the largest instance before assuming this is fine.**
+
+**2. A backend at 0 replicas runs no passes.** On `autoscaling: true` instances
+the activation waits until the backend wakes. The window coincides with nobody
+using the instance, so it is usually harmless — but an external consumer reading
+that data at the scheduled time sees stale values. Which instances have
+`autoscaling: true` is not yet enumerated.
+
+**3. The attempt counter is in-memory.** A record that cannot activate is retried
+`MAX_ATTEMPTS` times *per process*. A crash-looping backend resets the counter on
+every restart, so a poison record could be retried indefinitely across restarts.
+The alternative — a terminal `FAILED` status — was rejected because it forces a
+migration in every customer repo for a value the database does not enforce. This
+is a deliberate trade, not an oversight, but it is a trade.
+
+**4. `MAX_AGE_DAYS` skips work silently unless someone reads the log.** Rows older
+than the window are deliberately not replayed, which is right — a dormant
+instance should not wake and apply a year of backdated changes. But the only
+signal is a log line. Nothing alerts that an instance has activations it will
+never apply.
+
+**5. It masks the underlying breakage.** With catch-up in place, a completely
+dead timer looks like a slightly late activation. That is the intended benefit,
+and it means nobody will notice that the in-process scheduler is broken, because
+the symptom is gone. If the timer path is ever meant to be fixed rather than
+retired, this removes the pressure to do it.
+
+**6. Latency is a floor, not a guarantee.** 60 s is worst case *per pass*, but a
+slow pass on a large instance extends it. There is no deadline enforcement.
 
 ---
 
-## 5. Side by side
+## 6. Side by side
 
 | | A: register+callback | B: poll instance DBs | C: central store | D: reconcile |
 |---|---|---|---|---|
 | New Deployments | 1 (stateful) | 1 | 1 | **0** |
 | New database / PVC | yes | no | yes + backups | **no** |
-| New Secrets | 53 keys or 1 shared | — | 53 write creds | **0** |
 | RBAC grant | ideally none | **`secrets get` namespace-wide** | none | **none** |
-| lex-app change | registration API + callback endpoint | **none** | write path change | one module |
-| Serves all 53 instances | HTTP variant only | Celery only (6) | yes | **yes** |
+| lex-app change | registration + endpoint + deregistration | **none** | write path | one module |
+| Coupling type | HTTP contract + token | **untyped, to the DB schema** | two systems of record | none |
+| Survives version skew | ⚠️ `ref` shape must be forever-compatible | ❌ must satisfy all 53 versions at once | ⚠️ | ✅ ships with the image |
+| Fails silently when misconfigured | **yes — the §0 failure** | yes | yes (cancel path) | **no — defaults on** |
 | Shared failure domain | firing | firing | **writing** | **none** |
-| Blast radius if compromised | callbacks into instances | **all customer credentials** | all schedule data | n/a |
-| Precision | seconds | seconds | seconds | interval (60s) |
+| Worst realistic outcome | instances silently unscheduled | fleet credential exposure | **withdrawn change fires** | activation is late |
 | Effort | high | medium | high | **shipped** |
-
----
-
-## 6. What this unblocks
-
-The per-instance beat pod was retained for one reason: it also ran
-django-celery-beat's clock for these activations, so switching
-`recoveryDriver: beat → supervisor` silently stopped future-dated changes from
-firing. That was the recorded blocker on
-[LEX_TERRAFORM_MODULES#35](https://github.com/ExcellenceCloudGmbH/LEX_TERRAFORM_MODULES/pull/35).
-
-With a catch-up floor, a missed timer costs latency rather than the activation.
-Beat is no longer required for bitemporal, and `values.yaml` now says so where
-the driver is chosen. #35 can proceed on its own merits.
 
 ---
 
@@ -337,29 +425,33 @@ the driver is chosen. #35 can proceed on its own merits.
 
 1. **Ship D** (done). Fixes a live bug on 47 instances and removes the
    correctness dependency on any clock.
-2. **Merge #35.** Retire per-instance beat; the blocker is gone.
-3. **Measure.** If nobody reports activation lateness, there is no scheduler to
-   build and this project is finished.
-4. **Only if precision is genuinely required**, build A — as a *nudge*, with D
-   underneath as the floor. That ordering means the shared component is
-   introduced after evidence, and is never load-bearing when it is.
+2. **Merge [#35](https://github.com/ExcellenceCloudGmbH/LEX_TERRAFORM_MODULES/pull/35).**
+   Per-instance beat was retained only because it also ran the bitemporal clock;
+   that blocker is gone and `values.yaml` now records it.
+3. **Measure the query cost** (§5.1) on the largest instance before this runs
+   fleet-wide for months.
+4. **Measure lateness.** If nobody reports it, there is no scheduler to build.
+5. **Only if precision is genuinely required**, build A as a *nudge* with D as the
+   floor — so the shared component is introduced after evidence, and is never
+   load-bearing.
 
-**Do not build B.** "No lex-app change" is a real advantage and the wrong thing
-to optimise for: it purchases a faster rollout with permanent namespace-wide
-access to every customer's credentials, for a component that only needs to know
-what time it is.
+**Do not build B.** It replaces a typed coupling with an untyped one, must
+satisfy 53 simultaneously-deployed schema versions, and buys that with
+namespace-wide access to every customer credential — for a component that only
+needs to know what time it is.
 
 ---
 
-## 8. Open infra questions
+## 8. Open questions
 
-1. **Which instances have `autoscaling: true`?** Decides whether D has a gap
-   (backend at 0 → no pass) and whether A's HTTP callback is viable at all. Small
-   set expected; not yet enumerated.
-2. **Raise the recovery supervisor limit above 256Mi.** Unrelated to this design
-   but adjacent: instance 1047's supervisor is `OOMKilled` 68 times over five
-   hours because a Django boot settles just above the limit. It is also the
-   evidence for why "add a small pod per instance" is not free.
-3. **If A is ever built, where does its state live?** A scheduler that forgets
-   timers on restart is useless; a scheduler with a database is option C wearing
-   a different hat. This is the question that decides whether A is small.
+1. **Which instances have `autoscaling: true`?** Decides D's gap (§5.2) and
+   whether A's HTTP callback is viable at all.
+2. **What does the reconcile query cost on the largest instance?** (§5.1) The one
+   number that could change D's default interval.
+3. **Raise the recovery supervisor limit above 256Mi.** Adjacent, not caused by
+   this: instance 1047's supervisor is `OOMKilled` 68 times in five hours because
+   a Django boot settles just above the limit. It is also the evidence for why
+   "add a small pod per instance" is not free.
+4. **If A is ever built, where does its state live?** A scheduler that forgets
+   timers on restart is useless; one with a database is C wearing a different
+   hat. That question decides whether A is small.

--- a/lex/core/services/activation_reconcile.py
+++ b/lex/core/services/activation_reconcile.py
@@ -1,0 +1,297 @@
+"""Catch-up pass for future-dated bitemporal activations.
+
+Why this exists
+---------------
+Saving a history row with a future ``valid_from`` schedules its own activation:
+:func:`lex.core.services.bitemporal_signals._schedule_future_activation` writes a
+timer and marks the meta record ``SCHEDULED``. Which timer depends on the
+deployment:
+
+* ``CELERY_ACTIVE=true`` — a ``ClockedSchedule`` + one-off ``PeriodicTask`` row,
+  fired by a per-instance ``django-celery-beat`` pod;
+* otherwise — an in-process ``sched`` entry held by a daemon thread
+  (:class:`~lex.process_admin.utils.local_scheduler.LocalSchedulerBackend`).
+
+**Both timers are volatile, and the second one is lost on every restart.**
+Nothing rehydrates the in-process queue, so a deploy, node move or OOM silently
+drops every pending activation on that instance; the meta rows stay
+``SCHEDULED`` forever and the data never becomes current. No error is raised.
+The beat timer survives restarts, but only by keeping an always-on pod per
+instance whose sole remaining job is holding a clock.
+
+The durable fact is not the timer — it is the meta row. ``SCHEDULED`` plus the
+history row's ``valid_from`` states exactly what should already have happened.
+This module reads that and finishes the job.
+
+That inverts the failure model. A timer that never fires becomes a *latency*
+problem rather than a silent data-loss one, because this pass converges on the
+same result. It is what makes it safe to retire per-instance beat, and what
+makes any future cluster-level scheduler an optimisation that is allowed to
+fail rather than a component every instance depends on.
+
+Safety
+------
+Running this repeatedly, or concurrently with a timer firing the same
+activation, is safe by construction:
+
+* ``BitemporalSynchronizer.sync_record_for_model`` is convergent — it derives
+  the main-table row from whichever history record is currently valid, so two
+  runs produce one result;
+* ``activate_history_version`` re-checks ``valid_from`` and refuses to act
+  early;
+* the ``SCHEDULED -> DONE`` transition is a no-op on repeat.
+
+Deliberately **not** dispatched to Celery. Activation is a small convergent
+write, not a calculation, and running it in-process means this works
+identically on instances that have no broker at all — which is most of them.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import timedelta
+from typing import Any, Dict, Iterator, Tuple
+
+from django.apps import apps
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+_SCHEDULED = "SCHEDULED"
+_DONE = "DONE"
+
+# Per-process failure counters, keyed by (meta model label, meta pk).
+#
+# A row that fails to activate stays SCHEDULED and would otherwise be retried on
+# every pass forever. Bounding it here rather than with a terminal FAILED status
+# is deliberate: meta models are generated per customer model, so adding a
+# choice would require a migration in every customer repository for a value the
+# database does not enforce anyway. The cost is that the counter resets on
+# restart, which is acceptable — a restart is exactly when a retry is most
+# likely to succeed.
+_failures: Dict[Tuple[str, Any], int] = {}
+_failures_lock = threading.Lock()
+
+
+def _setting(name: str, default):
+    from django.conf import settings
+
+    return getattr(settings, name, default)
+
+
+def _max_attempts() -> int:
+    return max(1, int(_setting("LEX_ACTIVATION_RECONCILE_MAX_ATTEMPTS", 5)))
+
+
+def _max_age() -> timedelta:
+    return timedelta(days=max(1, int(_setting("LEX_ACTIVATION_RECONCILE_MAX_AGE_DAYS", 30))))
+
+
+def _interval() -> float:
+    return max(5.0, float(_setting("LEX_ACTIVATION_RECONCILE_INTERVAL_SECONDS", 60)))
+
+
+def _enabled() -> bool:
+    return bool(_setting("LEX_ACTIVATION_RECONCILE_ENABLED", True))
+
+
+def _outcome_of(returned) -> str:
+    """Normalise what ``activate_history_version`` handed back.
+
+    The task's own contract is a status string ("success", "failed_too_early",
+    "skipped_missing_record", "failed_model_lookup"), but it is wrapped by
+    ``@lex_shared_task``, whose wrapper returns ``(result, args)``. Calling the
+    task in-process therefore yields the tuple, not the string.
+
+    Unwrapping defensively rather than indexing ``[0]`` blindly means a change
+    to the decorator's return shape degrades to "not success" — a retry — rather
+    than being read as a spurious success and dropping the record.
+    """
+    if isinstance(returned, (tuple, list)) and returned:
+        returned = returned[0]
+    return returned if isinstance(returned, str) else ""
+
+
+def iter_bitemporal_models() -> Iterator[Tuple[type, type, type]]:
+    """Yield ``(main_model, history_model, meta_model)`` for every bitemporal model.
+
+    Discovered from the app registry rather than a list, so a customer model
+    gains catch-up simply by having history enabled — there is nothing to
+    register and nothing to keep in sync.
+    """
+    for model in apps.get_models():
+        history = getattr(model, "history", None)
+        history_model = getattr(history, "model", None) if history is not None else None
+        if history_model is None:
+            continue
+        meta = getattr(history_model, "meta_history", None)
+        meta_model = getattr(meta, "model", None) if meta is not None else None
+        if meta_model is None:
+            continue
+        yield model, history_model, meta_model
+
+
+def _overdue_history_ids(meta_model, history_model, now) -> list:
+    """History ids whose activation was scheduled and is now due.
+
+    Only *current* meta versions (``sys_to IS NULL``) count — a superseded meta
+    row describes what we used to believe, not outstanding work.
+
+    Bounded below by ``LEX_ACTIVATION_RECONCILE_MAX_AGE_DAYS`` so a long-dormant
+    instance does not wake up and replay a year of history in one pass. Rows
+    older than the window are reported, never silently actioned.
+    """
+    scheduled_ids = list(
+        meta_model.objects.filter(
+            meta_task_status=_SCHEDULED,
+            sys_to__isnull=True,
+        ).values_list("history_object_id", flat=True)
+    )
+    if not scheduled_ids:
+        return []
+
+    return list(
+        history_model.objects.filter(
+            pk__in=scheduled_ids,
+            valid_from__lte=now,
+            valid_from__gte=now - _max_age(),
+        ).values_list("pk", flat=True)
+    )
+
+
+def reconcile_pending_activations(now=None) -> Dict[str, int]:
+    """Activate every future-dated record whose moment has passed.
+
+    ``now`` selects which rows are considered due. It does **not** override the
+    clock inside ``activate_history_version``, which independently re-checks
+    ``valid_from`` before acting — so passing a synthetic future ``now`` selects
+    a row that the task then declines. That asymmetry is deliberate: the task's
+    own guard is the authority on whether a record may activate, and this pass
+    is only allowed to decide *when to look*.
+
+    Returns counters for observability and tests. Never raises: a failure on one
+    record must not stop the rest, and this runs on a background thread where an
+    escaping exception would kill the loop.
+    """
+    stats = {"models": 0, "overdue": 0, "activated": 0, "failed": 0, "gave_up": 0}
+    if not _enabled():
+        return stats
+
+    now = now or timezone.now()
+
+    from lex.lex_app.celery_tasks import activate_history_version
+
+    for main_model, history_model, meta_model in iter_bitemporal_models():
+        stats["models"] += 1
+        try:
+            overdue = _overdue_history_ids(meta_model, history_model, now)
+        except Exception:
+            # A model whose meta table is missing or mid-migration must not take
+            # the whole pass down with it.
+            logger.warning(
+                "Activation reconcile: could not query %s", meta_model.__name__,
+                exc_info=True,
+            )
+            continue
+
+        for history_id in overdue:
+            stats["overdue"] += 1
+            key = (meta_model._meta.label_lower, history_id)
+
+            with _failures_lock:
+                attempts = _failures.get(key, 0)
+            if attempts >= _max_attempts():
+                stats["gave_up"] += 1
+                continue
+
+            try:
+                # Called directly, not .delay(): see the module docstring.
+                #
+                # This task reports failure by RETURN VALUE, not by raising:
+                # "success", or one of "failed_too_early" /
+                # "skipped_missing_record" / "failed_model_lookup". Treating a
+                # clean return as success would silently count activations that
+                # never happened and drop them from the retry set.
+                outcome = _outcome_of(
+                    activate_history_version(
+                        main_model._meta.app_label,
+                        main_model.__name__,
+                        history_id,
+                    )
+                )
+                if outcome == "success":
+                    with _failures_lock:
+                        _failures.pop(key, None)
+                    stats["activated"] += 1
+                    logger.info(
+                        "Activation reconcile: activated %s history %s (overdue)",
+                        main_model.__name__, history_id,
+                    )
+                else:
+                    with _failures_lock:
+                        _failures[key] = attempts + 1
+                    stats["failed"] += 1
+                    logger.warning(
+                        "Activation reconcile: %s history %s declined (%s), "
+                        "attempt %s/%s",
+                        main_model.__name__, history_id, outcome,
+                        attempts + 1, _max_attempts(),
+                    )
+            except Exception:
+                with _failures_lock:
+                    _failures[key] = attempts + 1
+                stats["failed"] += 1
+                logger.warning(
+                    "Activation reconcile: %s history %s failed (attempt %s/%s)",
+                    main_model.__name__, history_id, attempts + 1, _max_attempts(),
+                    exc_info=True,
+                )
+
+    if stats["overdue"]:
+        logger.info("Activation reconcile pass: %s", stats)
+    return stats
+
+
+_stop = threading.Event()
+_thread: threading.Thread | None = None
+
+
+def _loop() -> None:
+    interval = _interval()
+    logger.info("Activation reconcile loop started (interval=%ss)", interval)
+    # One pass immediately: a restart is the single most likely reason an
+    # in-process timer was lost, so startup is when catch-up matters most.
+    while True:
+        try:
+            reconcile_pending_activations()
+        except Exception:  # pragma: no cover - reconcile already swallows
+            logger.exception("Activation reconcile: pass failed")
+        if _stop.wait(interval):
+            return
+
+
+def start_background_reconcile() -> bool:
+    """Start the catch-up loop. Idempotent; returns True if it is now running.
+
+    Call only from the served backend process — see ``apps.ready``. Running it
+    from a management command or a worker would duplicate the work for no gain.
+    """
+    global _thread
+    if not _enabled():
+        logger.debug("Activation reconcile disabled (LEX_ACTIVATION_RECONCILE_ENABLED)")
+        return False
+    if _thread is not None and _thread.is_alive():
+        return True
+    _stop.clear()
+    _thread = threading.Thread(
+        target=_loop, name="lex-activation-reconcile", daemon=True
+    )
+    _thread.start()
+    return True
+
+
+def stop_background_reconcile() -> None:
+    """Signal the loop to exit (tests, shutdown)."""
+    _stop.set()

--- a/lex/core/services/activation_reconcile.py
+++ b/lex/core/services/activation_reconcile.py
@@ -259,15 +259,35 @@ _thread: threading.Thread | None = None
 
 
 def _loop() -> None:
+    """Run a pass, wait, repeat — until stopped.
+
+    ``close_old_connections`` around each pass is required, not hygiene. Django
+    opens a database connection per thread and normally closes it on the
+    ``request_finished`` signal; a background thread has no request cycle, so
+    without this the connection is opened once and held for the life of the pod.
+    When Postgres drops an idle connection, restarts, or fails over, that
+    connection goes stale and every later pass raises OperationalError. The loop
+    would survive — it catches — but it would log an error every interval
+    forever and never reconnect, which is a silent stop dressed up as noise.
+
+    Calling it before *and* after matters: before, so a pass never starts on a
+    connection that died while we were waiting; after, so a failed pass cannot
+    leave a broken connection parked until the next one.
+    """
+    from django.db import close_old_connections
+
     interval = _interval()
     logger.info("Activation reconcile loop started (interval=%ss)", interval)
     # One pass immediately: a restart is the single most likely reason an
     # in-process timer was lost, so startup is when catch-up matters most.
     while True:
         try:
+            close_old_connections()
             reconcile_pending_activations()
         except Exception:  # pragma: no cover - reconcile already swallows
             logger.exception("Activation reconcile: pass failed")
+        finally:
+            close_old_connections()
         if _stop.wait(interval):
             return
 

--- a/lex/lex_app/apps.py
+++ b/lex/lex_app/apps.py
@@ -135,6 +135,26 @@ class LexAppConfig(GenericAppConfig):
                 target=_run_async_ready, name="lex-async-ready", daemon=True
             ).start()
 
+            # Catch up any future-dated activation whose timer was lost.
+            #
+            # Gated to the served backend: this is the one always-on process per
+            # instance, and running it from a management command or a worker
+            # would duplicate the work. The loop takes a pass immediately on
+            # start, because a restart is precisely how the in-process timer
+            # queue gets dropped.
+            if running_in_uvicorn():
+                try:
+                    from lex.core.services.activation_reconcile import (
+                        start_background_reconcile,
+                    )
+
+                    start_background_reconcile()
+                except Exception:
+                    logger.exception(
+                        "Failed to start the activation reconcile loop; "
+                        "future-dated activations will rely on timers alone"
+                    )
+
     def register_models(self):
         """
         Override parent's register_models to filter out lex core models

--- a/lex/lex_app/settings.py
+++ b/lex/lex_app/settings.py
@@ -576,6 +576,41 @@ LEX_WORKER_IDLE_SHUTDOWN_SECONDS = float(
     os.getenv("LEX_WORKER_IDLE_SHUTDOWN_SECONDS", "30")
 )
 
+# ---------------------------------------------------------------------------
+# Bitemporal activation catch-up
+#
+# A future-dated history row schedules a timer for its own activation. Both
+# timer backends are volatile — the in-process one (used whenever Celery is off,
+# i.e. most instances) is lost on every restart with nothing to rehydrate it, so
+# pending activations were silently dropped and the data never became current.
+#
+# The meta row is the durable record: SCHEDULED plus the history row's
+# valid_from says what should already have happened. The reconcile loop reads
+# that and finishes the job, which turns a missed timer into a latency problem
+# instead of silent data loss. See lex/core/services/activation_reconcile.py.
+#
+# Interval is the worst-case activation lateness. Lower it if a scheduled change
+# must be visible promptly; there is no correctness reason to.
+# ---------------------------------------------------------------------------
+LEX_ACTIVATION_RECONCILE_ENABLED = (
+    os.getenv("LEX_ACTIVATION_RECONCILE_ENABLED", "true").strip().lower() == "true"
+)
+LEX_ACTIVATION_RECONCILE_INTERVAL_SECONDS = float(
+    os.getenv("LEX_ACTIVATION_RECONCILE_INTERVAL_SECONDS", "60")
+)
+# Do not replay activations older than this. A long-dormant instance coming back
+# should not silently apply a year of backdated changes in one pass; anything
+# older is reported and left for a human.
+LEX_ACTIVATION_RECONCILE_MAX_AGE_DAYS = int(
+    os.getenv("LEX_ACTIVATION_RECONCILE_MAX_AGE_DAYS", "30")
+)
+# Per-process attempt cap so a permanently-broken record cannot be retried on
+# every pass forever. Resets on restart, which is when a retry is most likely to
+# succeed anyway.
+LEX_ACTIVATION_RECONCILE_MAX_ATTEMPTS = int(
+    os.getenv("LEX_ACTIVATION_RECONCILE_MAX_ATTEMPTS", "5")
+)
+
 if LEX_TASK_RECOVERY_ENABLED:
     # django-celery-beat's DatabaseScheduler ingests CELERY_BEAT_SCHEDULE at
     # startup via update_from_dict, so this entry lands as a PeriodicTask row

--- a/lex/test_project/test-plan/clusters/05-history/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/05-history/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 5
 slug: history
 title: History & Bitemporal
-max_scenario: 103
+max_scenario: 109
 letters:
   a:
     title: ''
@@ -118,3 +118,12 @@ letters:
       xfail: 1
     note: end-to-end edited_at → Z serialization → parse_as_of_datetime → get_queryset_as_of chain;
       5.101 xfail(strict) pins BUG-026 (edited_at vs valid_from/sys_from clock-read gap)
+  n:
+    title: Activation catch-up (reconcile pass)
+    scenarios: 5.104-5.109
+    status: complete
+    tests:
+      pass: 6
+      skip: 0
+      xfail: 0
+    note: catch-up pass that activates overdue SCHEDULED meta rows without a timer. Closes the gap where the in-process LocalSchedulerBackend queue is lost on every restart (all non-Celery instances), and makes retiring per-instance beat safe by turning a missed timer into latency rather than silent data loss

--- a/lex/test_project/test-plan/clusters/05-history/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/05-history/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 5
 slug: history
 title: History & Bitemporal
-max_scenario: 109
+max_scenario: 110
 letters:
   a:
     title: ''
@@ -120,10 +120,10 @@ letters:
       5.101 xfail(strict) pins BUG-026 (edited_at vs valid_from/sys_from clock-read gap)
   n:
     title: Activation catch-up (reconcile pass)
-    scenarios: 5.104-5.109
+    scenarios: 5.104-5.110
     status: complete
     tests:
-      pass: 6
+      pass: 7
       skip: 0
       xfail: 0
     note: catch-up pass that activates overdue SCHEDULED meta rows without a timer. Closes the gap where the in-process LocalSchedulerBackend queue is lost on every restart (all non-Celery instances), and makes retiring per-instance beat safe by turning a missed timer into latency rather than silent data loss

--- a/lex/test_project/test-plan/clusters/05-history/batches.md
+++ b/lex/test_project/test-plan/clusters/05-history/batches.md
@@ -47,3 +47,20 @@
 | Prereqs | BUG-025 fix (Z-serialized datetimes) |
 | Status | ✅ Complete — 5 pass / 1 xfail(strict) |
 | Note | Customer concern 2026-07-14 ("we rely on the as_of mechanism"). 5.98 edited_at is the true edit instant and its serialized form denotes the same instant; 5.99 as_of before the edit returns exactly the pre-edit snapshot (values included); 5.100 as_of now knows both versions, latest current; 5.101 (xfail strict, **BUG-026**) anchoring as_of on the record's own serialized edited_at must land on the post-edit side — fails today because `edited_at` and `valid_from`/`sys_from` come from separate clock reads (~ms gap). Fix design + the `_history_date` trap are documented in the BUG-026 row. Extension (2026-07-14, customer list-time-travel report): 5.102 the LIST endpoint (`?as_of=`, the grid's surface) shows pre-edit values at a pre-edit UTC anchor and current values at now; 5.103 naive as_of == UTC by contract, and an offset-aware local anchor for the same instant lands identically — pinning the backend as correct while the frontend's naive-local anchors (BUG-F-022) were the real culprit. |
+
+---
+
+### Batch 5n — Activation catch-up (reconcile pass) ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 5.104 – 5.109 |
+| Type | E |
+| Files covered | `lex/core/services/activation_reconcile.py` (new), `lex/lex_app/settings.py` (4 `LEX_ACTIVATION_RECONCILE_*` knobs), `lex/lex_app/apps.py` (startup wiring, gated to the served backend) |
+| Test file | `lex/test_project/tests/history/test_5n_activation_reconcile.py` |
+| Test classes | `TestCluster05n_ActivationReconcile` |
+| Fixtures | `HistSimpleItem` (shared with 5l) |
+| Est. tests | 6 |
+| Status | ✅ Complete — 6 pass / 0 fail |
+| Note | Consumer side of the contract 5l covers on the producer side. Two real defects were caught by these tests while writing them: (1) `activate_history_version` reports failure by **return value**, not by raising, so treating a clean return as success counted activations that never happened — 5.104 caught it; (2) `@lex_shared_task` wraps that return as `(result, args)`, so the status string has to be unwrapped, and `_outcome_of` degrades to "not success" rather than indexing blindly, so a future change to the decorator causes a retry rather than a silent drop. |
+

--- a/lex/test_project/test-plan/clusters/05-history/batches.md
+++ b/lex/test_project/test-plan/clusters/05-history/batches.md
@@ -42,7 +42,7 @@
 | Test file | `lex/test_project/tests/history/test_5m_asof_edit_time.py` |
 | Test classes | `TestCluster05m_AsOfEditTime` |
 | Fixtures | reuses `HistSimpleItem` |
-| Est. tests | 6 |
+| Est. tests | 7 |
 | Coverage gain | pins the full timestamp chain end to end (stamp → serialize → parse → compare) |
 | Prereqs | BUG-025 fix (Z-serialized datetimes) |
 | Status | ✅ Complete — 5 pass / 1 xfail(strict) |
@@ -54,13 +54,13 @@
 
 | Property | Value |
 | --- | --- |
-| Scenario range | 5.104 – 5.109 |
+| Scenario range | 5.104 – 5.110 |
 | Type | E |
 | Files covered | `lex/core/services/activation_reconcile.py` (new), `lex/lex_app/settings.py` (4 `LEX_ACTIVATION_RECONCILE_*` knobs), `lex/lex_app/apps.py` (startup wiring, gated to the served backend) |
 | Test file | `lex/test_project/tests/history/test_5n_activation_reconcile.py` |
 | Test classes | `TestCluster05n_ActivationReconcile` |
 | Fixtures | `HistSimpleItem` (shared with 5l) |
-| Est. tests | 6 |
-| Status | ✅ Complete — 6 pass / 0 fail |
+| Est. tests | 7 |
+| Status | ✅ Complete — 7 pass / 0 fail |
 | Note | Consumer side of the contract 5l covers on the producer side. Two real defects were caught by these tests while writing them: (1) `activate_history_version` reports failure by **return value**, not by raising, so treating a clean return as success counted activations that never happened — 5.104 caught it; (2) `@lex_shared_task` wraps that return as `(result, args)`, so the status string has to be unwrapped, and `_outcome_of` degrades to "not success" rather than indexing blindly, so a future change to the decorator causes a retry rather than a silent drop. |
-
+| Follow-up | 5.110 added after review: the loop is a long-lived thread doing ORM work, and Django only closes connections on `request_finished`. Without `close_old_connections` around each pass the thread holds one connection for the life of the pod, so a Postgres restart or failover ends catch-up permanently while logging an error every interval. |

--- a/lex/test_project/test-plan/clusters/05-history/cluster.md
+++ b/lex/test_project/test-plan/clusters/05-history/cluster.md
@@ -45,3 +45,20 @@
 **Why a regression matters:** `as_of` answers "what did this record look like before the edit?" — audit-grade functionality customers explicitly rely on.
 
 **Scenario range:** 5.98 – 5.103. **Test file:** `lex/test_project/tests/history/test_5m_asof_edit_time.py`. **Type:** E. **Status:** ✅ Complete — 5 pass; 5.101 `xfail(strict)` pins **BUG-026** (`edited_at` vs history-window clock-read gap; anchoring `as_of` at a record's own `edited_at` misses the edit).
+
+### 5n. Activation catch-up (reconcile pass) ✅
+
+**What it tests:** `reconcile_pending_activations` — the pass that activates future-dated
+records whose scheduling timer never fired. Overdue `SCHEDULED` meta rows are activated,
+not-yet-due rows are left alone, the pass is idempotent, activations older than the age
+window are not replayed, a failing record is given up after the attempt cap, and terminal
+meta states (DONE / CANCELLED) are never resurrected.
+
+**Why a regression matters:** both timer backends are volatile. The in-process one — used
+by every instance without Celery, which is most of them — is lost on every restart with
+nothing to rehydrate it, so a deploy silently dropped pending activations and the data
+never became current. This pass is the floor that makes that recoverable, and the reason
+per-instance beat can be retired.
+
+**Scenario range:** 5.104 – 5.109. **Test file:** `lex/test_project/tests/history/test_5n_activation_reconcile.py`. **Type:** E. **Status:** ✅ 6 pass.
+

--- a/lex/test_project/test-plan/clusters/05-history/cluster.md
+++ b/lex/test_project/test-plan/clusters/05-history/cluster.md
@@ -60,5 +60,5 @@ nothing to rehydrate it, so a deploy silently dropped pending activations and th
 never became current. This pass is the floor that makes that recoverable, and the reason
 per-instance beat can be retired.
 
-**Scenario range:** 5.104 – 5.109. **Test file:** `lex/test_project/tests/history/test_5n_activation_reconcile.py`. **Type:** E. **Status:** ✅ 6 pass.
+**Scenario range:** 5.104 – 5.110. **Test file:** `lex/test_project/tests/history/test_5n_activation_reconcile.py`. **Type:** E. **Status:** ✅ 7 pass.
 

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -14,7 +14,7 @@
 | 2. CRUD via REST API | 10 | 107 | 15 | 0 | 0 |
 | 3. Validation Hooks | 7 | 38 | 6 | 0 | 0 |
 | 4. Permissions | 13 | 74 | 18 | 2 | 0 |
-| 5. History & Bitemporal | 13 | 109 | 21 | 6 | 3 |
+| 5. History & Bitemporal | 13 | 110 | 22 | 6 | 3 |
 | 6. Audit Logging | 17 | 118 | 21 | 3 | 0 |
 | 7. Calculation State Machine | 19 | 221 | 78 | 0 | 0 |
 | 8. Celery & Async | 15 | 153 | 89 | 12 | 0 |
@@ -119,7 +119,7 @@
 | 5k |  | 5.81-5.87 | complete | 0 | 3 | 1 | auto-skip — MetaHistorical* not wired; prod registration covered in unit tests |
 | 5l |  | 5.91-5.97 | planned | 0 | 0 | 0 | save side of the future-activation handoff (worker side = 8.43); scenarios 5.91–5.97, reuses `HistSimpleItem` |
 | 5m | Edit-time correctness + as_of time-travel round trip | 5.98-5.103 | complete | 5 | 0 | 1 | end-to-end edited_at → Z serialization → parse_as_of_datetime → get_queryset_as_of chain; 5.101 xfail(strict) pins BUG-026 (edited_at vs valid_from/sys_from clock-read gap) |
-| 5n | Activation catch-up (reconcile pass) | 5.104-5.109 | complete | 6 | 0 | 0 | catch-up pass that activates overdue SCHEDULED meta rows without a timer. Closes the gap where the in-process LocalSchedulerBackend queue is lost on every restart (all non-Celery instances), and makes retiring per-instance beat safe by turning a missed timer into latency rather than silent data loss |
+| 5n | Activation catch-up (reconcile pass) | 5.104-5.110 | complete | 7 | 0 | 0 | catch-up pass that activates overdue SCHEDULED meta rows without a timer. Closes the gap where the in-process LocalSchedulerBackend queue is lost on every restart (all non-Celery instances), and makes retiring per-instance beat safe by turning a missed timer into latency rather than silent data loss |
 
 ## 6. Audit Logging (`audit_logging`)
 

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -14,7 +14,7 @@
 | 2. CRUD via REST API | 10 | 107 | 15 | 0 | 0 |
 | 3. Validation Hooks | 7 | 38 | 6 | 0 | 0 |
 | 4. Permissions | 13 | 74 | 18 | 2 | 0 |
-| 5. History & Bitemporal | 12 | 103 | 15 | 6 | 3 |
+| 5. History & Bitemporal | 13 | 109 | 21 | 6 | 3 |
 | 6. Audit Logging | 17 | 118 | 21 | 3 | 0 |
 | 7. Calculation State Machine | 19 | 221 | 78 | 0 | 0 |
 | 8. Celery & Async | 15 | 153 | 89 | 12 | 0 |
@@ -119,6 +119,7 @@
 | 5k |  | 5.81-5.87 | complete | 0 | 3 | 1 | auto-skip — MetaHistorical* not wired; prod registration covered in unit tests |
 | 5l |  | 5.91-5.97 | planned | 0 | 0 | 0 | save side of the future-activation handoff (worker side = 8.43); scenarios 5.91–5.97, reuses `HistSimpleItem` |
 | 5m | Edit-time correctness + as_of time-travel round trip | 5.98-5.103 | complete | 5 | 0 | 1 | end-to-end edited_at → Z serialization → parse_as_of_datetime → get_queryset_as_of chain; 5.101 xfail(strict) pins BUG-026 (edited_at vs valid_from/sys_from clock-read gap) |
+| 5n | Activation catch-up (reconcile pass) | 5.104-5.109 | complete | 6 | 0 | 0 | catch-up pass that activates overdue SCHEDULED meta rows without a timer. Closes the gap where the in-process LocalSchedulerBackend queue is lost on every restart (all non-Celery instances), and makes retiring per-instance beat safe by turning a missed timer into latency rather than silent data loss |
 
 ## 6. Audit Logging (`audit_logging`)
 

--- a/lex/test_project/test-plan/progress/sessions/2026-08-04-activation-reconcile.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-08-04-activation-reconcile.md
@@ -1,0 +1,55 @@
+# Session — Bitemporal activation catch-up (batch 5n)
+
+**Date:** 2026-08-04
+**Batch:** 5n (scenarios 5.104–5.109), 6 pass
+
+## Why
+
+A future-dated history row schedules a timer to activate itself. Both timer
+backends are volatile, and the in-process one — used whenever `CELERY_ACTIVE` is
+false, i.e. 47 of 53 instances — is held in a daemon thread with nothing to
+rehydrate it. Every backend restart silently dropped that instance's pending
+activations: the meta row stayed `SCHEDULED` forever, the main table never
+caught up, no error was raised.
+
+The timer was being treated as the system of record. It is not — the meta row
+is. `meta_task_status = SCHEDULED` plus the history row's `valid_from` states
+exactly what should already have happened, and both live in the instance's own
+database.
+
+## What landed
+
+`lex/core/services/activation_reconcile.py` — a pass that finds overdue
+`SCHEDULED` rows and activates them, run at backend startup and every 60s
+thereafter (`running_in_uvicorn()`-gated, so management commands and workers do
+not duplicate it). Four `LEX_ACTIVATION_RECONCILE_*` settings.
+
+This inverts the failure model: a timer that never fires now costs *latency*
+rather than losing the activation. That is what makes retiring per-instance beat
+safe, and what would make any future cluster-level scheduler an optimisation
+allowed to fail rather than a component 53 instances depend on.
+
+## Two defects the tests caught while being written
+
+Both would have shipped as silent no-ops:
+
+1. **`activate_history_version` reports failure by return value, not by
+   raising** — `"failed_too_early"`, `"skipped_missing_record"`,
+   `"failed_model_lookup"`, `"success"`. The first implementation treated a
+   clean return as success, so it counted activations that never happened and
+   dropped them from the retry set. 5.104 failed and exposed it.
+2. **`@lex_shared_task` wraps that return as `(result, args)`**, so the status
+   string needs unwrapping. `_outcome_of` unwraps defensively rather than
+   indexing `[0]`, so a future change to the decorator degrades to "not
+   success" — a retry — instead of a spurious success.
+
+A third was a test bug, not a source bug: faking `now` selects a row that
+`activate_history_version` then declines, because it re-checks `valid_from`
+against the real clock. The fixture moves `valid_from` into the past instead,
+which is what an hour actually passing looks like to every layer at once.
+
+## Companion
+
+Terraform `feat/activation-reconcile-retire-beat` sets the env unconditionally
+(not in the MQ/Worker branch — the non-Celery instances are the ones that need
+it) and records that beat is no longer required for bitemporal.

--- a/lex/test_project/tests/history/test_5n_activation_reconcile.py
+++ b/lex/test_project/tests/history/test_5n_activation_reconcile.py
@@ -29,7 +29,10 @@ Intent (``lex/core/services/activation_reconcile.py``):
           ``LEX_ACTIVATION_RECONCILE_MAX_ATTEMPTS``, then given up, so a
           permanently-broken row cannot burn a pass forever (5.108);
       (f) terminal meta states (DONE / CANCELLED) are never re-activated
-          (5.109).
+          (5.109);
+      (g) the background loop closes stale database connections around every
+          pass, so a Postgres restart does not silently end catch-up for the
+          life of the pod (5.110).
 
 Companion to 5l, which covers the *producer* side of the same contract (a
 future save schedules correctly). 5n covers what happens when that schedule is
@@ -365,4 +368,43 @@ class TestCluster05n_ActivationReconcile(E2ETestCase):
         self.assertEqual(
             HistSimpleItem.objects.get(pk=item.pk).name, "before",
             "The withdrawn change must not be applied.",
+        )
+
+    # -- 5.110 ---------------------------------------------------------------
+    def test_5_110_loop_closes_stale_connections_around_each_pass(self) -> None:
+        """
+        Scenario 5.110 — the loop must survive a database connection dying.
+        Given: the background loop running a pass
+        When:  the pass completes (or fails)
+        Then:  close_old_connections is called before AND after.
+
+        Django opens a connection per thread and normally closes it on the
+        request_finished signal. A background thread has no request cycle, so
+        without this the connection is held for the life of the pod; once
+        Postgres drops it, restarts or fails over, every later pass raises
+        OperationalError and the loop logs an error every interval forever
+        without ever reconnecting — a silent stop dressed up as noise.
+        """
+        from lex.core.services import activation_reconcile
+
+        calls = []
+
+        def _stop_after_one_pass(*_a, **_kw):
+            activation_reconcile.stop_background_reconcile()
+            return {}
+
+        with patch("django.db.close_old_connections", side_effect=lambda: calls.append("closed")), \
+             patch.object(
+                 activation_reconcile,
+                 "reconcile_pending_activations",
+                 side_effect=_stop_after_one_pass,
+             ):
+            activation_reconcile._stop.clear()
+            activation_reconcile._loop()
+
+        self.assertGreaterEqual(
+            len(calls), 2,
+            "close_old_connections must run before and after each pass; "
+            f"saw {len(calls)} call(s). Without both, a dropped connection ends "
+            "catch-up for the life of the pod.",
         )

--- a/lex/test_project/tests/history/test_5n_activation_reconcile.py
+++ b/lex/test_project/tests/history/test_5n_activation_reconcile.py
@@ -1,0 +1,368 @@
+"""
+Cluster 5n: Bitemporal activation catch-up — the timer is not the truth.
+
+Intent (``lex/core/services/activation_reconcile.py``):
+
+    A future-dated save schedules a timer for its own activation. Both timer
+    backends are volatile: the in-process ``LocalSchedulerBackend`` queue (used
+    whenever ``CELERY_ACTIVE`` is false, i.e. most instances) is held in a daemon
+    thread and lost on every restart, with nothing to rehydrate it. Before this
+    batch, that meant a deploy or an OOM silently dropped every pending
+    activation — the meta row stayed ``SCHEDULED`` forever, the main table never
+    caught up, and nothing was logged.
+
+    The durable record is the meta row, not the timer: ``meta_task_status =
+    "SCHEDULED"`` plus the history row's ``valid_from`` states exactly what
+    should already have happened. ``reconcile_pending_activations`` reads that
+    and finishes the job.
+
+    The contract this batch pins:
+
+      (a) an overdue SCHEDULED row is activated — the main table catches up
+          even though no timer ever fired (5.104);
+      (b) a row whose moment has not arrived is left strictly alone (5.105);
+      (c) the pass is idempotent — a second run activates nothing and does not
+          disturb the result (5.106);
+      (d) activations older than ``LEX_ACTIVATION_RECONCILE_MAX_AGE_DAYS`` are
+          reported, never silently replayed (5.107);
+      (e) a record that fails to activate is retried only up to
+          ``LEX_ACTIVATION_RECONCILE_MAX_ATTEMPTS``, then given up, so a
+          permanently-broken row cannot burn a pass forever (5.108);
+      (f) terminal meta states (DONE / CANCELLED) are never re-activated
+          (5.109).
+
+Companion to 5l, which covers the *producer* side of the same contract (a
+future save schedules correctly). 5n covers what happens when that schedule is
+lost — which, on the majority of the fleet, is every restart.
+
+Run: python -m lex pytest lex/test_project/tests/history/test_5n_activation_reconcile.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.test import override_settings
+from django.utils import timezone
+
+from lex.test_project.tests._e2e_test_case import E2ETestCase
+
+from .models import ALL_MODELS, HistSimpleItem
+
+pytestmark = pytest.mark.history
+
+
+def _l2_wired() -> bool:
+    """L2 (MetaHistorical) is wired on the *historical* model — probe at call
+    time, mirroring 5l."""
+    try:
+        return hasattr(HistSimpleItem.history.model, "meta_history") and bool(
+            HistSimpleItem.history.model.meta_history.model
+        )
+    except Exception:
+        return False
+
+
+_SKIP_REASON_L2 = (
+    "Activation catch-up reads the L2 meta record (meta_task_status). The "
+    "test_project's HistSimpleItem fixture does not have MetaHistorical* wired "
+    "in this build; see 5l for the same limitation."
+)
+
+
+class TestCluster05n_ActivationReconcile(E2ETestCase):
+    """Overdue SCHEDULED rows activate without any timer having fired."""
+
+    e2e_models = ALL_MODELS
+
+    def setUp(self):
+        super().setUp()
+        # The attempt counter is process-global; a leaked entry from another
+        # test would silently suppress an activation here.
+        from lex.core.services import activation_reconcile
+
+        activation_reconcile._failures.clear()
+        try:
+            from django_celery_beat.models import PeriodicTask
+
+            PeriodicTask.objects.filter(task="activate_history_version").delete()
+        except Exception:
+            pass
+
+    # ---------------------------------------------------------------- helpers
+    def _future_item(self, hours: int = 1):
+        """An item whose latest version is dated ``hours`` into the future.
+
+        Returns ``(item, future_moment)``. The main table deliberately still
+        reads the *previous* version at this point — that is the state a lost
+        timer leaves behind.
+        """
+        item = HistSimpleItem.objects.create(name="before", value=0)
+
+        # Backdate the initial version well into the past. Without this the base
+        # row sits at "now", so once _moment_arrives moves the scheduled row back
+        # by 30s the scheduled row becomes the OLDER of the two — the
+        # synchronizer then correctly keeps "before", and the test would be
+        # asserting the wrong thing for the wrong reason.
+        base = (
+            HistSimpleItem.history.filter(id=item.pk)
+            .order_by("valid_from", "history_id")
+            .first()
+        )
+        type(base).objects.filter(pk=base.pk).update(
+            valid_from=timezone.now() - timedelta(days=400)
+        )
+
+        future = timezone.now() + timedelta(hours=hours)
+        item.name = "after"
+        item.value = 1
+        item._history_date = future
+        item.save()
+        return item, future
+
+    def _moment_arrives(self, item, seconds_ago: int = 30):
+        """Move the scheduled row's ``valid_from`` into the past.
+
+        This is how the test makes the moment arrive. Passing a synthetic
+        ``now`` to the reconcile pass does not work and must not be used:
+        ``activate_history_version`` re-checks ``valid_from`` against the real
+        clock and declines anything not yet due, so a faked ``now`` selects the
+        row and then fails to activate it. Moving the row is what a real hour
+        passing looks like to every layer at once.
+        """
+        hist = (
+            HistSimpleItem.history.filter(id=item.pk)
+            .order_by("-valid_from", "-history_id")
+            .first()
+        )
+        past = timezone.now() - timedelta(seconds=seconds_ago)
+        type(hist).objects.filter(pk=hist.pk).update(valid_from=past)
+        return past
+
+    def _meta_rows(self, item):
+        meta_model = HistSimpleItem.history.model.meta_history.model
+        history_ids = list(
+            HistSimpleItem.history.filter(id=item.pk).values_list("pk", flat=True)
+        )
+        return meta_model.objects.filter(history_object_id__in=history_ids)
+
+    # -- 5.104 ---------------------------------------------------------------
+    def test_5_104_overdue_activation_catches_up_without_a_timer(self) -> None:
+        """
+        Scenario 5.104 — the core contract, and the bug this batch exists for.
+        Given: a future-dated save whose timer was lost (never fired)
+        When:  the reconcile pass runs after the moment has passed
+        Then:  the main table catches up and the meta row leaves SCHEDULED —
+               proving the activation does not depend on the timer surviving
+        """
+        if not _l2_wired():
+            self.skipTest(_SKIP_REASON_L2)
+
+        from lex.core.services.activation_reconcile import (
+            reconcile_pending_activations,
+        )
+
+        item, future = self._future_item(hours=1)
+
+        self.assertEqual(
+            HistSimpleItem.objects.get(pk=item.pk).name,
+            "before",
+            "Precondition: the main table must still hold the pre-activation value.",
+        )
+        self.assertTrue(
+            self._meta_rows(item).filter(meta_task_status="SCHEDULED").exists(),
+            "Precondition: a SCHEDULED meta row must exist to be caught up.",
+        )
+
+        # The moment arrives. No timer fires — only the reconcile pass runs.
+        self._moment_arrives(item)
+        stats = reconcile_pending_activations()
+
+        self.assertEqual(
+            stats["activated"], 1,
+            f"Exactly one overdue activation was expected; got {stats}",
+        )
+        self.assertEqual(
+            HistSimpleItem.objects.get(pk=item.pk).name,
+            "after",
+            "The main table must catch up to the activated version.",
+        )
+        self.assertFalse(
+            self._meta_rows(item).filter(meta_task_status="SCHEDULED").exists(),
+            "The meta row must leave SCHEDULED once activated.",
+        )
+
+    # -- 5.105 ---------------------------------------------------------------
+    def test_5_105_not_yet_due_is_left_alone(self) -> None:
+        """
+        Scenario 5.105 — catch-up must never activate early.
+        Given: a future-dated save whose moment has NOT arrived
+        When:  the reconcile pass runs
+        Then:  nothing is activated and the main table is untouched — otherwise
+               the pass would defeat the whole point of scheduling
+        """
+        if not _l2_wired():
+            self.skipTest(_SKIP_REASON_L2)
+
+        from lex.core.services.activation_reconcile import (
+            reconcile_pending_activations,
+        )
+
+        item, _future = self._future_item(hours=1)
+
+        stats = reconcile_pending_activations()
+
+        self.assertEqual(stats["activated"], 0, f"Nothing was due; got {stats}")
+        self.assertEqual(
+            HistSimpleItem.objects.get(pk=item.pk).name,
+            "before",
+            "A not-yet-due record must not be activated early.",
+        )
+        self.assertTrue(
+            self._meta_rows(item).filter(meta_task_status="SCHEDULED").exists(),
+            "The row must remain SCHEDULED for its real moment.",
+        )
+
+    # -- 5.106 ---------------------------------------------------------------
+    def test_5_106_second_pass_is_a_no_op(self) -> None:
+        """
+        Scenario 5.106 — the pass is idempotent.
+        Given: an activation already caught up by a previous pass
+        When:  the pass runs again
+        Then:  it activates nothing further and the value is unchanged. The loop
+               runs every 60s forever, so a non-idempotent pass would re-apply
+               the same activation continuously.
+        """
+        if not _l2_wired():
+            self.skipTest(_SKIP_REASON_L2)
+
+        from lex.core.services.activation_reconcile import (
+            reconcile_pending_activations,
+        )
+
+        item, _future = self._future_item(hours=1)
+        self._moment_arrives(item)
+
+        first = reconcile_pending_activations()
+        second = reconcile_pending_activations()
+
+        self.assertEqual(first["activated"], 1)
+        self.assertEqual(
+            second["activated"], 0,
+            f"The second pass must find nothing left to do; got {second}",
+        )
+        self.assertEqual(
+            HistSimpleItem.objects.get(pk=item.pk).name, "after",
+            "The value must be unchanged by the redundant pass.",
+        )
+
+    # -- 5.107 ---------------------------------------------------------------
+    @override_settings(LEX_ACTIVATION_RECONCILE_MAX_AGE_DAYS=1)
+    def test_5_107_ancient_activations_are_not_replayed(self) -> None:
+        """
+        Scenario 5.107 — a dormant instance must not replay history on wake.
+        Given: an activation whose moment passed long before the age window
+        When:  the reconcile pass runs
+        Then:  it is NOT activated. An instance offline for months should not
+               come back and silently apply a backlog of backdated changes; that
+               is a decision for a human, not a background loop.
+        """
+        if not _l2_wired():
+            self.skipTest(_SKIP_REASON_L2)
+
+        from lex.core.services.activation_reconcile import (
+            reconcile_pending_activations,
+        )
+
+        item, _future = self._future_item(hours=1)
+        # Far outside the 1-day window configured above.
+        self._moment_arrives(item, seconds_ago=45 * 24 * 3600)
+
+        stats = reconcile_pending_activations()
+
+        self.assertEqual(
+            stats["activated"], 0,
+            f"An activation older than the window must not be replayed; got {stats}",
+        )
+        self.assertEqual(
+            HistSimpleItem.objects.get(pk=item.pk).name, "before",
+            "The main table must be left for a human to resolve.",
+        )
+
+    # -- 5.108 ---------------------------------------------------------------
+    @override_settings(LEX_ACTIVATION_RECONCILE_MAX_ATTEMPTS=2)
+    def test_5_108_failing_record_is_given_up_not_retried_forever(self) -> None:
+        """
+        Scenario 5.108 — a broken record must not burn every pass forever.
+        Given: an overdue activation that raises every time it is attempted
+        When:  the pass runs repeatedly
+        Then:  it is attempted up to the cap and then skipped. Without the cap a
+               single poison record would be retried every 60s for the life of
+               the process, filling logs and delaying healthy work.
+        """
+        if not _l2_wired():
+            self.skipTest(_SKIP_REASON_L2)
+
+        from lex.core.services.activation_reconcile import (
+            reconcile_pending_activations,
+        )
+
+        item, _future = self._future_item(hours=1)
+        self._moment_arrives(item)
+
+        # reconcile_pending_activations imports the task inside the function, so
+        # patch it at its source module.
+        with patch(
+            "lex.lex_app.celery_tasks.activate_history_version",
+            side_effect=RuntimeError("activation exploded"),
+        ):
+            first = reconcile_pending_activations()
+            second = reconcile_pending_activations()
+            third = reconcile_pending_activations()
+
+        self.assertEqual(first["failed"], 1, f"First attempt should fail; got {first}")
+        self.assertEqual(second["failed"], 1, f"Second attempt should fail; got {second}")
+        self.assertEqual(
+            third["gave_up"], 1,
+            f"After {2} attempts the record must be given up, not retried; got {third}",
+        )
+        self.assertEqual(
+            third["failed"], 0,
+            "A given-up record must not be attempted again in the same process.",
+        )
+
+    # -- 5.109 ---------------------------------------------------------------
+    def test_5_109_terminal_meta_states_are_never_reactivated(self) -> None:
+        """
+        Scenario 5.109 — DONE and CANCELLED are terminal.
+        Given: an overdue history row whose meta rows are all terminal
+        When:  the reconcile pass runs
+        Then:  nothing is activated. A cancelled schedule must stay cancelled —
+               resurrecting it would re-apply a change a user explicitly
+               withdrew.
+        """
+        if not _l2_wired():
+            self.skipTest(_SKIP_REASON_L2)
+
+        from lex.core.services.activation_reconcile import (
+            reconcile_pending_activations,
+        )
+
+        item, _future = self._future_item(hours=1)
+        self._moment_arrives(item)
+        self._meta_rows(item).filter(meta_task_status="SCHEDULED").update(
+            meta_task_status="CANCELLED"
+        )
+
+        stats = reconcile_pending_activations()
+
+        self.assertEqual(
+            stats["activated"], 0,
+            f"A cancelled activation must never be resurrected; got {stats}",
+        )
+        self.assertEqual(
+            HistSimpleItem.objects.get(pk=item.pk).name, "before",
+            "The withdrawn change must not be applied.",
+        )


### PR DESCRIPTION
## The bug

A future-dated history row schedules a timer to activate itself. Both timer backends are volatile, and the one used whenever Celery is off — an in-process `sched` queue on a daemon thread ([`local_scheduler.py`](../blob/lex-app-v2/lex/process_admin/utils/local_scheduler.py)) — is **lost on every restart, with nothing to rehydrate it**.

So a deploy, node move or OOM silently drops every pending activation on that instance. The meta row stays `SCHEDULED` forever, the main table never catches up, and **nothing is logged**. No error, no warning.

**That is 47 of 53 production instances** — every one that doesn't run Celery.

## The fix

The timer was being treated as the system of record. It isn't. The meta row is: `meta_task_status = SCHEDULED` plus the history row's `valid_from` states exactly what should already have happened, and both live in the instance's own database.

`reconcile_pending_activations` reads that and finishes the job — at backend startup (a restart is precisely how the timer queue gets dropped) and every 60 s thereafter.

**This inverts the failure model.** A timer that never fires now costs *latency* instead of losing the activation, because the pass converges on the same result.

## Why it's safe to run every 60 s forever

Verified against the code, not assumed:

- `sync_record_for_model` is **convergent** — it derives the main row from whichever history record is currently valid, so two runs produce one result;
- `activate_history_version` re-checks `valid_from` and refuses to act early;
- `SCHEDULED → DONE` is a no-op on repeat.

Runs **in-process, not dispatched to Celery**: activation is a small convergent write, not a calculation, and in-process means it behaves identically on instances with no broker at all — which is the majority.

## Two defects the tests caught

Both would have shipped as silent no-ops:

1. **`activate_history_version` reports failure by return value, not by raising** (`"failed_too_early"`, `"skipped_missing_record"`, `"failed_model_lookup"`, `"success"`). The first implementation treated a clean return as success — counting activations that never happened and dropping them from the retry set. Scenario 5.104 failed and exposed it.
2. **`@lex_shared_task` wraps that return as `(result, args)`**, so the status string needs unwrapping. `_outcome_of` unwraps *defensively* rather than indexing `[0]`, so a future change to the decorator degrades to a retry rather than a false success.

## Bounded in both directions

| Guard | Why |
|---|---|
| `LEX_ACTIVATION_RECONCILE_MAX_AGE_DAYS` (30) | A dormant instance must not wake and silently apply a year of backdated changes. Older rows are reported, never replayed. |
| `LEX_ACTIVATION_RECONCILE_MAX_ATTEMPTS` (5) | One poison record cannot burn every pass forever. |

The attempt counter is deliberately **in-memory** rather than a terminal `FAILED` status: meta models are generated per customer model, so a new status choice would force a migration in **every customer repository** for a value the database does not enforce. That is a trade, and it is documented as one — a crash-looping backend resets the counter.

## The default is `true`, on purpose

```python
LEX_ACTIVATION_RECONCILE_ENABLED = os.getenv("LEX_ACTIVATION_RECONCILE_ENABLED", "true") == "true"
```

Compare `LEX_TASK_RECOVERY_ENABLED`, which defaults `"false"` — and which Terraform set on the supervisor pod but not the workers, producing a healthy-looking supervisor that swept an empty index **23,625 times in 2.5 days** while a user watched a spinner for two hours.

**Absence of configuration must not mean absence of function.** An instance that never receives the ConfigMap key still catches up.

## Known weakness, documented not hidden

`meta_task_status` carries **no `db_index`**, so the selection query is a sequential scan per bitemporal model every 60 s, on the pod that also serves user requests. Free on small instances; **unmeasured on a large one**. Mitigations in preference order are in the design doc; the cheapest is raising the interval, which is a pure latency/cost trade with no correctness impact.

Worth checking `pg_stat_statements` on the largest instance before this runs fleet-wide for months.

## Tests

Batch **5n**, scenarios 5.104–5.109, **6 pass**. Companion to 5l, which covers the producer side of the same contract.

Regression: history cluster **47 pass / 1 skip / 1 xfail / 0 fail**. Plan shards + session fragment + dashboard synced; `test_plan_aggregates.py validate` clean.

## What this unblocks

Per-instance beat was retained for one reason: it also ran django-celery-beat's clock for these activations, so switching `recoveryDriver: beat → supervisor` silently stopped future-dated changes firing. **That blocker is gone.** See LEX_TERRAFORM_MODULES#37, which records it where the driver is chosen, and unblocks LEX_TERRAFORM_MODULES#35.

## Design docs

- `docs/superpowers/specs/2026-08-04-global-scheduler-infra.md` (in this PR) — all four approaches with infra, lex-app, the seam between them, and how each fails
- `docs/superpowers/specs/2026-08-04-global-scheduler-options.md` — the software argument for choosing this over a cluster-level scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)