### PR TITLE
fix(release-notes): commit the style exemplar and make drafting failure visible

### DIFF
--- a/.github/scripts/release_notes/__main__.py
+++ b/.github/scripts/release_notes/__main__.py
@@ -72,12 +72,30 @@ def _pac_arg(args: argparse.Namespace) -> Path | None:
     return Path(args.pac_checkout) if args.pac_checkout else None
 
 
+def _load_exemplar() -> str:
+    """The style exemplar, or a built-in stand-in if it is missing.
+
+    A missing style file must never sink a release note. This crashed CI once:
+    the exemplar existed on the author's laptop but had never been committed,
+    so every local dry run passed and the first real run died before
+    `notes.draft()` — the one function that guarantees a usable body.
+    """
+    if EXEMPLAR_PATH.exists():
+        return EXEMPLAR_PATH.read_text(encoding="utf-8")
+    print(
+        f"Style exemplar missing at {EXEMPLAR_PATH} — falling back to the "
+        "built-in one. Restore the file to control the house style.",
+        file=sys.stderr,
+    )
+    return notes.FALLBACK_EXEMPLAR
+
+
 def cmd_draft_notes(args: argparse.Namespace) -> int:
     token = os.environ.get("GITHUB_TOKEN", "")
     if not token:
         print("GITHUB_TOKEN is not set", file=sys.stderr)
         return 1
-    exemplar = EXEMPLAR_PATH.read_text(encoding="utf-8")
+    exemplar = _load_exemplar()
     body = notes.draft(
         _digest_for(args.tag, pac_checkout=_pac_arg(args)),
         exemplar=exemplar,

--- a/.github/scripts/release_notes/notes.py
+++ b/.github/scripts/release_notes/notes.py
@@ -14,6 +14,30 @@ from typing import Callable
 
 FAILURE_MARKER = "<!-- lex:notes-draft-failed -->"
 
+# Used only when docs/releases/RELEASE_NOTES_2.1.3_github.md is unavailable.
+# The real file is richer and should win; this exists so a missing style
+# reference degrades the prose instead of killing the release note.
+FALLBACK_EXEMPLAR = """\
+## Main changes
+
+- **New sidebar.** A full-height side navigation with a consolidated header bar.
+  More room for your data, and models are easier to find.
+- **Number formatting per column.** Choose how a numeric column displays — a plain
+  number, a currency, or a percentage — and how many decimals to show.
+
+## Optimizations
+
+- **Live-updating tables.** Open grids refresh themselves when the underlying data
+  changes — no manual **Refresh**.
+
+## Bug fixes
+
+- **Timezone bug.** Timestamps could appear shifted by a couple of hours. Times now
+  display correctly in your local timezone.
+
+**Upgrade note:** run database migrations on upgrade. No configuration changes needed.
+"""
+
 REQUIRED_HEADINGS = ("## Main changes", "## Optimizations", "## Bug fixes")
 
 MODELS_ENDPOINT = "https://models.github.ai/inference/chat/completions"

--- a/.github/workflows/prerelease_gate.yml
+++ b/.github/workflows/prerelease_gate.yml
@@ -201,11 +201,19 @@ jobs:
           test -s drafted.md
           echo "Drafted $(wc -l < drafted.md) lines."
 
-      - name: Append the note to the prerelease body
-        if: ${{ always() && steps.draft.outcome == 'success' }}
+      # Runs whatever happened above. Gating this on the drafter succeeding is
+      # what turned the first real run into silence: the drafter crashed on a
+      # missing style file, this step skipped, and the prerelease carried no
+      # note and no explanation. `notes.draft()` guarantees a usable body, but
+      # only once it is reached — anything that dies earlier needs a signal
+      # here, or the failure is invisible to the person about to promote.
+      - name: Append the note (or a failure notice) to the prerelease body
+        if: ${{ always() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
+          DRAFT_OUTCOME: ${{ steps.draft.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           BODY=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '.body')
@@ -213,11 +221,30 @@ jobs:
             echo "Notes already drafted for $TAG — leaving the human's edits alone."
             exit 0
           fi
+
+          if [ "$DRAFT_OUTCOME" = "success" ] && [ -s drafted.md ]; then
+            cp drafted.md note.md
+          else
+            # Loud, not silent. The reviewer sees this on the page they are
+            # already looking at, with a link to the log that explains it.
+            {
+              printf '<!-- lex:notes-draft-failed -->\n\n'
+              printf '> **Release notes could not be drafted automatically.**\n'
+              printf '> The drafting step failed — see [the workflow run](%s).\n' "$RUN_URL"
+              printf '> Write the notes by hand before promoting, or re-run the job.\n'
+            } > note.md
+          fi
+
           {
             printf '%s\n' "$BODY"
             printf '\n---\n\n'
-            cat drafted.md
+            cat note.md
             printf '\n<!-- lex:notes-drafted tag=%s -->\n' "$TAG"
           } > combined.md
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file combined.md
-          echo "Drafted release notes onto $TAG — review and edit before promoting."
+
+          if [ "$DRAFT_OUTCOME" = "success" ]; then
+            echo "Drafted release notes onto $TAG — review and edit before promoting."
+          else
+            echo "::warning::Drafting failed for $TAG; posted a failure notice on the release instead."
+          fi

--- a/docs/releases/RELEASE_NOTES_2.1.3_github.md
+++ b/docs/releases/RELEASE_NOTES_2.1.3_github.md
@@ -1,0 +1,38 @@
+## Main changes
+
+- **New design and theme.** The whole app has a refreshed look — cleaner tables, forms, and navigation, in both light and dark mode.
+- **New sidebar.** A full-height side navigation with a consolidated header bar. More room for your data, and models are easier to find.
+- **Settings option.** A settings panel lets each user tune how a grid looks and behaves — row density, which columns are pinned, the column layout, and enabling or disabling the column filter toggle. Your choices are remembered.
+- **Less cluttered table view.** Columns auto-fit to their content, date columns show the date only by default (the full timestamp is on hover), and the toolbar is tidier — so the grid shows more data with less noise.
+- **Number formatting per column.** Choose how a numeric column displays — a plain number, a currency (€, $, £, CHF, ¥), or a percentage — and how many decimal places to show. Set it once and the column stays formatted that way.
+- **Card-like foreign keys.** A column that links to another record now shows that record's name as a compact chip, whose text can be customized with a serializer.
+- **Colorful calculation status, pinned left.** The calculation status is shown as a color-coded pill (in-progress, success, error…) and pinned to the left of the grid, so you can always see it while scrolling.
+- **Action column pinned right.** The per-row actions column is pinned to the right by default, so the controls stay put no matter how wide the table gets.
+- **Calculate moved into the actions bar.** The **Calculate** button now lives with the other per-row actions, next to the status pill — keeping calculation controls together.
+- **Toggle the selection column.** The row-selection checkbox column can be shown or hidden, so you only see it when you actually need to select rows.
+- **New quick-edit panel.** Editing opens a sliding panel that's part of the grid surface — quicker than a separate page, and you stay in context with your data.
+- **Current / As-of / History.** A single control switches a table between its live values, a point-in-time "as of" view (the data as it was at any past moment), and the full history of changes.
+- **Calculation logs that read like a document.** Calculations can group their output into titled sections — a table of contents for a run, with nested sub-sections. In the log view (the `CalculationLogTreeView`), the left pane lists every section so you can jump straight to it, and sections fold away to focus on one phase at a time. Section titles, severity badges, and a copy button round it out.
+
+## Optimizations
+
+- **Live-updating tables.** Open grids refresh themselves when the underlying data changes — no manual **Refresh**.
+- **Faithful PDF export.** The **Download PDF** of a calculation log now renders just like the on-screen view — headings, tables, and code blocks intact.
+- **Lower memory on heavy operations.** Data-heavy calculations use noticeably less memory per record, and large fan-out calculations stream their work instead of building everything up front — so big runs stay within a bounded memory budget instead of exhausting the instance.
+
+## Bug fixes
+
+- **Timezone bug.** Timestamps (edit times, calculation-log times, history) and the "as-of" time-travel could appear shifted by a couple of hours. Times now display correctly in your local timezone, and time-travel lands on the right moment.
+- **File upload / removal problem.** Removing a file from a file field and saving no longer brings the old file back — a removed attachment stays removed, while replacing or leaving a file untouched behaves as expected.
+- **Duplicate records on save.** Double-clicking **Save** could create two copies of a record. Save is now guarded, so a record is created once.
+- **Form validation errors are now shown.** When a save was rejected by a validation rule, the form could fail without saying why. The message now appears on the relevant field.
+- **Number and yes/no column filters.** Filtering a numeric or true/false column could fail to load the list. These filters now work correctly.
+- **Exports respect your sort order.** An Excel/CSV export now comes out in the same order as the grid on screen.
+- **Exports respect field permissions.** Columns you don't have permission to see are no longer included in exports.
+- **New table views activate automatically.** A list view you just created now opens straight away instead of staying inactive.
+- **Safer content rendering.** Process-flow output is now sanitized before it's displayed, closing a path where crafted content could run in the browser.
+- **History stays intact.** Historical records can no longer be deleted, protecting the audit trail.
+
+---
+
+**Upgrade note:** run database migrations on upgrade (this release adds one new, nullable column for the calculation-log sections — instant, no data rewrite). No configuration changes are needed.


### PR DESCRIPTION
`v2.1.7rc1` drafted no notes and gave no indication why. Two bugs, the second worse than the first.

## The exemplar was never committed

```
FileNotFoundError: '/home/runner/work/lex-app/lex-app/docs/releases/RELEASE_NOTES_2.1.3_github.md'
```

`docs/releases/RELEASE_NOTES_2.1.3_github.md` existed only as an untracked file on my working copy. Every local dry run passed because it was sitting right there; CI has never had it.

That killed the drafter **before** `notes.draft()` — the one function that guarantees a usable body no matter what the model does. All the fail-open logic was downstream of the crash.

Fixed twice over: the file is now in the repo, and a missing exemplar falls back to a built-in one rather than raising. A missing style reference should degrade the prose, not sink the release note.

## Failure was silent, which is the real defect

The append step was gated:

```yaml
if: ${{ always() && steps.draft.outcome == 'success' }}
```

So the crash skipped it and the prerelease carried no note **and no explanation**. Fail-open inside Python is worthless if the workflow turns an early crash into silence — you had to read a step-level log inside a green job to find out anything had gone wrong.

The step now always runs. When drafting produced nothing it posts a visible notice on the release page, linking the run that failed, plus a `::warning::` annotation.

## Verification

- 221 tests pass
- Fallback path exercised by moving the exemplar aside and confirming `_load_exemplar()` degrades with a warning
- The built-in fallback passes `notes.validate()` — it can't itself become a source of malformed output

## After merge

`v2.1.7rc1` is still sitting green with a boilerplate body. Delete and re-cut it to exercise the fixed path; the gate will re-run and this time the note lands. That run is also the first real test of `pull-requests: read` — watch for `PR enrichment: N/M commits matched` in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)