### PR TITLE
fix(release-notes): run the drafter from the default branch, not the tag

### DIFF
--- a/.github/workflows/prerelease_gate.yml
+++ b/.github/workflows/prerelease_gate.yml
@@ -179,6 +179,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0   # tags + full history are the input
+          # Take the DRAFTING TOOLS from the default branch, not from the tag.
+          #
+          # A `release` event leaves GITHUB_SHA pointing at the tagged commit,
+          # so a bare checkout pins .github/scripts/ to whatever existed when
+          # the tag was cut — while the workflow YAML above always comes from
+          # the default branch. The two then disagree, and fixes merged after
+          # tagging never take effect: v2.1.7rc1 kept emitting pre-fix output
+          # from a job running post-fix YAML, which reads as the fix not
+          # working rather than as never having run.
+          #
+          # The commit range is computed from tag refs, which fetch-depth: 0
+          # brings along regardless of which branch is checked out.
+          ref: ${{ github.event.repository.default_branch }}
 
       - uses: actions/setup-python@v5
         with:
@@ -239,11 +252,17 @@ jobs:
             } > note.md
           fi
 
+          # Only a real draft claims the idempotence marker. A failure notice
+          # that stamped it would make its own failure permanent: the next run
+          # would see the marker, assume a human had written the notes, and
+          # decline to try again.
           {
             printf '%s\n' "$BODY"
             printf '\n---\n\n'
             cat note.md
-            printf '\n<!-- lex:notes-drafted tag=%s -->\n' "$TAG"
+            if [ "$DRAFT_OUTCOME" = "success" ]; then
+              printf '\n<!-- lex:notes-drafted tag=%s -->\n' "$TAG"
+            fi
           } > combined.md
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file combined.md
 


### PR DESCRIPTION
`v2.1.7rc1` produced identical broken output after both fixes had merged. That looked like the fixes not working. They had never run.

## Two commits, one job

A `release` event leaves `GITHUB_SHA` pointing at the **tagged commit**. So in `draft-notes`:

- the **workflow YAML** comes from the default branch — which is why the new append logic, the failure notice and the `DRAFT_OUTCOME` handling all ran
- `actions/checkout@v4` with no `ref:` takes **`.github/scripts/` from the tag**

`v2.1.7rc1` was tagged at 13:09. The dedupe and transport fixes merged at 13:35. The job at 13:42 ran *new YAML over old Python* and dutifully reproduced the old output — and would keep doing so forever, no matter what landed on `lex-app-v2`.

The log even says `Drafted release notes onto v2.1.7rc1`, because from its point of view it succeeded.

`publish_release_notes.yml` already pinned `ref: ${{ github.event.repository.default_branch }}`. I got it right in one workflow and wrong in the other. Now they agree.

The commit range is computed from tag refs, which `fetch-depth: 0` supplies regardless of which branch is checked out.

## A failure that made itself permanent

The failure notice was stamping `<!-- lex:notes-drafted -->` — the same marker that means "a human has written these notes, don't touch them". So a failed draft blocked its own retry. Now only a real draft claims it.

## Still needed: `ANTHROPIC_API_KEY`

This PR makes the *right code* run. It does not make drafting succeed — that secret is still absent, so GitHub Models is still the only transport and it still answers 410 during its retirement brownout.

With this merged and a fresh prerelease you will get the **deduped fallback**: seven readable entries instead of twenty-five duplicates, plus a notice saying drafting failed. Real prose needs the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)