### PR TITLE
fix(release-notes): stop the drafter announcing our toolchain as a feature

### DIFF
--- a/.github/scripts/release_notes/digest.py
+++ b/.github/scripts/release_notes/digest.py
@@ -77,6 +77,24 @@ class Commit:
 _MERGE_PREFIXES = ("Merge pull request ", "Merge branch ", "Merge remote-tracking ")
 _BUNDLE_PREFIX = "build(frontend): update bundle"
 
+# Work on the toolchain rather than on the product. Kept in the digest — the
+# changelog is a record of everything that shipped — but flagged so the note
+# drafter can leave it out. Without this flag a model reads
+# `feat(release-notes): pluggable model provider` as a LEX feature and writes
+# "LEX can now connect to Gemini", which is what v2.1.7rc1 published.
+INTERNAL_TYPES = frozenset({"ci", "build", "chore", "test", "docs"})
+INTERNAL_SCOPES = frozenset({
+    "release-notes", "test-plan", "ci", "gate", "showcase", "plan", "spec",
+    "setup-with-ai", "agent", "copilot",
+})
+
+
+def is_internal(type_: str, scope: str | None) -> bool:
+    """True when a change is about how we build LEX, not about LEX."""
+    if type_ in INTERNAL_TYPES:
+        return True
+    return (scope or "").strip().lower() in INTERNAL_SCOPES
+
 
 def is_noise(subject: str) -> bool:
     """True for commits that must never reach a changelog."""
@@ -104,6 +122,7 @@ def _entry(commit: Commit, component: str) -> dict:
         "breaking": parsed.breaking,
         "subject": parsed.subject,
         "pr_number": commit.pr_number,
+        "internal": is_internal(parsed.type, parsed.scope),
     }
 
 

--- a/.github/scripts/release_notes/notes.py
+++ b/.github/scripts/release_notes/notes.py
@@ -58,7 +58,7 @@ GEMINI_ENDPOINT = (
     "https://generativelanguage.googleapis.com/v1beta/models/"
     "{model}:generateContent"
 )
-GEMINI_MODEL = "gemini-2.5-flash"
+GEMINI_MODEL = "gemini-2.5-pro"
 
 OPENAI_ENDPOINT = "https://api.openai.com/v1/chat/completions"
 OPENAI_MODEL = "gpt-4o"
@@ -70,33 +70,77 @@ MODELS_ENDPOINT = "https://models.github.ai/inference/chat/completions"
 MODEL = "openai/gpt-4o"
 
 _INSTRUCTIONS = """\
-You are writing the release note for a business application called LEX.
+You are writing the customer-facing release note for LEX.
 
-Audience: two readers at once. A business user who has never seen the codebase
-and wants to know what changed for them, and a technical user who wants to know
-what actually changed. One document must satisfy both.
+WHAT LEX IS
+LEX is a platform for building business applications. Customers use a deployed
+LEX instance through a web UI: browsing and editing records in data grids,
+uploading files, running calculations over that data, and reading calculation
+logs and audit history. Your readers are those business users and the people
+who support them. They have never seen the source code and do not know how LEX
+is built, tested or released.
 
-Rules:
-- Use only these headings, in this order: "## Main changes", "## Optimizations",
-  "## Bug fixes". Omit any heading you have nothing to put under it. Never emit
-  a heading with no entries.
-- Each entry is a bullet starting with a bold summary phrase, then one or two
-  plain sentences. Example: "- **New sidebar.** A full-height side navigation."
-- Group entries by what the change means to a user, NOT by which repository or
-  component it came from. Never mention "backend", "frontend", or repository
-  names.
-- Do not invent changes. Every entry must trace to an item in the digest.
-- Do not mention internal class names, file paths, or commit hashes.
-- End with a line starting "**Upgrade note:**" describing any action needed on
-  upgrade, or stating that none is needed.
+THE MOST IMPORTANT RULE
+Describe only what changed **for someone using LEX**. The digest also contains
+work on the toolchain that builds and ships LEX — CI pipelines, test plans,
+release automation, developer setup. Entries with "internal": true are that
+kind of work. Leave them out. Entries without the flag may still be internal;
+judge by whether a user of the LEX web UI could notice.
 
-Match the tone and shape of this previous release note exactly:
+Never describe a change to our own tooling as a LEX capability. A previous
+release turned "the release-note drafter can now call Gemini" into "LEX can now
+connect to Gemini and OpenAI, allowing you to integrate with a wider range of
+large language models" — a feature that does not exist, announced to customers.
+If you find yourself writing about models, pipelines, CI, or repositories, stop:
+that is our machinery, not the product.
+
+IF NOTHING IS USER-FACING
+Say so, in full:
+
+    No user-facing changes in this release. This release contains internal
+    improvements to how LEX is built and released.
+
+    **Upgrade note:** no action is needed on upgrade.
+
+That is a correct and complete answer. Do not pad a thin release by promoting
+internal work into features. A short honest note is worth more than a long
+invented one.
+
+FORMAT
+Use only these headings, in this order, and only when you have entries for them:
+"## Main changes" (new capability), "## Optimizations" (existing things now
+faster, lighter or more reliable), "## Bug fixes" (something was wrong and is
+now right). Omit any heading you have nothing for. Never write a heading with
+nothing under it.
+
+Each entry is one bullet: a bold summary phrase, then one or two plain
+sentences saying what a user will notice.
+
+    - **New sidebar.** A full-height side navigation with a consolidated header
+      bar. More room for your data, and models are easier to find.
+
+WRITING
+- Group by what the change means to a user, never by component or repository.
+  Never write "backend", "frontend", or a repository name.
+- Merge entries describing the same user-visible change into one bullet. Two
+  fixes to embedded authentication are one bullet, not two.
+- Be concrete. "Date columns show the date only, with the full timestamp on
+  hover" — not "an improved date experience".
+- Cut filler. No "seamless", "robust", "enhanced experience", "allowing you to",
+  "a wider range of". If removing a phrase loses no information, remove it.
+- Every statement must trace to a digest entry. Do not infer capabilities that
+  are not there, and do not soften or inflate what an entry says.
+- No class names, file paths, commit hashes, PR numbers or internal jargon.
+- End with a line starting "**Upgrade note:**" — any action needed on upgrade,
+  or that none is.
+
+Match the tone of this previous release note:
 
 <exemplar>
 {exemplar}
 </exemplar>
 
-Here is the digest of what changed in {tag}:
+Changes in {tag}:
 
 <digest>
 {digest}
@@ -186,7 +230,10 @@ def _post(url: str, *, headers: dict, json_body: dict) -> dict:
         return json.loads(response.read().decode("utf-8"))
 
 
-def github_models(prompt: str, *, api_key: str, post: Callable[..., dict] = _post) -> str:
+def github_models(
+    prompt: str, *, api_key: str, model: str = MODEL,
+    post: Callable[..., dict] = _post,
+) -> str:
     """Call GitHub Models with the job's GITHUB_TOKEN. No new secret needed.
 
     The calling workflow job must declare `permissions: models: read`.
@@ -195,7 +242,7 @@ def github_models(prompt: str, *, api_key: str, post: Callable[..., dict] = _pos
         MODELS_ENDPOINT,
         headers={"Authorization": f"Bearer {api_key}", "Accept": "application/vnd.github+json"},
         json_body={
-            "model": MODEL,
+            "model": model,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": 0.2,
         },
@@ -207,14 +254,15 @@ def github_models(prompt: str, *, api_key: str, post: Callable[..., dict] = _pos
 
 
 def anthropic_messages(
-    prompt: str, *, api_key: str, post: Callable[..., dict] = _post
+    prompt: str, *, api_key: str, model: str = ANTHROPIC_MODEL,
+    post: Callable[..., dict] = _post,
 ) -> str:
     """Draft via the Anthropic Messages API. Requires ANTHROPIC_API_KEY."""
     payload = post(
         ANTHROPIC_ENDPOINT,
         headers={"x-api-key": api_key, "anthropic-version": ANTHROPIC_VERSION},
         json_body={
-            "model": ANTHROPIC_MODEL,
+            "model": model,
             "max_tokens": ANTHROPIC_MAX_TOKENS,
             "messages": [{"role": "user", "content": prompt}],
         },
@@ -236,13 +284,16 @@ def _chat_completion_text(payload: dict, who: str) -> str:
         raise ValueError(f"unexpected response from {who}: {payload!r}") from exc
 
 
-def openai_chat(prompt: str, *, api_key: str, post: Callable[..., dict] = _post) -> str:
+def openai_chat(
+    prompt: str, *, api_key: str, model: str = OPENAI_MODEL,
+    post: Callable[..., dict] = _post,
+) -> str:
     """Draft via the OpenAI chat-completions API. Requires OPENAI_API_KEY."""
     payload = post(
         OPENAI_ENDPOINT,
         headers={"Authorization": f"Bearer {api_key}"},
         json_body={
-            "model": OPENAI_MODEL,
+            "model": model,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": 0.2,
         },
@@ -250,7 +301,10 @@ def openai_chat(prompt: str, *, api_key: str, post: Callable[..., dict] = _post)
     return _chat_completion_text(payload, "OpenAI")
 
 
-def gemini_generate(prompt: str, *, api_key: str, post: Callable[..., dict] = _post) -> str:
+def gemini_generate(
+    prompt: str, *, api_key: str, model: str = GEMINI_MODEL,
+    post: Callable[..., dict] = _post,
+) -> str:
     """Draft via the Gemini generateContent API. Requires GEMINI_API_KEY.
 
     The key goes in the `x-goog-api-key` header rather than the `?key=` query
@@ -258,7 +312,7 @@ def gemini_generate(prompt: str, *, api_key: str, post: Callable[..., dict] = _p
     credential out of request logs, proxy logs and error messages.
     """
     payload = post(
-        GEMINI_ENDPOINT.format(model=GEMINI_MODEL),
+        GEMINI_ENDPOINT.format(model=model),
         headers={"x-goog-api-key": api_key},
         json_body={
             "contents": [{"parts": [{"text": prompt}]}],
@@ -292,6 +346,13 @@ PROVIDERS: dict[str, tuple[str, Callable[..., str]]] = {
 # answers 410 during its brownout, so it is only ever a last resort.
 PROVIDER_ORDER = ("anthropic", "gemini", "openai", "github-models")
 
+_DEFAULT_MODELS = {
+    "anthropic": ANTHROPIC_MODEL,
+    "gemini": GEMINI_MODEL,
+    "openai": OPENAI_MODEL,
+    "github-models": MODEL,
+}
+
 # What people actually type.
 _ALIASES = {
     "google": "gemini",
@@ -304,6 +365,14 @@ _ALIASES = {
     "github-models": "github-models",
     "githubmodels": "github-models",
 }
+
+
+def model_for(provider: str, env: dict) -> str:
+    """The model to use, honouring a LEX_NOTES_MODEL override."""
+    override = (env.get("LEX_NOTES_MODEL") or "").strip()
+    if override:
+        return override
+    return _DEFAULT_MODELS[provider]
 
 
 def resolve_provider(
@@ -333,12 +402,12 @@ def resolve_provider(
             raise ValueError(
                 f"notes provider {resolved!r} was requested but {env_key} is not set"
             )
-        return resolved, functools.partial(call, api_key=api_key)
+        return resolved, functools.partial(call, api_key=api_key, model=model_for(resolved, env))
 
     for candidate in PROVIDER_ORDER:
         env_key, call = PROVIDERS[candidate]
         api_key = env.get(env_key, "")
         if api_key:
-            return candidate, functools.partial(call, api_key=api_key)
+            return candidate, functools.partial(call, api_key=api_key, model=model_for(candidate, env))
 
     return None

--- a/.github/scripts/tests/test_release_notes_digest.py
+++ b/.github/scripts/tests/test_release_notes_digest.py
@@ -190,3 +190,34 @@ def test_the_same_pr_number_in_each_repo_stays_separate():
     got = digest.build_digest("v2.1.7", "v2.1.6", back, front)
     assert len(got["changes"]) == 2
     assert {c["component"] for c in got["changes"]} == {"backend", "frontend"}
+
+
+# ── Internal-vs-user-facing classification ────────────────────────────
+
+def test_housekeeping_types_are_flagged_internal():
+    for t in ("ci", "build", "chore", "test", "docs"):
+        assert digest.is_internal(t, None) is True, t
+
+
+def test_toolchain_scopes_are_flagged_internal_whatever_the_type():
+    # feat(release-notes) is a feature *of our pipeline*, not of LEX. Read as
+    # a product change it becomes "LEX can now connect to Gemini" — which is
+    # what v2.1.7rc1 actually published.
+    for scope in ("release-notes", "test-plan", "ci", "gate", "showcase", "plan", "spec"):
+        assert digest.is_internal("feat", scope) is True, scope
+
+
+def test_product_changes_are_not_flagged_internal():
+    for typ, scope in (("fix", "auth"), ("fix", "calc"), ("feat", "grid"), ("fix", "proxy")):
+        assert digest.is_internal(typ, scope) is False, (typ, scope)
+
+
+def test_the_digest_carries_the_flag():
+    commits = [
+        digest.Commit(sha="aaa", subject="feat(release-notes): pluggable providers"),
+        digest.Commit(sha="bbb", subject="fix(auth): renew the embedded token"),
+    ]
+    got = digest.build_digest("v2.1.7", "v2.1.6", commits, [])
+    by_scope = {c["scope"]: c["internal"] for c in got["changes"]}
+    assert by_scope["release-notes"] is True
+    assert by_scope["auth"] is False

--- a/.github/scripts/tests/test_release_notes_notes.py
+++ b/.github/scripts/tests/test_release_notes_notes.py
@@ -250,3 +250,72 @@ def test_the_resolved_callable_actually_reaches_its_transport():
     _, call = notes.resolve_provider("gemini", {"GEMINI_API_KEY": "g-key"})
     payload = {"candidates": [{"content": {"parts": [{"text": "VIA REGISTRY"}]}}]}
     assert call("P", post=lambda u, *, headers, json_body: payload) == "VIA REGISTRY"
+
+
+# ── Prompt guardrails ─────────────────────────────────────────────────
+#
+# These pin the instructions that stop the drafter announcing our toolchain as
+# a product feature. v2.1.7rc1 published "LEX can now connect to Gemini and
+# OpenAI" from a commit about the release-note drafter. Deleting any of these
+# lines re-opens that door, so the tests fail loudly if they go.
+
+def test_prompt_states_what_lex_is():
+    prompt = notes.build_prompt(_digest(), exemplar="X")
+    assert "WHAT LEX IS" in prompt
+    assert "never seen the source code" in prompt
+
+
+def test_prompt_forbids_promoting_internal_work_to_features():
+    prompt = notes.build_prompt(_digest(), exemplar="X")
+    assert '"internal": true' in prompt
+    assert "Leave them out." in prompt
+    # The actual failure, kept in the prompt as a worked example. Collapse
+    # whitespace first: the instructions are hard-wrapped, so the phrase spans
+    # a line break in the source.
+    flat = " ".join(prompt.split())
+    assert "LEX can now connect to Gemini and OpenAI" in flat
+    assert "that is our machinery, not the product" in flat
+
+
+def test_prompt_permits_an_empty_release():
+    prompt = notes.build_prompt(_digest(), exemplar="X")
+    assert "No user-facing changes in this release." in prompt
+    assert "Do not pad a thin release" in prompt
+
+
+def test_prompt_requires_merging_duplicate_user_visible_changes():
+    prompt = notes.build_prompt(_digest(), exemplar="X")
+    assert "Merge entries describing the same user-visible change" in prompt
+
+
+def test_the_internal_flag_reaches_the_prompt():
+    d = {"tag": "v1", "previous_tag": None, "changes": [
+        {"sha": "a", "component": "backend", "type": "feat", "scope": "release-notes",
+         "breaking": False, "subject": "pluggable providers", "pr_number": 1, "internal": True},
+    ]}
+    assert '"internal": true' in notes.build_prompt(d, exemplar="X").lower()
+
+
+# ── Model selection ───────────────────────────────────────────────────
+
+def test_default_model_per_provider():
+    assert notes.model_for("gemini", {}) == notes.GEMINI_MODEL
+    assert notes.model_for("anthropic", {}) == notes.ANTHROPIC_MODEL
+
+
+def test_lex_notes_model_overrides_the_default():
+    assert notes.model_for("gemini", {"LEX_NOTES_MODEL": "gemini-3-ultra"}) == "gemini-3-ultra"
+
+
+def test_the_resolved_callable_carries_the_overridden_model():
+    captured = {}
+
+    def fake_post(url, *, headers, json_body):
+        captured.update(url=url)
+        return {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}
+
+    _, call = notes.resolve_provider(
+        "gemini", {"GEMINI_API_KEY": "k", "LEX_NOTES_MODEL": "gemini-3-ultra"}
+    )
+    call("P", post=fake_post)
+    assert "gemini-3-ultra" in captured["url"]

--- a/.github/workflows/prerelease_gate.yml
+++ b/.github/workflows/prerelease_gate.yml
@@ -212,6 +212,10 @@ jobs:
           # With none of them, drafting fails open with a visible notice rather
           # than blocking the release.
           LEX_NOTES_PROVIDER: ${{ vars.LEX_NOTES_PROVIDER || secrets.LEX_NOTES_PROVIDER }}
+          # Optional: override the model for whichever provider is chosen.
+          # Defaults are the reasoning tier, not the fast tier — deciding
+          # what is user-facing and what to merge is judgement work.
+          LEX_NOTES_MODEL: ${{ vars.LEX_NOTES_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
`v2.1.7rc1` shipped this:

> **New AI model providers.** LEX can now connect to Gemini and OpenAI, allowing you to integrate with a wider range of large language models for your applications.

**LEX gained no such capability.** That came from `feat(release-notes): pluggable model provider, with Gemini and OpenAI` — a change to the release-note drafter itself. The model read our machinery as the product and announced a feature that does not exist.

That is the worst failure this pipeline has. Duplicate lines are ugly; an invented capability is a false claim to customers.

## Why

The digest was **eight parts internal tooling out of eleven** — five entries scoped `release-notes`, plus CI and build work. The prompt never said what LEX is, never said to omit internal changes, and demanded a `## Main changes` section. With nothing user-facing to put there, the model manufactured something.

The other symptoms share that root: two bullets describing the same embedded-auth fix, and copy like "providing a more seamless experience" where the 2.1.3 exemplar is concrete.

## What changed

**Digest entries carry an `internal` flag** — housekeeping types plus toolchain scopes (`release-notes`, `test-plan`, `ci`, `gate`, `showcase`, `setup-with-ai`…). They stay in `CHANGELOG.md`, which records everything that shipped, but the drafter is told to leave them out. On that release the flag catches 6 of 11; the prompt handles the rest by judgement, since scopes like `design-system` are genuinely ambiguous.

**The prompt was rewritten.** It opens with what LEX is and who reads the notes, so the model can tell product from toolchain. It forbids describing our own tooling as a capability, quoting the actual failure as a worked example. And it explicitly permits:

> No user-facing changes in this release. This release contains internal improvements to how LEX is built and released.

as a complete answer. **Removing the pressure to fill a section is what stops the invention.** It also requires merging entries about the same user-visible change, and bans the filler vocabulary.

**Gemini's default moves `2.5-flash` → `2.5-pro`,** with `LEX_NOTES_MODEL` overriding the model for any provider. Deciding what is user-facing and what to merge is judgement work, not summarisation — the fast tier was the wrong tool.

## Caveat

I cannot verify the improved prose without a key, so the proof is the next run. What I can say is that each specific defect now has a specific countermeasure, and eight new tests pin the guardrails so they cannot be quietly deleted.

Judge the next draft against `docs/releases/RELEASE_NOTES_2.1.3_github.md`. For a release this internal, a two-line "no user-facing changes" note is the **correct** output, not a disappointing one.

253 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)