### PR TITLE
fix(release-notes): draft from PR bodies, and stop announcing our toolchain as a feature

### DIFF
--- a/.github/scripts/release_notes/digest.py
+++ b/.github/scripts/release_notes/digest.py
@@ -71,6 +71,7 @@ class Commit:
     subject: str
     pr_number: int | None = None
     pr_title: str | None = None
+    pr_body: str | None = None
 
 
 # Commits that are real work but say nothing about the shipped product.
@@ -96,6 +97,40 @@ def is_internal(type_: str, scope: str | None) -> bool:
     return (scope or "").strip().lower() in INTERNAL_SCOPES
 
 
+# How much of a PR body to carry per change. Bodies in this repository are
+# essays — #675 explains the user-visible symptom ("I triggered a calculation
+# and edited_at was updated") that its nine-word subject cannot. That sentence
+# is what a release note needs, and the author already wrote it.
+PR_BODY_LIMIT = 4000
+
+_TRAILER_MARKERS = (
+    "Co-Authored-By:",
+    "🤖 Generated with",
+    "Signed-off-by:",
+)
+
+
+def summarise_body(body: str | None) -> str:
+    """Trim a PR body down to the part worth putting in a prompt."""
+    if not body:
+        return ""
+
+    text = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+
+    lines: list[str] = []
+    for line in text.splitlines():
+        if any(line.lstrip().startswith(m) for m in _TRAILER_MARKERS):
+            continue
+        lines.append(line)
+
+    cleaned = "\n".join(lines).strip()
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+
+    if len(cleaned) > PR_BODY_LIMIT:
+        cleaned = cleaned[:PR_BODY_LIMIT].rstrip() + "…[truncated]"
+    return cleaned
+
+
 def is_noise(subject: str) -> bool:
     """True for commits that must never reach a changelog."""
     subject = (subject or "").strip()
@@ -114,6 +149,7 @@ def _entry(commit: Commit, component: str) -> dict:
     # conform. Enrichment is what makes the input usable at that number.
     subject = commit.pr_title or commit.subject
     parsed = parse_subject(subject)
+    internal = is_internal(parsed.type, parsed.scope)
     return {
         "sha": commit.sha,
         "component": component,
@@ -122,7 +158,10 @@ def _entry(commit: Commit, component: str) -> dict:
         "breaking": parsed.breaking,
         "subject": parsed.subject,
         "pr_number": commit.pr_number,
-        "internal": is_internal(parsed.type, parsed.scope),
+        "internal": internal,
+        # Internal changes are omitted from the note, so their bodies would be
+        # pure prompt cost. They keep their line in the changelog either way.
+        "detail": "" if internal else summarise_body(commit.pr_body),
     }
 
 
@@ -198,11 +237,11 @@ def collect_commits(
 # commit conformance depends on.
 _PR_JQ = (
     "[.[] | select(.merged_at != null)] + . "
-    "| .[0] | select(. != null) | [.number, .title] | @json"
+    "| .[0] | select(. != null) | [.number, .title, (.body // \"\")] | @json"
 )
 
 
-def _lookup_pr(sha: str) -> tuple[int, str] | None:
+def _lookup_pr(sha: str) -> tuple[int, str, str] | None:
     """The PR a commit belongs to, via the GitHub API. Merged ones win."""
     result = subprocess.run(
         ["gh", "api", f"repos/{{owner}}/{{repo}}/commits/{sha}/pulls",
@@ -213,14 +252,14 @@ def _lookup_pr(sha: str) -> tuple[int, str] | None:
     )
     if result.returncode != 0 or not result.stdout.strip():
         return None
-    number, title = json.loads(result.stdout.strip())
-    return int(number), title
+    number, title, body = json.loads(result.stdout.strip())
+    return int(number), title, body
 
 
 def enrich_with_prs(
     commits: list[Commit],
     *,
-    lookup: Callable[[str], tuple[int, str] | None] = _lookup_pr,
+    lookup: Callable[[str], tuple[int, str, str] | None] = _lookup_pr,
 ) -> list[Commit]:
     """Attach PR number and title where a commit came through a PR.
 
@@ -243,9 +282,12 @@ def enrich_with_prs(
             enriched.append(commit)
         else:
             hits += 1
-            number, title = found
+            number, title, body = found
             enriched.append(
-                Commit(sha=commit.sha, subject=commit.subject, pr_number=number, pr_title=title)
+                Commit(
+                    sha=commit.sha, subject=commit.subject,
+                    pr_number=number, pr_title=title, pr_body=body,
+                )
             )
     if commits:
         print(f"PR enrichment: {hits}/{len(commits)} commits matched a pull request.",

--- a/.github/scripts/release_notes/notes.py
+++ b/.github/scripts/release_notes/notes.py
@@ -106,6 +106,22 @@ That is a correct and complete answer. Do not pad a thin release by promoting
 internal work into features. A short honest note is worth more than a long
 invented one.
 
+WHAT YOU ARE GIVEN
+Each entry has a "subject" — one line, written for reviewers — and a "detail",
+which is the author's own explanation from the pull request. **Base your
+description on the detail, not the subject.** The subject says what was
+changed; the detail usually says what was wrong, what a user experienced, and
+what they will experience now. That is the release note.
+
+The detail is written for engineers. Take the user-visible facts from it and
+leave the internals behind: read past the root-cause analysis and file names to
+the symptom and the outcome. If the detail describes something a user never
+sees, that entry probably does not belong in the note at all.
+
+Where an entry has no detail, say only what the subject supports. Do not
+invent specifics to fill the gap — a thin bullet is better than a confident
+wrong one.
+
 FORMAT
 Use only these headings, in this order, and only when you have entries for them:
 "## Main changes" (new capability), "## Optimizations" (existing things now
@@ -150,13 +166,44 @@ Return only the markdown release note. No preamble, no explanation.
 """
 
 
+# Matches the budget the Copilot test-bot prompt uses in
+# .github/scripts/copilot_assemble_prompt.py. Well inside every provider's
+# context window; the cap exists to stop an unusually large release quietly
+# turning into an expensive or truncated request.
+MAX_PROMPT_BYTES = 60_000
+
+
 def build_prompt(digest: dict, *, exemplar: str) -> str:
-    """Assemble the model prompt from the digest and a style exemplar."""
-    return _INSTRUCTIONS.format(
-        exemplar=exemplar,
-        tag=digest["tag"],
-        digest=json.dumps(digest["changes"], indent=2),
+    """Assemble the model prompt from the digest and a style exemplar.
+
+    Entries carry the author's PR body in "detail". That is the material the
+    note is actually written from — a subject line alone makes the model invent
+    specifics, which is how "renew the embedded Streamlit token" became a claim
+    about automatic session renewal that nobody had verified.
+    """
+    changes = digest["changes"]
+    prompt = _INSTRUCTIONS.format(
+        exemplar=exemplar, tag=digest["tag"],
+        digest=json.dumps(changes, indent=2),
     )
+
+    if len(prompt.encode("utf-8")) <= MAX_PROMPT_BYTES:
+        return prompt
+
+    # Over budget: shorten details, longest first, so one enormous PR body
+    # cannot crowd out every other change. Internal entries already have none.
+    trimmed = [dict(c) for c in changes]
+    for limit in (2000, 1000, 400, 0):
+        for entry in trimmed:
+            if len(entry.get("detail", "")) > limit:
+                entry["detail"] = entry["detail"][:limit].rstrip() + "…[truncated]" if limit else ""
+        prompt = _INSTRUCTIONS.format(
+            exemplar=exemplar, tag=digest["tag"],
+            digest=json.dumps(trimmed, indent=2),
+        )
+        if len(prompt.encode("utf-8")) <= MAX_PROMPT_BYTES:
+            break
+    return prompt
 
 
 def validate(text: str) -> str | None:

--- a/.github/scripts/tests/test_release_notes_digest.py
+++ b/.github/scripts/tests/test_release_notes_digest.py
@@ -123,7 +123,8 @@ def test_enrich_prefers_the_pr_title():
 
     def fake_lookup(sha: str):
         assert sha == "705850d"
-        return (675, "fix(calc): never stamp edited_at for a calculation-owned save")
+        return (675, "fix(calc): never stamp edited_at for a calculation-owned save",
+                "## Why\n\nedited_at records the last user edit.")
 
     got = digest.enrich_with_prs(commits, lookup=fake_lookup)
     assert got[0].pr_number == 675
@@ -221,3 +222,57 @@ def test_the_digest_carries_the_flag():
     by_scope = {c["scope"]: c["internal"] for c in got["changes"]}
     assert by_scope["release-notes"] is True
     assert by_scope["auth"] is False
+
+
+# ── PR bodies as context ──────────────────────────────────────────────
+#
+# Subjects alone make the drafter invent detail. "renew the embedded Streamlit
+# token instead of prompting re-login" is nine words; its PR body explains that
+# embedded sessions previously died at the original deadline regardless. That
+# is the sentence a reader needs, and the author already wrote it.
+
+def test_the_pr_body_reaches_the_entry():
+    commits = [digest.Commit(sha="aaa", subject="fix(auth): renew the token",
+                             pr_number=678, pr_title="fix(auth): renew the token",
+                             pr_body="## Why\n\nSessions died at the original deadline.")]
+    got = digest.build_digest("v1", None, commits, [])
+    assert "died at the original deadline" in got["changes"][0]["detail"]
+
+
+def test_a_long_body_is_truncated_with_a_marker():
+    body = "x" * (digest.PR_BODY_LIMIT + 500)
+    commits = [digest.Commit(sha="a", subject="fix(auth): x", pr_number=1,
+                             pr_title="fix(auth): x", pr_body=body)]
+    got = digest.build_digest("v1", None, commits, [])
+    detail = got["changes"][0]["detail"]
+    assert len(detail) <= digest.PR_BODY_LIMIT + 40
+    assert detail.endswith("…[truncated]")
+
+
+def test_internal_changes_carry_no_body():
+    # They are omitted from the note, so their bodies are pure prompt cost.
+    commits = [digest.Commit(sha="a", subject="feat(release-notes): providers",
+                             pr_number=1, pr_title="feat(release-notes): providers",
+                             pr_body="A very long explanation of our CI tooling.")]
+    got = digest.build_digest("v1", None, commits, [])
+    assert got["changes"][0]["internal"] is True
+    assert got["changes"][0]["detail"] == ""
+
+
+def test_a_change_without_a_pr_body_has_an_empty_detail():
+    commits = [digest.Commit(sha="a", subject="fix(auth): direct push")]
+    got = digest.build_digest("v1", None, commits, [])
+    assert got["changes"][0]["detail"] == ""
+
+
+def test_html_comments_and_trailers_are_stripped_from_the_body():
+    body = ("## Why\n\nReal content.\n\n<!-- a template comment -->\n"
+            "🤖 Generated with [Claude Code](https://claude.com/claude-code)\n"
+            "Co-Authored-By: Someone <x@y.z>\n")
+    commits = [digest.Commit(sha="a", subject="fix(auth): x", pr_number=1,
+                             pr_title="fix(auth): x", pr_body=body)]
+    detail = digest.build_digest("v1", None, commits, [])["changes"][0]["detail"]
+    assert "Real content." in detail
+    assert "template comment" not in detail
+    assert "Co-Authored-By" not in detail
+    assert "Generated with" not in detail

--- a/.github/scripts/tests/test_release_notes_notes.py
+++ b/.github/scripts/tests/test_release_notes_notes.py
@@ -319,3 +319,34 @@ def test_the_resolved_callable_carries_the_overridden_model():
     )
     call("P", post=fake_post)
     assert "gemini-3-ultra" in captured["url"]
+
+
+def test_prompt_tells_the_model_to_write_from_the_detail():
+    flat = " ".join(notes.build_prompt(_digest(), exemplar="X").split())
+    assert "Base your description on the detail, not the subject." in flat
+    assert "Do not invent specifics to fill the gap" in flat
+
+
+def test_prompt_includes_the_detail_text():
+    d = {"tag": "v1", "previous_tag": None, "changes": [
+        {"sha": "a", "component": "backend", "type": "fix", "scope": "auth",
+         "breaking": False, "subject": "renew the token", "pr_number": 678,
+         "internal": False, "detail": "Sessions died at the original deadline."},
+    ]}
+    assert "Sessions died at the original deadline." in notes.build_prompt(d, exemplar="X")
+
+
+def test_an_oversized_digest_is_trimmed_into_budget():
+    changes = [
+        {"sha": f"{i}", "component": "backend", "type": "fix", "scope": "auth",
+         "breaking": False, "subject": f"fix {i}", "pr_number": i,
+         "internal": False, "detail": "y" * 9000}
+        for i in range(20)
+    ]
+    prompt = notes.build_prompt(
+        {"tag": "v1", "previous_tag": None, "changes": changes}, exemplar="X"
+    )
+    assert len(prompt.encode("utf-8")) <= notes.MAX_PROMPT_BYTES
+    # Still describes every change, just more briefly.
+    for i in range(20):
+        assert f"fix {i}" in prompt


### PR DESCRIPTION
Supersedes #701, which the branch ruleset would not let me update in place. Contains both commits.

Two rounds of bad output from `v2.1.7rc1`, with one root cause between them: **the drafter was describing changes it had never seen.**

## Round one: an invented feature

> **New AI model providers.** LEX can now connect to Gemini and OpenAI…

That came from `feat(release-notes): pluggable model provider` — a change to *this drafter*. The digest was eight parts internal tooling out of eleven, the prompt demanded a `## Main changes` section, and the model filled it by inventing.

Fixed by flagging toolchain work `internal` in the digest (kept in `CHANGELOG.md`, omitted from the note), telling the prompt what LEX is and who reads it, and — the load-bearing part — explicitly permitting *"No user-facing changes in this release"* as a complete answer. Removing the pressure to fill a section is what stops the invention.

## Round two: accurate but hollow

> In embedded applications, your session is renewed automatically without you needing to log in again.

Better — nothing fabricated, duplicates merged — but the specifics were extrapolated from a nine-word subject. That was the entire input.

**The other two pipelines in this repo already knew better:**

| pipeline | context it sends |
|---|---|
| docs receiver | commit log + diffstat + 800 lines of real diff, 45k budget |
| Copilot test-bot | test-plan docs, 60KB budget, *"read `docs/features/` for intent, not just the code"* |
| release notes | ~500 chars of subject lines |

Enrichment was already fetching each PR. It kept the title and **threw the body away**.

Bodies here are essays. #675 records the actual user report — *"I triggered a calculation and `edited_at` was updated"* — and that an interrupted run leaves a stale stamp on an `ABORTED` record. #678 explains that embedded sessions previously **died at the original deadline regardless**. That is the release note, already written by the person who made the change.

Entries now carry `detail`: the PR body with HTML comments and trailers stripped, capped at 4000 chars. Internal changes carry none — they are omitted anyway, so their bodies are pure prompt cost.

**For `v2.1.7rc1`: 17,233 characters of author-written explanation, where there were a few hundred.**

The prompt is told to write from the detail rather than the subject, to take the symptom and outcome and leave the root-cause analysis behind, and to stay thin rather than invent where an entry has no detail. Budgeted at 60KB — matching the test-bot — trimming longest-first so one large PR cannot crowd out the rest. The real prompt for that release comes to 30,184 bytes.

Also: Gemini `2.5-flash` → `2.5-pro`, with `LEX_NOTES_MODEL` to override per provider. This stopped being summarisation when it started requiring judgement about what counts as user-facing.

## Caveat

I have no key, so I cannot see the improved prose — the next run is the proof. Eleven new tests pin the guardrails and the context plumbing so neither can be quietly undone.

261 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)