### PR TITLE
fix(gate): unbreak the prerelease gate's 1.107 CLI-help contract

### DIFF
--- a/.github/scripts/showcase_clusters.py
+++ b/.github/scripts/showcase_clusters.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass, field
 from showcase_test_descriptions import (  # noqa: E402
     CRUD_API_TESTS,
     EXPORTS_TESTS,
+    INIT_TESTS,
     PERMISSIONS_TESTS,
     QUERIES_TESTS,
     SERIALIZERS_TESTS,
@@ -191,7 +192,8 @@ CLUSTERS: tuple[Cluster, ...] = (
         why_it_matters=(
             "Day-one onboarding is the single highest-risk moment in "
             "the customer journey."
-        )
+        ),
+        test_descriptions=INIT_TESTS,
     ),
     Cluster(
         key="crud_api",

--- a/.github/scripts/showcase_test_descriptions.py
+++ b/.github/scripts/showcase_test_descriptions.py
@@ -25,9 +25,11 @@ Coverage status (5 May 2026)
   (kept inline; populated first as the gate-critical clusters).
 * permissions, signals_ws, exports, serializers, queries, crud_api —
   covered here.
-* Other clusters (init, calculations, history, audit_logging,
-  api_layer, stress) fall back to a generic "engineering: add a
-  description in this file" line in the report.
+* init — the CLI-contract scenarios (sub-cluster 1m) are covered here;
+  the rest of the cluster still falls back.
+* Other clusters (calculations, history, audit_logging, api_layer,
+  stress) fall back to a generic "engineering: add a description in
+  this file" line in the report.
 """
 
 from __future__ import annotations
@@ -533,3 +535,38 @@ SERIALIZERS_TESTS: dict[str, str] = {
         "regression from the wrapping process.",
 }
 
+
+# ── init ─────────────────────────────────────────────────────────────
+# Sub-cluster 1m is the operator-facing CLI contract: the run
+# configurations `lex setup` writes into PyCharm must each invoke a
+# subcommand the `lex` CLI actually resolves, and `lex --help` must
+# advertise those subcommands under the spelling an operator types.
+INIT_TESTS: dict[str, str] = {
+    "test_1_102_scaffold_produces_complete_run_file_set":
+        "Setting up a project writes the full set of one-click run configurations — "
+        "every engineer's tray looks the same on every machine.",
+    "test_1_103_every_run_xml_uses_lex_script":
+        "Every generated run configuration invokes the platform CLI rather than a stray "
+        "script, so the environment is prepared the same way each time.",
+    "test_1_104_every_run_subcommand_resolves":
+        "Every one-click run configuration points at a command that really exists. If broken, "
+        "an operator clicks a button in their IDE and gets 'no such command'.",
+    "test_1_105_explicit_commands_are_all_registered":
+        "The commands the platform's tooling and documentation depend on are all still "
+        "registered. If broken, a rename has silently retired a command people rely on.",
+    "test_1_106_skip_bootstrap_set_matches_explicit_handlers":
+        "The list of commands allowed to start without a full application boot only names "
+        "real commands, so no command quietly takes the slow path.",
+    "test_1_107_lex_root_help_lists_explicit_commands":
+        "Running the CLI's help lists every command an operator is meant to type. If broken, "
+        "a working command is undiscoverable to anyone who didn't already know its name.",
+    "test_1_107b_deprecated_aliases_stay_out_of_root_help":
+        "Older spellings kept alive for existing documentation still run, but stay out of the "
+        "help listing so each command is advertised exactly once.",
+    "test_1_108_each_explicit_subcommand_help_exits_zero":
+        "Every command answers '--help' cleanly. If broken, a command is mis-declared and will "
+        "fail the moment someone runs it.",
+    "test_1_109_every_delegated_command_is_a_real_django_command":
+        "Run configurations that hand off to the underlying application framework name commands "
+        "it actually knows, so operators get real work instead of a confusing error.",
+}

--- a/.github/scripts/tests/test_prompt_surface_parity.py
+++ b/.github/scripts/tests/test_prompt_surface_parity.py
@@ -1,23 +1,30 @@
 """Drift guard: every agent front-end must share ONE surface-enumeration rule.
 
-There are four prompt surfaces that tell an agent how to decompose a change into
+These are the prompt surfaces that tell an agent how to decompose a change into
 test surfaces and clusters:
 
   1. `lex/test_project/test-plan/progress/conventions.md` — the **canonical**
      source. The cloud Copilot prompt inlines this file verbatim
      (see `copilot_assemble_prompt.assemble_prompt`), so whatever lands here is
      what the cloud agent reads.
-  2. `.github/instructions/testing.instructions.md` — VS Code Copilot / cloud IDE.
-  3. `.claude/skills/lex-testing/SKILL.md` — Claude Code skill.
-  4. `AGENTS.md` — JetBrains Copilot / Cursor / Codex (load-bearing in PyCharm).
+  2. `.claude/skills/lex-testing/SKILL.md` — Claude Code skill.
+  3. `AGENTS.md` — JetBrains Copilot / Cursor / Codex (load-bearing in PyCharm).
+
+`.github/instructions/testing.instructions.md` (VS Code Copilot / cloud IDE) was
+a fourth surface until `.github/instructions/` and `.github/agents/` were removed
+wholesale; AGENTS.md is what those front-ends read now. A guard that keeps
+checking a file nobody ships fails on every run and says nothing about drift, so
+the surface is off the list rather than pinned at a path that does not exist.
+`_surface_text` below turns any *future* deletion into that same conversation —
+an explicit "update SURFACES" failure instead of a bare FileNotFoundError.
 
 These drifted once: the cloud assembler taught a weaker "primary/secondary"
 decomposition while the local surfaces taught full surface enumeration, and none
 of them taught the *execution-path* dimension — which is why an agent enumerated
 the entry points of a feature but missed that one operation can run by more than
 one route, each route its own surface. This test pins that the shared rule — and
-specifically its execution-path clause — is present in all four, so the cloud and
-local paths can never silently diverge again.
+specifically its execution-path clause — is present in every surface, so the
+cloud and local paths can never silently diverge again.
 """
 
 from __future__ import annotations
@@ -32,10 +39,25 @@ CANONICAL = REPO_ROOT / "lex" / "test_project" / "test-plan" / "progress" / "con
 
 SURFACES = {
     "conventions.md (canonical)": CANONICAL,
-    "testing.instructions.md": REPO_ROOT / ".github" / "instructions" / "testing.instructions.md",
     "lex-testing SKILL.md": REPO_ROOT / ".claude" / "skills" / "lex-testing" / "SKILL.md",
     "AGENTS.md": REPO_ROOT / "AGENTS.md",
 }
+
+
+def _surface_text(name: str) -> str:
+    """Read a surface, failing with the actionable message when it is gone.
+
+    A retired surface should be dropped from ``SURFACES`` in the same change
+    that deletes the file. If it isn't, this says so — a raw FileNotFoundError
+    reads like a broken checkout rather than a stale guard.
+    """
+    path = SURFACES[name]
+    assert path.is_file(), (
+        f"{name} is listed as a prompt surface but {path.relative_to(REPO_ROOT)} "
+        f"does not exist. If the surface was retired on purpose, remove it from "
+        f"SURFACES; otherwise restore the file."
+    )
+    return path.read_text()
 
 
 def test_canonical_source_owns_the_surface_rule() -> None:
@@ -55,16 +77,15 @@ def test_canonical_source_owns_the_surface_rule() -> None:
 
 @pytest.mark.parametrize("name", list(SURFACES))
 def test_every_surface_carries_the_execution_path_rule(name: str) -> None:
-    """All four agent front-ends must teach the execution-path surface dimension.
+    """Every agent front-end must teach the execution-path surface dimension.
     If any one drops or never gained it, cloud and local agents drift — exactly
     the failure this guard exists to prevent."""
-    path = SURFACES[name]
-    text = path.read_text().lower()
+    text = _surface_text(name).lower()
     assert "execution path" in text, (
         f"{name} is missing the execution-path surface rule. Every prompt surface "
         f"must teach it (one operation may run by more than one route; each route is "
-        f"its own surface). Update {path.relative_to(REPO_ROOT)} to match the "
-        f"canonical rule in conventions.md."
+        f"its own surface). Update {SURFACES[name].relative_to(REPO_ROOT)} to match "
+        f"the canonical rule in conventions.md."
     )
 
 
@@ -72,10 +93,10 @@ def test_every_surface_carries_the_execution_path_rule(name: str) -> None:
 def test_local_surfaces_point_at_the_canonical_source(name: str) -> None:
     """Each local surface must name conventions.md as the authoritative source, so
     future edits have one obvious home and reviewers know the satellites mirror it."""
-    text = SURFACES[name].read_text()
+    text = _surface_text(name)
     assert "conventions.md" in text, (
         f"{name} must reference conventions.md as the canonical source of the "
-        f"surface rule, so the four surfaces stay anchored to one source of truth."
+        f"surface rule, so every surface stays anchored to one source of truth."
     )
 
 

--- a/lex/test_project/test-plan/clusters/14-queries/cluster.md
+++ b/lex/test_project/test-plan/clusters/14-queries/cluster.md
@@ -475,13 +475,14 @@ No broker, Redis, or database required.
 | 1.102 | Generated `.run.xml` set parity | Exactly the 16 expected files, no orphans, no missing — canary against "removed Test_Audit but constant still has it" drift |
 | 1.103 | Every `.run.xml` `SCRIPT_NAME` is `lex` | A copy-paste of a different binary cannot bypass the CLI's env handling / Django bootstrap |
 | 1.104 | First-token of every `.run.xml` `PARAMETERS` resolves | Either explicit `@lex.command(...)` Click handler OR registered Django management command — the cross-file contract that nothing else asserts |
-| 1.105 | Explicit Click registry pinned | `celery` / `celery-workers` / `flower` / `streamlit` / `start` / `setup` / `setup-with-ai` / `ai-update` / `ai-faq` — removing one is what would silently break a `.run.xml` |
+| 1.105 | Explicit Click registry pinned | `celery` / `celery-workers` / `flower` / `streamlit` / `start` / `setup` / `setup-with-ai` / `ai-update` / `ai-faq` / `ai-issue-report` (+ its `ai_issue_report` alias) — removing one is what would silently break a `.run.xml` |
 | 1.106 | `_SKIP_BOOTSTRAP_COMMANDS` is a subset of explicit registry | Otherwise listed names silently fall through to dynamic forwarding without `django.setup()` |
-| 1.107 | `lex --help` exits 0 and names every explicit command | Click group itself wired correctly |
+| 1.107 | `lex --help` exits 0 and names every explicit command an operator types | Click group itself wired correctly; deprecated `hidden=True` aliases are excluded (1.107b owns them) |
+| 1.107b | Deprecated spellings stay registered but out of the root help | A hidden alias (`ai_issue_report`) still runs for older docs, while `--help` advertises one spelling per command |
 | 1.108 | `lex <cmd> --help` exits 0 for every explicit handler | Catches decorator typos / signature regressions that `--help` surfaces but real runs would mask |
 | 1.109 | Every Django-side subcommand referenced by a `.run.xml` is registered | `init` / `migrate` / `makemigrations` / `flush` / `test` / `create_db` resolve through Django's command loader — otherwise dynamic forwarding produces a less-helpful error |
 
-**Status:**  Complete — 8 pass / 0 fail in 0.020s. See progress.md Session 40.
+**Status:**  Complete — 9 pass / 0 fail. See progress.md Session 40. 1.107 was split on 14 August 2026 when `ai-issue-report` became the canonical hyphenated spelling and the underscore became a hidden alias: the old assertion required the hidden spelling to appear in `lex --help`, which `hidden=True` guarantees it will not.
 
 ### 5g. History `valid_to` chaining contract  — implemented
 

--- a/lex/test_project/tests/init/test_1m_cli_commands.py
+++ b/lex/test_project/tests/init/test_1m_cli_commands.py
@@ -57,6 +57,30 @@ import pytest
 
 pytestmark = pytest.mark.init
 
+# Explicit ``@lex.command(...)`` names the framework depends on. Pinned
+# here so a rename that leaves a ``.run.xml`` (or the docs) behind fails
+# in CI rather than in the operator's PyCharm.
+EXPLICIT_COMMANDS = frozenset({
+    "celery",
+    "celery-workers",
+    "flower",
+    "streamlit",
+    "start",
+    "setup",
+    "setup-with-ai",
+    "ai-update",
+    "ai-faq",
+    "ai-issue-report",
+    "ai_issue_report",
+})
+
+# Deprecated spellings kept registered — and runnable — for people
+# following older docs and support macros, but registered with
+# ``hidden=True`` so ``lex --help`` advertises one spelling per command.
+HIDDEN_ALIASES = frozenset({
+    "ai_issue_report",
+})
+
 # ---------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------
@@ -234,18 +258,7 @@ class TestCluster01m_ExplicitClickCommands(TestCase):
     sees the breakage at the CLI source-file level.
     """
 
-    EXPECTED_EXPLICIT_COMMANDS = frozenset({
-        "celery",
-        "celery-workers",
-        "flower",
-        "streamlit",
-        "start",
-        "setup",
-        "setup-with-ai",
-        "ai-update",
-        "ai-faq",
-        "ai_issue_report",
-    })
+    EXPECTED_EXPLICIT_COMMANDS = EXPLICIT_COMMANDS
 
     def test_1_105_explicit_commands_are_all_registered(self):
         """1.105: every explicit Click handler we depend on is on the group."""
@@ -288,21 +301,16 @@ class TestCluster01m_HelpInvocability(TestCase):
     covers that side via ``django.core.management.get_commands``.
     """
 
-    EXPECTED_EXPLICIT_COMMANDS = frozenset({
-        "celery",
-        "celery-workers",
-        "flower",
-        "streamlit",
-        "start",
-        "setup",
-        "setup-with-ai",
-        "ai-update",
-        "ai-faq",
-        "ai_issue_report",
-    })
+    EXPECTED_EXPLICIT_COMMANDS = EXPLICIT_COMMANDS
 
     def test_1_107_lex_root_help_lists_explicit_commands(self):
-        """1.107: ``lex --help`` exits 0 and names every explicit command."""
+        """1.107: ``lex --help`` exits 0 and names every explicit command
+        an operator is meant to type.
+
+        Deprecated spellings (``HIDDEN_ALIASES``) are excluded: they stay
+        runnable — 1.108 proves that — but ``hidden=True`` keeps them out
+        of the listing so the help advertises one spelling per command.
+        """
         runner = CliRunner()
         result = runner.invoke(lex, ["--help"])
         self.assertEqual(
@@ -310,11 +318,34 @@ class TestCluster01m_HelpInvocability(TestCase):
             f"`lex --help` failed: exit={result.exit_code}\n"
             f"output: {result.output}",
         )
-        for name in self.EXPECTED_EXPLICIT_COMMANDS:
+        for name in self.EXPECTED_EXPLICIT_COMMANDS - HIDDEN_ALIASES:
             self.assertIn(
                 name, result.output,
                 f"`lex --help` does not mention {name!r}.",
             )
+
+    def test_1_107b_deprecated_aliases_stay_out_of_root_help(self):
+        """1.107b: hidden aliases are registered but not advertised.
+
+        Dropping ``hidden=True`` would list the same command twice under
+        two spellings, which is exactly the ambiguity the canonical
+        hyphenated names exist to remove.
+        """
+        runner = CliRunner()
+        result = runner.invoke(lex, ["--help"])
+        for name in HIDDEN_ALIASES:
+            with self.subTest(command=name):
+                self.assertIn(
+                    name, lex.commands,
+                    f"deprecated alias {name!r} is no longer registered — "
+                    f"drop it from HIDDEN_ALIASES/EXPLICIT_COMMANDS if the "
+                    f"spelling was retired on purpose.",
+                )
+                self.assertNotIn(
+                    name, result.output,
+                    f"`lex --help` lists the deprecated spelling {name!r}; "
+                    f"register it with hidden=True.",
+                )
 
     def test_1_108_each_explicit_subcommand_help_exits_zero(self):
         """1.108: ``lex <cmd> --help`` exits 0 for every explicit handler.


### PR DESCRIPTION
Two CI surfaces are red on `lex-app-v2`, both from the same commit (`3584c64`) leaving a guard behind. This fixes each at the assertion, not by weakening it.

## 1. Prerelease gate — `init` / 1.107

[Run 31786676975](https://github.com/ExcellenceCloudGmbH/lex-app/actions/runs/31786676975): 1268/1279 scenarios passing, one hard failure.

```
AssertionError: 'ai_issue_report' not found in 'Usage: root [OPTIONS] ...
```

`3584c64` made `ai-issue-report` the canonical spelling and kept the underscore as a `hidden=True` alias. `hidden=True` means Click omits it from `lex --help` — by design, so the help advertises one spelling per command. **The CLI is correct; the assertion was left behind by the rename** and could never pass again.

- 1.107 now checks the spellings an operator is meant to type (`EXPLICIT_COMMANDS - HIDDEN_ALIASES`).
- Simply dropping the alias from that assertion would have quietly dropped its coverage, so **1.107b** picks it up from the other side: the alias must stay *registered* — existing docs and support macros tell people to type it — while staying *out* of the help. Both halves of `hidden=True` are pinned now.
- `EXPECTED_EXPLICIT_COMMANDS` existed twice verbatim in two classes; hoisted to one module-level constant. Added `ai-issue-report` to it — 1.105 was pinning only the alias, so the canonical spelling could have been renamed with nothing failing.

Verified against click 8.3.1: `'ai_issue_report' in help` is `False`, `'ai-issue-report'` is `True`, the alias is registered, and `lex ai_issue_report --help` exits 0.

## 2. Script Tests — parity guard

[Run 31786676438](https://github.com/ExcellenceCloudGmbH/lex-app/actions/runs/31786676438), red since the same commit removed `.github/instructions/` and `.github/agents/` wholesale. The parity guard still listed `testing.instructions.md` as one of four required prompt surfaces, so two parametrised cases died on `FileNotFoundError` every run — a guard checking a file nobody ships fails constantly and says nothing about drift.

The surface is off the list rather than pinned at a path that does not exist; `AGENTS.md` is what those front-ends read now and is already guarded. `_surface_text()` turns the *next* deletion into the same conversation instead of the same crash: a listed-but-missing surface fails with "remove it from SURFACES, or restore the file".

## 3. Report quality

The health report rendered its placeholder for the only failure — "this scenario does not yet have a written description in the showcase catalogue" — so the PDF gave stakeholders a raw method name and an `AssertionError`. Added `INIT_TESTS` covering all nine sub-cluster 1m scenarios.

## Verification

```
lex/test_project/tests/init/test_1m_cli_commands.py   9 passed, 12 subtests
.github/scripts/tests                                 251 passed, 0 failed
```

(Previously 251 passed / 2 failed; the two dropped cases are the retired surface's.)

## Note for the merger

The gate deleted its own `v2.1.7` tag and prerelease when it went red (`cleanup-on-red`), and it triggers on `release` — so nothing re-runs it on this branch. **Re-cut the `v2.1.7` prerelease after merge** to see it green. `Script Tests` runs on push and covers item 2 directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
