### PR TITLE
fix(streamlit): stop an idle dashboard expiring on its handshake token

### DIFF
--- a/docs/features/access-and-ui/streamlit dashboards.md
+++ b/docs/features/access-and-ui/streamlit dashboards.md
@@ -86,6 +86,14 @@ When a dashboard is embedded in the Lex App frontend, the user's access token is
 
 The token exchange is handled automatically by the `StreamlitIframe` component — no developer configuration needed beyond defining the dashboard methods on your models.
 
+### Staying signed in
+
+Access tokens are short-lived, and a dashboard is often left open far longer than one lasts. The framework renews ahead of every expiry for as long as the page is open, so a dashboard someone comes back to after lunch keeps working — nothing to configure, and nothing for the user to click.
+
+Renewal always goes through the auth proxy, which is the only component that holds the refresh token. Your dashboard code never sees or manages tokens; read the current user from `st.session_state["user_info"]` and their permissions from `st.session_state["permissions"]` as usual.
+
+Sessions do not live forever: Keycloak's SSO maximum lifetime still applies, and a session revoked in Keycloak stops working immediately. When renewal genuinely can't succeed, the embedded dashboard asks the surrounding app to re-authenticate, and a standalone one offers a sign-in link.
+
 ## In the Frontend
 
 Dashboards appear in two places:

--- a/docs/reference/Environment Variables.md
+++ b/docs/reference/Environment Variables.md
@@ -19,6 +19,9 @@ Lex App reads its runtime configuration from environment variables — usually l
 | Variable                | Purpose                                                                                  |
 | ----------------------- | ---------------------------------------------------------------------------------------- |
 | `IS_STREAMLIT_ENABLED`  | `true` to enable the Streamlit toolbar icon in the frontend. See [[features/access-and-ui/streamlit dashboards]]. |
+| `LEX_INTERNAL_AUTH_SECRET` | Shared secret the dashboard presents when it asks the auth proxy for a fresh access token. `lex streamlit` mints one automatically, because it runs both halves in a single process; set it explicitly only if you run the proxy and Streamlit as separate processes. |
+| `LEX_PROXY_PORT`        | Port the auth proxy listens on. Default `8501`. |
+| `LEX_PROXY_INTERNAL_URL` | Full base URL the dashboard uses to reach the proxy, when it is not `http://127.0.0.1:$LEX_PROXY_PORT`. |
 
 ## Keycloak / OIDC
 

--- a/lex/bin/lex.py
+++ b/lex/bin/lex.py
@@ -3,6 +3,7 @@ import asyncio
 import io
 import os
 import platform
+import secrets
 import subprocess
 import sys
 import threading
@@ -352,15 +353,25 @@ def streamlit(ctx):
         if not os.path.isabs(streamlit_app_path):
             streamlit_args[file_index] = f"{LEX_APP_PACKAGE_ROOT}/{streamlit_app_path}"
 
+    proxy_port = os.environ.setdefault("LEX_PROXY_PORT", "8501")
+
+    # Shared secret for the proxy's /auth/token endpoint, which is how the
+    # dashboard renews the access token it was handed at connect time. Minted
+    # here, before either half starts, so both read the same value out of the
+    # environment they share -- the proxy is imported as top-level ``proxy`` in
+    # the uvicorn thread while Streamlit imports ``lex.streamlit_app``, so they
+    # are separate module objects and cannot share a Python-level constant.
+    os.environ.setdefault("LEX_INTERNAL_AUTH_SECRET", secrets.token_urlsafe(32))
+
     def run_uvicorn():
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        uvicorn.run("proxy:app", host="0.0.0.0", port=8501, loop="asyncio")
+        uvicorn.run("proxy:app", host="0.0.0.0", port=int(proxy_port), loop="asyncio")
 
     t = threading.Thread(target=run_uvicorn, daemon=True)
     t.start()
 
-    streamlit_main(streamlit_args + ["--browser.serverPort", "8501", "--server.port", "8080"])
+    streamlit_main(streamlit_args + ["--browser.serverPort", proxy_port, "--server.port", "8080"])
 
 
 @lex.command(name="pytest", context_settings=dict(ignore_unknown_options=True, allow_extra_args=True))

--- a/lex/proxy.py
+++ b/lex/proxy.py
@@ -99,6 +99,35 @@ PERSIST_JWT_AUTH_TO_SESSION = _env_bool("PERSIST_JWT_AUTH_TO_SESSION", True)
 SET_ST_ACCESS_COOKIE = _env_bool("SET_ST_ACCESS_COOKIE", True)
 ST_ACCESS_COOKIE_MAX_AGE = int(os.getenv("ST_ACCESS_COOKIE_MAX_AGE", "600"))  # 10 minutes
 
+# -----------------------------------------------------------------------------
+# Internal token-pull channel
+# -----------------------------------------------------------------------------
+# Everything this proxy injects into the upstream request -- access token,
+# refresh token, identity -- reaches Streamlit only through the *WebSocket
+# handshake*, and Streamlit snapshots those headers once per connection
+# (``st.context.headers`` reads the session's client request). The socket then
+# stays open for hours, so a running dashboard has no way to learn about a token
+# this proxy refreshed five minutes ago: it is stuck with the credential it was
+# handed at connect time, and dies when that one expires.
+#
+# ``/auth/token`` is the missing pull direction. The co-located Streamlit process
+# presents the browser's own session cookie and gets back a freshly refreshed
+# access token. Refreshing stays exclusively this proxy's job, so the refresh
+# token is never spent from two places -- the rotation race that made local
+# refresh unusable in the first place.
+#
+# The endpoint is guarded by a shared secret rather than the session cookie
+# alone: the cookie is HttpOnly, but page script could still ``fetch`` it with
+# ``credentials: 'include'`` and read the raw access token out of the response.
+# The secret is process-local by default, which is exactly right when the proxy
+# and Streamlit share a process (see ``lex streamlit``); set
+# ``LEX_INTERNAL_AUTH_SECRET`` when they do not.
+INTERNAL_AUTH_HEADER = "x-lex-internal-auth"
+INTERNAL_AUTH_SECRET = os.getenv("LEX_INTERNAL_AUTH_SECRET") or ""
+if not INTERNAL_AUTH_SECRET:
+    INTERNAL_AUTH_SECRET = secrets.token_urlsafe(32)
+    os.environ["LEX_INTERNAL_AUTH_SECRET"] = INTERNAL_AUTH_SECRET
+
 # The proxy talks to an internal Streamlit upstream (typically localhost), so
 # avoid sending those hops through system proxy settings unless explicitly
 # requested.
@@ -462,6 +491,30 @@ def _claims_from_token_set(tokens: Dict[str, Any]) -> Dict[str, Any]:
     return {}
 
 
+def _jwt_user_payload(token: str, claims: Dict[str, Any]) -> Dict[str, Any]:
+    """Identity for a bare access token. Carries no refresh token, by design."""
+    return {
+        "sub": claims.get("sub"),
+        "email": claims.get("email"),
+        "preferred_username": claims.get("preferred_username"),
+        "access_token": token,
+    }
+
+
+def _session_user_payload(session: Dict[str, Any], tokens: Dict[str, Any]) -> Dict[str, Any]:
+    """Identity for a server-side session, including its renewable token set."""
+    claims = _claims_from_token_set(tokens)
+    session_email = (session.get("user") or {}).get("email") or ""
+    return {
+        "sub": claims.get("sub") or "",
+        "email": claims.get("email") or session_email or tokens.get("email") or "",
+        "preferred_username": claims.get("preferred_username") or claims.get("name") or "",
+        "access_token": tokens.get("access_token"),
+        "id_token": tokens.get("id_token"),
+        "refresh_token": tokens.get("refresh_token"),
+    }
+
+
 # -----------------------------------------------------------------------------
 # URL helpers
 # -----------------------------------------------------------------------------
@@ -671,6 +724,43 @@ async def logout(request: Request):
     return await oauth2_logout(request)
 
 
+async def internal_token(request: Request):
+    """Hand the co-located Streamlit process a *currently valid* access token.
+
+    Streamlit only ever sees the headers of the WebSocket handshake that opened
+    its session, so a dashboard left open outlives the token it was started
+    with. This is the pull side of that: same session, same refresh authority,
+    but readable at any moment rather than only at connect time.
+
+    ``_ensure_valid_access_token`` does the refreshing, so this endpoint returns
+    a token that is valid *now* even when the stored one had already expired.
+    Deliberately no refresh token in the response -- spending it stays this
+    proxy's job alone, which is what keeps rotation single-writer.
+    """
+    supplied = request.headers.get(INTERNAL_AUTH_HEADER, "")
+    # compare_digest rejects non-ASCII str outright, so compare bytes: a header
+    # carrying a stray non-ASCII byte is a 403, not a 500.
+    if not supplied or not secrets.compare_digest(
+        supplied.encode("utf-8", "ignore"), INTERNAL_AUTH_SECRET.encode("utf-8")
+    ):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    if "user" not in request.session:
+        return JSONResponse({"error": "no_session"}, status_code=401)
+
+    tokens = await _ensure_valid_access_token(request.session)
+    if not tokens or not tokens.get("access_token"):
+        return JSONResponse({"error": "unauthenticated"}, status_code=401)
+
+    return JSONResponse(
+        {
+            "access_token": tokens.get("access_token"),
+            "expires_at": int(tokens.get("expires_at") or 0),
+            "email": tokens.get("email") or (request.session.get("user") or {}).get("email") or "",
+        }
+    )
+
+
 # -----------------------------------------------------------------------------
 # WebSocket proxy
 # -----------------------------------------------------------------------------
@@ -726,39 +816,28 @@ async def ws_proxy(websocket: WebSocket):
     user_payload: Optional[Dict[str, Any]] = None
     auth_method = "none"
 
-    auth_header = websocket.query_params.get("auth_token", "") or websocket.headers.get("authorization", "")
-    if auth_header.startswith("Bearer "):
-        jwt_token = auth_header[7:]
-    elif auth_header:
-        jwt_token = auth_header
-    else:
-        jwt_token = websocket.cookies.get("st_access")
-
-    if jwt_token:
+    # Same precedence as the HTTP path, and for the same reason: the handshake
+    # is the *only* moment a long-lived Streamlit connection is handed a
+    # credential, so it must be handed the renewable one whenever it exists.
+    explicit_token = websocket.query_params.get("auth_token", "") or websocket.headers.get("authorization", "")
+    if explicit_token:
+        jwt_token = explicit_token[7:] if explicit_token.startswith("Bearer ") else explicit_token
         payload = validate_jwt_token(jwt_token)
         if payload:
-            user_payload = {
-                "sub": payload.get("sub"),
-                "email": payload.get("email"),
-                "preferred_username": payload.get("preferred_username"),
-                "access_token": jwt_token,
-            }
+            user_payload = _jwt_user_payload(jwt_token, payload)
             auth_method = "jwt"
 
     if not user_payload and "user" in scope_session:
         tokens = await _ensure_valid_access_token({"user": scope_session.get("user")})
         if tokens:
-            claims = _claims_from_token_set(tokens)
-            session_email = (scope_session.get("user") or {}).get("email") or ""
-            user_payload = {
-                "sub": claims.get("sub") or "",
-                "email": claims.get("email") or session_email or tokens.get("email") or "",
-                "preferred_username": claims.get("preferred_username") or claims.get("name") or "",
-                "access_token": tokens.get("access_token"),
-                "id_token": tokens.get("id_token"),
-                "refresh_token": tokens.get("refresh_token"),
-            }
+            user_payload = _session_user_payload(scope_session, tokens)
             auth_method = "session"
+
+    if not user_payload and websocket.cookies.get("st_access"):
+        payload = validate_jwt_token(websocket.cookies["st_access"])
+        if payload:
+            user_payload = _jwt_user_payload(websocket.cookies["st_access"], payload)
+            auth_method = "jwt"
 
     if not user_payload:
         with suppress(Exception):
@@ -872,55 +951,54 @@ async def proxy(request: Request):
     # Track where token came from (important to decide whether to set cookie)
     token_source = "none"
 
-    auth_header = (
-        request.cookies.get("st_access", "")
-        or request.query_params.get("auth_token", "")
+    # 1) Explicit ``auth_token`` handoff (query param or header).
+    #    Highest precedence: it is the freshest credential the caller can
+    #    present, and re-sourcing the iframe with a new one is how the embedded
+    #    dashboard renews itself.
+    jwt_token = ""
+    jwt_payload: Optional[Dict[str, Any]] = None
+    explicit_token = (
+        request.query_params.get("auth_token", "")
         or request.headers.get("auth_token", "")
         or request.headers.get("authorization", "")
     )
-
-    if request.cookies.get("st_access"):
-        token_source = "cookie"
-    elif request.query_params.get("auth_token"):
-        token_source = "query"
-    elif request.headers.get("auth_token") or request.headers.get("authorization"):
-        token_source = "header"
-
-    # 1) JWT auth
-    jwt_token = ""
-    jwt_payload: Optional[Dict[str, Any]] = None
-    if auth_header:
-        jwt_token = auth_header[7:] if auth_header.startswith("Bearer ") else auth_header
+    if explicit_token:
+        token_source = "query" if request.query_params.get("auth_token") else "header"
+        jwt_token = explicit_token[7:] if explicit_token.startswith("Bearer ") else explicit_token
         jwt_payload = validate_jwt_token(jwt_token)
         if jwt_payload:
-            user_payload = {
-                "sub": jwt_payload.get("sub"),
-                "email": jwt_payload.get("email"),
-                "preferred_username": jwt_payload.get("preferred_username"),
-                "access_token": jwt_token,  # keep so we can forward Authorization if desired
-            }
+            user_payload = _jwt_user_payload(jwt_token, jwt_payload)
             auth_method = "jwt"
 
-            # ✅ FIX: persist this one-off auth_token into a real session/token-store entry
+            # Persist this one-off auth_token into a real session/token-store entry
             await _persist_jwt_to_session_if_needed(request, jwt_token, jwt_payload, token_source)
 
-    # 2) Session auth (cookie from SessionMiddleware -> server-side tokens)
+    # 2) Session auth (cookie from SessionMiddleware -> server-side tokens).
+    #    Checked BEFORE the ``st_access`` cookie, and that ordering is the whole
+    #    point: the session is the only credential that carries a refresh token.
+    #    ``auth_callback`` sets ``st_access`` on every login, so consulting the
+    #    cookie first classified a freshly logged-in user as ``jwt`` with no
+    #    refresh token at all -- an unrenewable credential that expired minutes
+    #    later and took the dashboard down with it.
     if not user_payload and "user" in request.session:
         tokens = await _ensure_valid_access_token(request.session)
         if tokens:
-            claims = _claims_from_token_set(tokens)
-            session_email = (request.session.get("user") or {}).get("email") or ""
-            user_payload = {
-                "sub": claims.get("sub") or "",
-                "email": claims.get("email") or session_email or tokens.get("email") or "",
-                "preferred_username": claims.get("preferred_username") or claims.get("name") or "",
-                "access_token": tokens.get("access_token"),
-                "id_token": tokens.get("id_token"),
-                "refresh_token": tokens.get("refresh_token"),
-            }
+            user_payload = _session_user_payload(request.session, tokens)
             auth_method = "session"
 
-    # 3) Deny
+    # 3) ``st_access`` cookie: last resort, for the embedded path where the
+    #    frontend cannot repeat ``auth_token`` on follow-up requests and no
+    #    server-side session was established.
+    if not user_payload and request.cookies.get("st_access"):
+        token_source = "cookie"
+        jwt_token = request.cookies["st_access"]
+        jwt_payload = validate_jwt_token(jwt_token)
+        if jwt_payload:
+            user_payload = _jwt_user_payload(jwt_token, jwt_payload)
+            auth_method = "jwt"
+            await _persist_jwt_to_session_if_needed(request, jwt_token, jwt_payload, token_source)
+
+    # 4) Deny
     if not user_payload:
         # Never redirect an iframe document load to the IdP: Keycloak's login page
         # sets frame-ancestors 'self' and the browser shows "refused to connect".
@@ -1020,6 +1098,8 @@ routes = [
     Route("/oauth2/logout", oauth2_logout, methods=["GET"]),
     Route("/oauth2/sign_out", oauth2_sign_out, methods=["GET"]),
     Route("/auth/logout", oauth2_logout, methods=["GET"]),
+    # Must precede the catch-all, or it would be proxied to Streamlit instead.
+    Route("/auth/token", internal_token, methods=["GET"]),
     WebSocketRoute("/{path:path}", ws_proxy),
     Route("/{path:path}", proxy, methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]),
 ]

--- a/lex/streamlit_app.py
+++ b/lex/streamlit_app.py
@@ -1,3 +1,5 @@
+import html
+import json
 import logging
 import os
 import threading
@@ -9,6 +11,7 @@ from typing import Optional, Dict
 import jwt
 import requests
 import streamlit as st
+import streamlit.components.v1 as components
 from streamlit.runtime.scriptrunner import add_script_run_ctx, get_script_run_ctx
 
 logger = logging.getLogger(__name__)
@@ -16,14 +19,44 @@ log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 # -------------------------
-# Token refresh: config
+# Token lifecycle: config
 # -------------------------
-TOKEN_SKEW_SECONDS = 10          # refresh 10s before exp
+# Streamlit reads request headers off the WebSocket handshake that opened the
+# session -- ``st.context.headers`` resolves the session's *client*, and that
+# socket stays open for as long as the tab does. Every credential the auth proxy
+# injects is therefore a snapshot taken at connect time: it ages while the user
+# reads a chart, and re-reading the headers cannot produce a newer one because
+# no new handshake has happened.
+#
+# Keeping an idle dashboard alive means renewing ahead of expiry through a
+# channel that is still live. That channel is the proxy's ``/auth/token``
+# endpoint: it holds the refresh token, it is the only component allowed to
+# spend it, and it will hand back a currently-valid access token for the same
+# session at any moment. Renewing before expiry also keeps Keycloak's SSO idle
+# clock from running out, so the tab survives being left alone.
+TOKEN_SKEW_SECONDS = 10          # treat a token as spent this long before exp
+RENEW_LEAD_SECONDS = 60          # renew this long *before* exp, never after it
 REFRESH_MIN_INTERVAL = 15        # floor sleep
 REFRESH_MAX_BACKOFF = 300        # cap backoff to 5 minutes
-_TOKEN_REFRESH_LOCK = threading.Lock()
+RENEW_POLL_SECONDS = 5           # stop/liveness granularity while sleeping
+RENEWAL_GRACE_SECONDS = 120      # ride out a failing renewal this long before
+                                 # asking anyone to re-authenticate
+_TOKEN_REFRESH_LOCK = threading.RLock()
 
-st.set_page_config(layout="wide")
+# Under ``lex streamlit`` the proxy runs in this very process on 8501 while
+# Streamlit serves 8080 (see lex/bin/lex.py), so this is a loopback call.
+PROXY_INTERNAL_URL = (
+    os.getenv("LEX_PROXY_INTERNAL_URL")
+    or f"http://127.0.0.1:{os.getenv('LEX_PROXY_PORT', '8501')}"
+).rstrip("/")
+INTERNAL_AUTH_HEADER = "x-lex-internal-auth"
+
+# Guarded so the module can be imported (by tests, by tooling) without
+# Streamlit commands firing at import time. Streamlit executes this file with
+# ``__name__ == "__main__"``, so the app itself is unaffected.
+if __name__ == "__main__":
+    st.set_page_config(layout="wide")
+
 
 def _oidc_token_endpoint() -> str:
     base = (os.getenv("KEYCLOAK_URL") or "").rstrip("/")
@@ -41,14 +74,6 @@ def _decode_exp_no_verify(token: str) -> int:
 
 def _now() -> int:
     return int(time.time())
-
-
-def _compute_next_refresh_at(exp: int, expires_in: int | None) -> int:
-    if exp:
-        return max(_now() + REFRESH_MIN_INTERVAL, exp - TOKEN_SKEW_SECONDS)
-    if expires_in:
-        return _now() + max(REFRESH_MIN_INTERVAL, int(expires_in) - TOKEN_SKEW_SECONDS)
-    return _now() + REFRESH_MIN_INTERVAL
 
 
 def _post_refresh(refresh_token: str) -> dict | None:
@@ -75,16 +100,20 @@ def _post_refresh(refresh_token: str) -> dict | None:
         return None
 
 
+def _store_tokens(access: str, refresh: str | None = None, expires_in=None) -> None:
+    """Record a token set, keeping the refresh token when the response omits it."""
+    with _TOKEN_REFRESH_LOCK:
+        st.session_state.access_token = access or ""
+        if refresh is not None:
+            st.session_state.refresh_token = refresh
+        st.session_state.token_exp = _decode_exp_no_verify(access) if access else 0
+        st.session_state.expires_in = expires_in
+
+
 def _update_tokens_from_response(tok: dict) -> None:
     access = tok.get("access_token") or ""
     refresh = tok.get("refresh_token") or st.session_state.get("refresh_token") or ""
-    expires_in = tok.get("expires_in")
-    exp = _decode_exp_no_verify(access) if access else 0
-
-    st.session_state.access_token = access
-    st.session_state.refresh_token = refresh
-    st.session_state.token_exp = exp
-    st.session_state.expires_in = expires_in
+    _store_tokens(access, refresh, tok.get("expires_in"))
 
 
 def _token_exp_from_state_or_decode(access: str) -> int:
@@ -107,130 +136,242 @@ def _is_token_valid(access: str, skew_seconds: int = TOKEN_SKEW_SECONDS) -> bool
     return _now() < (exp - skew_seconds)
 
 
-def _sync_tokens_from_headers(h: Dict[str, str]) -> None:
-    token_from_header = (bearer_from_headers(h) or "").strip()
-    current_access = (st.session_state.get("access_token") or "").strip()
-    if token_from_header and (token_from_header != current_access or not st.session_state.get("token_exp")):
-        st.session_state.access_token = token_from_header
-        st.session_state.token_exp = _decode_exp_no_verify(token_from_header)
-        st.session_state.expires_in = None
+def _live_headers() -> Dict[str, str]:
+    """Headers of the session's *current* client connection.
 
+    Re-read rather than cached: a dropped WebSocket that reconnects, or an
+    embedded iframe re-sourced with a fresh ``auth_token``, arrives as a new
+    handshake through the proxy and therefore carries a newer credential.
+    """
+    try:
+        return normalize_headers(getattr(st.context, "headers", {}) or {})
+    except Exception:
+        return {}
+
+
+def _adopt_header_token(h: Dict[str, str]) -> bool:
+    """Take the handshake's access token, but only when it is genuinely newer.
+
+    The guard matters more than it looks. The headers are frozen for the life of
+    a connection, so once a renewal has landed in session state the header copy
+    is *older* than what we hold. Adopting it on inequality alone -- as this used
+    to -- silently reverted every renewal on the next rerun and put the session
+    straight back on the expired token it had just escaped.
+    """
+    token_from_header = (bearer_from_headers(h) or "").strip()
+    if not token_from_header:
+        return False
+
+    with _TOKEN_REFRESH_LOCK:
+        current = (st.session_state.get("access_token") or "").strip()
+        if token_from_header == current:
+            return False
+
+        header_exp = _decode_exp_no_verify(token_from_header)
+        current_exp = int(st.session_state.get("token_exp") or 0) if current else 0
+        if current and current_exp and header_exp and header_exp <= current_exp:
+            return False
+
+        st.session_state.access_token = token_from_header
+        st.session_state.token_exp = header_exp
+        st.session_state.expires_in = None
+        return True
+
+
+def _sync_tokens_from_headers(h: Dict[str, str]) -> None:
+    _adopt_header_token(h)
+
+    # The refresh token is only ever a fallback for deployments without the
+    # proxy; adopting the handshake copy is harmless because we never spend it
+    # while the proxy is answering.
     rt_hdr = (h.get("x-streamlit-refresh-token") or "").strip()
-    if rt_hdr:
+    if rt_hdr and rt_hdr != (st.session_state.get("refresh_token") or ""):
         st.session_state.refresh_token = rt_hdr
 
 
+def _pull_token_from_proxy(cookie_header: str) -> bool:
+    """Ask the proxy for a currently-valid access token for this browser session.
+
+    The proxy refreshes on our behalf, so this succeeds even when the token we
+    hold has already expired. Returns ``False`` when there is no proxy to ask,
+    no session cookie to present, or the session itself is gone.
+    """
+    secret = os.getenv("LEX_INTERNAL_AUTH_SECRET") or ""
+    if not secret or not cookie_header:
+        return False
+
+    try:
+        resp = requests.get(
+            f"{PROXY_INTERNAL_URL}/auth/token",
+            headers={"Cookie": cookie_header, INTERNAL_AUTH_HEADER: secret},
+            timeout=10,
+        )
+    except Exception as e:
+        log.warning("Token pull from proxy failed: %s", e)
+        return False
+
+    if resp.status_code != 200:
+        log.warning("Token pull from proxy returned %s", resp.status_code)
+        return False
+
+    try:
+        data = resp.json()
+    except Exception:
+        return False
+
+    access = (data.get("access_token") or "").strip()
+    if not access:
+        return False
+
+    # Keep whatever refresh token we already hold: the proxy deliberately does
+    # not return one, because spending it must stay single-writer.
+    _store_tokens(access, refresh=None, expires_in=None)
+    return True
+
+
+def renew_access_token() -> bool:
+    """Obtain a fresh access token, in order of decreasing authority."""
+    with _TOKEN_REFRESH_LOCK:
+        # Someone else may have renewed while we waited for the lock; renewal
+        # involves network round trips, so re-checking here keeps a rerun from
+        # blocking behind a refresh that has already delivered.
+        if _is_token_valid(st.session_state.get("access_token") or ""):
+            return True
+
+        h = _live_headers()
+
+        # 1) A reconnected socket or a re-sourced iframe may already have
+        #    delivered a newer credential in the handshake.
+        if _adopt_header_token(h) and _is_token_valid(st.session_state.get("access_token") or ""):
+            return True
+
+        # 2) The proxy: sole owner of the refresh token, always current.
+        if _pull_token_from_proxy(h.get("cookie", "")):
+            return True
+
+        # 3) No proxy answering (plain ``streamlit run``, or it is down). Only
+        #    then do we spend our own copy of the refresh token -- with the
+        #    proxy silent there is nobody to race for the rotation.
+        refresh = (st.session_state.get("refresh_token") or "").strip()
+        if refresh:
+            tok = _post_refresh(refresh)
+            if tok and tok.get("access_token"):
+                _update_tokens_from_response(tok)
+                return True
+
+        return False
+
+
 def ensure_valid_access_token(allow_refresh: bool = True) -> bool:
+    """True when session state holds a usable access token, renewing if needed."""
     access = (st.session_state.get("access_token") or "").strip()
     if _is_token_valid(access):
         return True
 
-    refresh = (st.session_state.get("refresh_token") or "").strip()
-    if allow_refresh and refresh:
-        with _TOKEN_REFRESH_LOCK:
-            access = (st.session_state.get("access_token") or "").strip()
-            if _is_token_valid(access):
-                return True
-            tok = _post_refresh(refresh)
-            if tok and tok.get("access_token"):
-                _update_tokens_from_response(tok)
-                return _is_token_valid(st.session_state.get("access_token") or "", skew_seconds=0)
+    if allow_refresh and renew_access_token():
+        return _is_token_valid(st.session_state.get("access_token") or "", skew_seconds=0)
 
     # Final strict check without skew to avoid dropping a token that is still valid for a few seconds.
     return _is_token_valid(st.session_state.get("access_token") or "", skew_seconds=0)
 
 
-def _invalidate_local_auth(reason: str) -> None:
-    logger.warning(reason)
-    st.session_state.authenticated = False
-    st.session_state.auth_method = ""
-    st.session_state.user_id = ""
-    st.session_state.user_email = ""
-    st.session_state.user_username = ""
-    st.session_state.access_token = ""
-    st.session_state.refresh_token = ""
-    st.session_state.token_exp = 0
-    st.session_state.expires_in = None
-    st.session_state.keycloak_context_token = ""
-    st.session_state.permissions = []
-    st.session_state.user_info = {"sub": "", "email": "", "preferred_username": ""}
+def _session_is_live(session_id: str) -> bool:
+    """False once Streamlit has torn this session down.
+
+    Without it the refresher outlives the browser tab: it only ever consulted a
+    session-state flag, which nothing sets when a user simply closes the page,
+    so every abandoned session left a thread renewing tokens forever.
+    """
+    if not session_id:
+        return True
+    try:
+        from streamlit import runtime
+
+        if not runtime.exists():
+            return False
+        return runtime.get_instance().is_active_session(session_id)
+    except Exception:
+        return True
 
 
-def _token_refresher(stop_key: str = "stop_token_refresher") -> None:
-    backoff = 5
-    while not st.session_state.get(stop_key, False):
-        access = st.session_state.get("access_token") or ""
-        refresh = st.session_state.get("refresh_token") or ""
-        exp = st.session_state.get("token_exp") or _decode_exp_no_verify(access)
+def _refresher_should_stop(session_id: str, stop_key: str) -> bool:
+    return bool(st.session_state.get(stop_key, False)) or not _session_is_live(session_id)
+
+
+def _seconds_until_renewal() -> int:
+    exp = int(st.session_state.get("token_exp") or 0)
+    if not exp:
         expires_in = st.session_state.get("expires_in")
+        if expires_in:
+            return max(REFRESH_MIN_INTERVAL, int(expires_in) - RENEW_LEAD_SECONDS)
+        return REFRESH_MIN_INTERVAL
+    return max(REFRESH_MIN_INTERVAL, exp - RENEW_LEAD_SECONDS - _now())
 
-        next_at = _compute_next_refresh_at(exp, expires_in)
-        sleep_for = max(1, next_at - _now())
 
-        end_at = _now() + sleep_for
-        while _now() < end_at:
-            if st.session_state.get(stop_key, False):
+def _token_refresher(session_id: str, stop_key: str = "stop_token_refresher") -> None:
+    """Renew ahead of every expiry for as long as the session exists.
+
+    This runs for session *and* jwt auth alike. Skipping it for proxy-managed
+    sessions was the original mistake: the proxy can only deliver a token at
+    handshake time, so "the proxy will handle it" meant nothing handled it, and
+    an idle tab expired on schedule.
+    """
+    backoff = 5
+    try:
+        while True:
+            if _refresher_should_stop(session_id, stop_key):
                 return
-            time.sleep(min(1.0, end_at - _now()))
 
-        if st.session_state.get(stop_key, False):
-            return
+            end_at = _now() + _seconds_until_renewal()
+            while _now() < end_at:
+                if _refresher_should_stop(session_id, stop_key):
+                    return
+                time.sleep(min(RENEW_POLL_SECONDS, max(1, end_at - _now())))
 
-        if not refresh:
-            backoff = min(REFRESH_MAX_BACKOFF, backoff * 2)
-            time.sleep(backoff)
-            continue
+            if _refresher_should_stop(session_id, stop_key):
+                return
 
-        with _TOKEN_REFRESH_LOCK:
-            # Another thread/run may have refreshed while we were sleeping.
-            latest_access = st.session_state.get("access_token") or ""
-            if _is_token_valid(latest_access):
+            if renew_access_token():
                 backoff = 5
+                st.session_state.token_renewal_failed = False
                 continue
 
-            refresh = st.session_state.get("refresh_token") or ""
-            if refresh:
-                tok = _post_refresh(refresh)
-                if tok and tok.get("access_token"):
-                    _update_tokens_from_response(tok)
-                    backoff = 5
-                    continue
-
-        backoff = min(REFRESH_MAX_BACKOFF, backoff * 2)
-        time.sleep(backoff)
+            # Renewal can fail transiently (proxy restarting, IdP blip). Back off
+            # and retry rather than tearing the session down on the first miss.
+            st.session_state.token_renewal_failed = True
+            backoff = min(REFRESH_MAX_BACKOFF, backoff * 2)
+            slept = 0
+            while slept < backoff:
+                if _refresher_should_stop(session_id, stop_key):
+                    return
+                time.sleep(min(RENEW_POLL_SECONDS, backoff - slept))
+                slept += RENEW_POLL_SECONDS
+    except Exception as e:
+        # Session state torn down from under us, or an unexpected fault. Exiting
+        # is right: a thread that cannot reach its session has nothing to renew.
+        log.info("Token refresher for session %s stopping: %s", session_id or "?", e)
 
 
 def start_token_refresh_thread_if_needed() -> None:
-    # Session auth is proxy-managed; local refresh can race with proxy refresh-token rotation.
-    if (st.session_state.get("auth_method") or "").strip().lower() == "session":
-        st.session_state.stop_token_refresher = True
-        old_th = st.session_state.get("token_refresher_thread")
-        if old_th and getattr(old_th, "is_alive", lambda: False)():
-            old_th.join(timeout=1.0)
-        st.session_state.token_refresher_started = False
-        st.session_state.token_refresher_thread = None
-        return
+    ctx = get_script_run_ctx()
+    session_id = getattr(ctx, "session_id", "") or ""
 
     th = st.session_state.get("token_refresher_thread")
     if th and getattr(th, "is_alive", lambda: False)():
+        # Re-bind: the session may have been served by a new ScriptRunner since
+        # the thread started.
+        add_script_run_ctx(th, ctx)
         st.session_state.token_refresher_started = True
-        return
-    st.session_state.token_refresher_started = False
-
-    if not st.session_state.get("refresh_token"):
-        headers = getattr(st.context, "headers", {}) or {}
-        h = normalize_headers(headers)
-        rt = h.get("x-streamlit-refresh-token") or ""
-        if rt:
-            st.session_state.refresh_token = rt
-
-    if not st.session_state.get("refresh_token"):
-        st.session_state.token_refresher_thread = None
         return
 
     st.session_state.stop_token_refresher = False
-    th = threading.Thread(target=_token_refresher, name="token_refresher", daemon=True)
-    add_script_run_ctx(th, get_script_run_ctx())
+    th = threading.Thread(
+        target=_token_refresher,
+        name="token_refresher",
+        args=(session_id,),
+        daemon=True,
+    )
+    add_script_run_ctx(th, ctx)
     th.start()
 
     st.session_state.token_refresher_started = True
@@ -301,8 +442,10 @@ def get_user_info(access_token: str):
 
 
 def sync_keycloak_context_from_access_token() -> None:
-    allow_refresh = (st.session_state.get("auth_method") or "").strip().lower() != "session"
-    if not ensure_valid_access_token(allow_refresh=allow_refresh):
+    # Renewal is allowed for every auth method now. Exempting ``session`` used to
+    # be the safe choice because Streamlit would have spent the same refresh
+    # token as the proxy; it no longer does -- it asks the proxy instead.
+    if not ensure_valid_access_token():
         return
 
     access_token = (st.session_state.get("access_token") or "").strip()
@@ -329,11 +472,14 @@ def sync_keycloak_context_from_access_token() -> None:
 
         kc_manager = KeycloakManager()
         permissions = kc_manager.get_uma_permissions(access_token)
-        st.session_state.permissions = permissions if isinstance(permissions, list) else []
     except Exception as e:
+        # Keep the permissions we already resolved. Blanking them on a failed
+        # lookup silently demotes the user to "no access" mid-session, which
+        # reads as a broken dashboard rather than a transient Keycloak blip.
         logger.error(f"Failed to get UMA permissions via KeycloakManager: {e}")
-        st.session_state.permissions = []
+        return
 
+    st.session_state.permissions = permissions if isinstance(permissions, list) else []
     st.session_state.keycloak_context_token = access_token
 
 
@@ -429,6 +575,57 @@ def render_logout_link() -> None:
     )
 
 
+def _within_renewal_grace() -> bool:
+    """True while a failing renewal is still plausibly transient.
+
+    A proxy restart or an IdP hiccup should never be visible to someone reading
+    a chart, so a failed renewal buys silence for a while and the refresher keeps
+    retrying underneath. Past the grace window the failure is structural --
+    Keycloak's SSO max lifetime, a revoked session -- and no amount of retrying
+    substitutes for signing in again.
+    """
+    if not st.session_state.get("token_renewal_failed"):
+        st.session_state.renewal_failing_since = 0
+        return True
+
+    since = int(st.session_state.get("renewal_failing_since") or 0)
+    if not since:
+        st.session_state.renewal_failing_since = _now()
+        return True
+    return (_now() - since) < RENEWAL_GRACE_SECONDS
+
+
+def render_session_recovery() -> None:
+    """Get the session renewed, preferring the paths the user never sees.
+
+    Embedded, the parent shell renews by re-sourcing the iframe with a fresh
+    ``auth_token``; it is already listening for ``lex-auth-required`` because the
+    proxy's iframe-breakout page posts exactly this message. Standalone there is
+    no shell to ask, and a Streamlit component iframe is sandboxed without
+    ``allow-top-navigation``, so the sign-in link -- a user gesture, always
+    permitted -- is the honest fallback rather than a redirect that would be
+    silently blocked.
+    """
+    login_url = f"{_current_base_url()}{_base_path()}/auth/login"
+    login_js = json.dumps(login_url)
+
+    components.html(
+        "<script>(function(){var u=" + login_js + ";"
+        "var m={type:'lex-auth-required',login:u,source:'streamlit'};"
+        "try{window.parent.postMessage(m,'*');}catch(e){}"
+        "try{if(window.top!==window.parent){window.top.postMessage(m,'*');}}catch(e){}"
+        "})();</script>",
+        height=0,
+    )
+
+    st.warning("⏳ Renewing your session…")
+    st.markdown(
+        f'<a href="{html.escape(login_url, quote=True)}" target="_top" rel="noopener">'
+        "Sign in again</a> if this message does not clear.",
+        unsafe_allow_html=True,
+    )
+
+
 # -------------------------
 # Session state initialization
 # -------------------------
@@ -463,22 +660,31 @@ def init_session_state() -> None:
         st.session_state.token_refresher_thread = None
     if "stop_token_refresher" not in st.session_state:
         st.session_state.stop_token_refresher = False
+    if "token_renewal_failed" not in st.session_state:
+        st.session_state.token_renewal_failed = False
+    if "reauth_requested" not in st.session_state:
+        st.session_state.reauth_requested = False
 
 
 # -------------------------
 # Authentication
 # -------------------------
 def authenticate_from_proxy_or_jwt() -> None:
+    """Establish identity from the proxy's headers and keep the token current.
+
+    Identity and token freshness are deliberately decoupled. The proxy already
+    authenticated the request; whether the credential it handed over has since
+    aged out is a renewal problem, not an identity problem, and answering it
+    with "Missing user information" both misdescribed the failure and made it
+    unrecoverable.
+    """
     headers = getattr(st.context, "headers", {}) or {}
     h = normalize_headers(headers)
     _sync_tokens_from_headers(h)
 
     if st.session_state.authenticated:
-        allow_refresh = (st.session_state.get("auth_method") or "").strip().lower() != "session"
-        if not ensure_valid_access_token(allow_refresh=allow_refresh):
-            _invalidate_local_auth("Access token expired and refresh failed; forcing re-authentication.")
-            return
         start_token_refresh_thread_if_needed()
+        st.session_state.token_renewal_failed = not ensure_valid_access_token()
         sync_keycloak_context_from_access_token()
         return
 
@@ -530,12 +736,8 @@ def authenticate_from_proxy_or_jwt() -> None:
         }
 
         _sync_tokens_from_headers(h)
-        allow_refresh = (st.session_state.get("auth_method") or "").strip().lower() != "session"
-        if not ensure_valid_access_token(allow_refresh=allow_refresh):
-            _invalidate_local_auth("Authenticated identity received without a valid access token.")
-            return
-
         start_token_refresh_thread_if_needed()
+        st.session_state.token_renewal_failed = not ensure_valid_access_token()
         sync_keycloak_context_from_access_token()
 
         logger.info(
@@ -577,27 +779,32 @@ def reset_streamlit_form_context() -> None:
 # -------------------------
 # App bootstrap
 # -------------------------
-init_session_state()
-
-# If user clicked logout link and landed on ?logout=1, we clear session_state safely and stop.
-handle_logout_landing()
-
-authenticate_from_proxy_or_jwt()
-
-if not st.session_state.authenticated:
-    st.error("❌ Authentication Error: Missing user information.")
-    st.info("Please access this application through the main portal.")
-    st.stop()
-
-# Form-safe logout control (won't break no matter what streamlit_structure.main() does)
-_logout_qp = st.query_params.get("is_logout_enabled")
-if _logout_qp is None or str(_logout_qp).lower() not in ("0", "false", "no", "n", "off"):
-    render_logout_link()
-
-# -------------------------
-# Main app
-# -------------------------
 if __name__ == "__main__":
+    init_session_state()
+
+    # If user clicked logout link and landed on ?logout=1, we clear session_state safely and stop.
+    handle_logout_landing()
+
+    authenticate_from_proxy_or_jwt()
+
+    if not st.session_state.authenticated:
+        # No identity on the connection at all: the request never carried the
+        # proxy's headers. This is the one situation the message below actually
+        # describes -- an expired token is a renewal problem, handled just after,
+        # not by claiming the user information is missing.
+        st.error("❌ Authentication Error: Missing user information.")
+        st.info("Please access this application through the main portal.")
+        st.stop()
+
+    if not _within_renewal_grace():
+        render_session_recovery()
+        st.stop()
+
+    # Form-safe logout control (won't break no matter what streamlit_structure.main() does)
+    _logout_qp = st.query_params.get("is_logout_enabled")
+    if _logout_qp is None or str(_logout_qp).lower() not in ("0", "false", "no", "n", "off"):
+        render_logout_link()
+
     from lex.lex_app.settings import repo_name
 
     try:

--- a/lex/test_project/test-plan/clusters/01-init/allocation.yaml
+++ b/lex/test_project/test-plan/clusters/01-init/allocation.yaml
@@ -1,7 +1,7 @@
 cluster: 1
 slug: init
 title: Init — Project Bootstrap
-max_scenario: 222
+max_scenario: 239
 letters:
   a:
     title: '`lex setup` — scaffolding'
@@ -282,4 +282,23 @@ letters:
       adopts a strictly newer auth_token rather than discarding it while the stored one is still
       valid, which silently defeated any renewal. First two-letter batch id - cluster 1 exhausted
       a-z. Renumbered from z/1.201-1.206 on merge
-
+  ab:
+    title: Streamlit session survival across an idle period (frozen-handshake fix)
+    scenarios: 1.223-1.239
+    status: complete
+    tests:
+      pass: 17
+      skip: 0
+      xfail: 0
+    note: >-
+      the third and last batch on this auth path (z made expiry graceful, aa let the embedded
+      caller renew, ab stops the session expiring at all). Root cause: Streamlit reads request
+      headers off the *websocket handshake*, so every credential the proxy injects is a snapshot
+      that ages while the socket stays open - and session auth had local refresh deliberately
+      disabled, leaving nothing to renew it. Adds proxy /auth/token (secret-guarded pull, proxy
+      stays sole refresh authority so nothing races the rotation), reorders credential precedence
+      so the renewable session outranks the short-lived st_access cookie on both the HTTP and WS
+      paths, and on the Streamlit side stops the frozen header token overwriting a renewed one,
+      renews ahead of expiry for session auth too, and decouples identity from token freshness -
+      the "Missing user information" screen was reporting an expired token as a missing user, and
+      re-entered itself on every rerun. 14 of 17 fail against the pre-fix tree.

--- a/lex/test_project/test-plan/clusters/01-init/batches.md
+++ b/lex/test_project/test-plan/clusters/01-init/batches.md
@@ -227,3 +227,21 @@
 | Prereqs | batch 1z (the breakout response this reacts to) |
 | Status | ✅ Complete — 6 pass / 0 fail |
 | Note | the breakout batch made the expiry a graceful re-login; this removes the re-login. Two defects had to be fixed for renewal to be possible at all: the token endpoint never published an expiry (the only code returning one, `_generate_new_token`, is unreachable **and** self-signs HS256, which the RS256/JWKS proxy would reject), and `_persist_jwt_to_session_if_needed` returned early whenever the stored token was still valid — so a token renewed *before* expiry, which is the only time renewal can arrive, was discarded and the session died at the original deadline anyway. 1.220 is the gate on that second one: it fails against the pre-fix proxy. A refresh token was deliberately **not** given to the embedded path — it would have to travel through the iframe URL into access logs, history and `Referer` headers. |
+
+---
+
+### Batch 1ab — Streamlit session survival across an idle period ✅
+
+| Property | Value |
+| --- | --- |
+| Scenario range | 1.223 – 1.239 |
+| Type | U |
+| Files covered | `lex/proxy.py` (`internal_token`, `proxy` + `ws_proxy` credential precedence, `_jwt_user_payload`, `_session_user_payload`), `lex/streamlit_app.py` (`_adopt_header_token`, `_sync_tokens_from_headers`, `_pull_token_from_proxy`, `renew_access_token`, `authenticate_from_proxy_or_jwt`, `sync_keycloak_context_from_access_token`, `_token_refresher`, `start_token_refresh_thread_if_needed`, `_within_renewal_grace`), `lex/bin/lex.py` (`streamlit` — mints the shared secret) |
+| Test file | `lex/test_project/tests/init/test_1ab_streamlit_session_survival.py` |
+| Test classes | `TestCluster01ab_ProxyRenewalChannel` (1.223–1.228, 1.239), `TestCluster01ab_StreamlitTokenLifecycle` (1.229–1.238) |
+| Fixtures | none — Starlette `TestClient` over the real `proxy.app`, a hand-signed SessionMiddleware cookie, capturing stand-ins for the HTTP and WebSocket upstreams, and a dict-backed `st.session_state` |
+| Tests landed | **17 pass / 0 fail**; whole `init` cluster **315 pass / 13 skip, 87 subtests pass** |
+| Coverage gain | the renewal path of a *running* dashboard, which had none: the pull endpoint and its secret guard, credential precedence on both the HTTP and WebSocket paths, and the Streamlit-side token lifecycle including the identity/expiry split |
+| Prereqs | batches 1z (breakout) and 1aa (embedded renewal) — same auth path |
+| Status | ✅ Complete — 14 of 17 scenarios fail against the pre-fix tree (the two pre-existing correct behaviours, 1.228 and 1.230, are kept as guards) |
+| Note | Root cause was a lifetime mismatch nobody had named: `st.context.headers` is the handshake request, frozen for the life of a socket that Streamlit keeps open for hours, while the access token it carries lives minutes. Session auth then had local refresh *deliberately* disabled on the reasoning that the proxy manages it — true of the proxy's own traffic, but the proxy can only deliver a credential at handshake time, so nothing renewed the running script's copy. Three secondary defects compounded it: `auth_callback` sets `st_access` on every login and the cookie was consulted before the session, so a normal login reached Streamlit as `jwt` with `refresh_token: None`; `_sync_tokens_from_headers` adopted the header token on mere inequality, reverting each renewal on the next rerun; and the expiry path called `_invalidate_local_auth`, wiping identity and rendering "Missing user information" about headers that were present — sticky, because the next rerun re-read the same frozen headers. Renewal now pulls from the proxy, so the refresh token still has exactly one writer. |

--- a/lex/test_project/test-plan/clusters/01-init/cluster.md
+++ b/lex/test_project/test-plan/clusters/01-init/cluster.md
@@ -200,3 +200,33 @@ does not remove user launch configurations.
 **Why a regression matters:** silent. Without a published expiry the caller has nothing to schedule against; if the proxy keeps the older token, every renewal is discarded and the session still dies at the original expiry — no error anywhere, just a user sent back to the login page mid-work.
 
 **Scenario range:** 1.217 – 1.222. **Test file:** `lex/test_project/tests/init/test_1aa_embedded_token_renewal.py`. **Type:** U. **Status:** ✅ 6 pass.
+
+---
+
+### 1ab. Streamlit session survival across an idle period ✅
+
+**What it tests:** that a Streamlit dashboard left open and idle keeps working. Streamlit reads request headers off the *WebSocket handshake* (`st.context.headers` resolves the session's client), so every credential the proxy injects is a snapshot taken once, when the socket opened — and the socket then stays open for hours. Renewal therefore has to come from a channel that is still live: the proxy's `/auth/token`, which owns the refresh token and remains the only component allowed to spend it.
+
+**Why a regression matters:** it is what the user sees. Before this batch an idle tab died on the access token's own lifetime and reported "Authentication Error: Missing user information" — a message about identity headers that were in fact present, on a page that could not recover, because the next rerun re-read the same frozen headers and invalidated again.
+
+| Scenario | Title | Asserts |
+| --- | --- | --- |
+| 1.223 | `/auth/token` needs the internal secret | a valid session cookie alone gets a 403 — page script can `fetch` with credentials, so the HttpOnly cookie must not be enough to exfiltrate a bearer token |
+| 1.224 | the pull returns a token valid *now* | the response carries the refreshed token and its expiry, not the stale stored copy |
+| 1.225 | the refresh token is never handed out | absent from the response — two components rotating it is the race the pull channel exists to avoid |
+| 1.226 | an unrenewable session is a 401 | the caller must distinguish "renewed" from "sign in again" |
+| 1.227 | session outranks the `st_access` cookie (HTTP) | forwarded as session auth *with* the refresh token; the cookie is set on every login, so consulting it first classified a fresh login as unrenewable `jwt` |
+| 1.228 | an explicit `auth_token` still wins | the embedded renewal handoff keeps its precedence over the session |
+| 1.239 | the WS handshake carries the renewable credential | the one moment a long-lived connection is handed anything must hand it the session's refresh token |
+| 1.229 | a stale handshake token never replaces a renewed one | adopting on inequality reverted every renewal on the next rerun |
+| 1.230 | a genuinely newer handshake token is adopted | a reconnect or a re-sourced iframe is a legitimate renewal path |
+| 1.231 | renewal pulls from the proxy | the refresh token in session state stays untouched while the proxy answers |
+| 1.232 | fallback when no proxy answers | the refresh token is spent only then — no second writer to race |
+| 1.233 | identity survives an unrenewable token | the user stays authenticated and identified, flagged only as needing renewal |
+| 1.234 | permissions are kept when Keycloak fails | a failed UMA lookup must not silently demote the user to no access |
+| 1.235 | the refresher runs for session auth too | "the proxy handles it" meant nobody did — the proxy only delivers at handshake time |
+| 1.236 | the refresher stops with the session | closing a tab sets no session-state flag, so a flag-only refresher outlived every abandoned session |
+| 1.237 | a transient failure stays invisible | a proxy restart must not put a re-auth notice in front of someone reading a chart |
+| 1.238 | a persistent failure surfaces recovery | past the grace window the cause is SSO max lifetime or a revoked session; a successful renewal clears the stamp |
+
+**Scenario range:** 1.223 – 1.239. **Test file:** `lex/test_project/tests/init/test_1ab_streamlit_session_survival.py`. **Type:** U. **Status:** ✅ 17 pass.

--- a/lex/test_project/test-plan/progress/dashboard.md
+++ b/lex/test_project/test-plan/progress/dashboard.md
@@ -10,7 +10,7 @@
 
 | Cluster | Batches | Max scenario | Pass | Skip | Xfail |
 |---|---|---|---|---|---|
-| 1. Init — Project Bootstrap | 27 | 222 | 116 | 0 | 0 |
+| 1. Init — Project Bootstrap | 28 | 239 | 133 | 0 | 0 |
 | 2. CRUD via REST API | 10 | 107 | 15 | 0 | 0 |
 | 3. Validation Hooks | 7 | 38 | 6 | 0 | 0 |
 | 4. Permissions | 13 | 74 | 18 | 2 | 0 |
@@ -32,6 +32,7 @@
 |---|---|---|---|---|---|---|---|
 | 1a | `lex setup` — scaffolding | 1.1-1.5 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 1aa | Embedded Streamlit token renewal (issuer expiry + proxy adoption) | 1.217-1.222 | complete | 6 | 0 | 0 | follow-up to the iframe breakout (batch z) - makes the expiry dead end avoidable rather than merely graceful. StreamlitTokenView now publishes expires_in/expires_at/refresh_interval (previously only returned by dead code that self-signed HS256, which the RS256/JWKS proxy would reject) and 401s instead of KeyError-ing when the session has no OIDC token; the proxy adopts a strictly newer auth_token rather than discarding it while the stored one is still valid, which silently defeated any renewal. First two-letter batch id - cluster 1 exhausted a-z. Renumbered from z/1.201-1.206 on merge |
+| 1ab | Streamlit session survival across an idle period (frozen-handshake fix) | 1.223-1.239 | complete | 17 | 0 | 0 | the third and last batch on this auth path (z made expiry graceful, aa let the embedded caller renew, ab stops the session expiring at all). Root cause: Streamlit reads request headers off the *websocket handshake*, so every credential the proxy injects is a snapshot that ages while the socket stays open - and session auth had local refresh deliberately disabled, leaving nothing to renew it. Adds proxy /auth/token (secret-guarded pull, proxy stays sole refresh authority so nothing races the rotation), reorders credential precedence so the renewable session outranks the short-lived st_access cookie on both the HTTP and WS paths, and on the Streamlit side stops the frozen header token overwriting a renewed one, renews ahead of expiry for session auth too, and decouples identity from token freshness - the "Missing user information" screen was reporting an expired token as a missing user, and re-entered itself on every rerun. 14 of 17 fail against the pre-fix tree. |
 | 1b | `lex Init` — first-run initialization | 1.6-1.16 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 1c | `INITIAL_DATA` loading (part of `lex Init`) |  | planned | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |
 | 1d |  | 1.23-1.30 | complete | 0 | 0 | 0 | counts folded into cluster top-line in pre-migration dashboard; per-letter tally not separately recorded |

--- a/lex/test_project/test-plan/progress/sessions/2026-08-18-1ab-streamlit-session-survival.md
+++ b/lex/test_project/test-plan/progress/sessions/2026-08-18-1ab-streamlit-session-survival.md
@@ -1,0 +1,77 @@
+---
+date: 2026-08-18
+clusters: [1]
+tests_added: 17
+suite_tally: "1ab: 17 pass / 0 fail; init cluster: 315 pass / 13 skip"
+---
+
+# Batch 1ab — Streamlit session survival across an idle period
+
+Third and last batch on this auth path. [Batch 1z](../../clusters/01-init/batches.md)
+made expiry graceful, [1aa](../../clusters/01-init/batches.md) let the embedded caller
+renew, and this one stops the session expiring at all — including on the standalone
+(non-embedded) path, which had no renewal mechanism whatsoever.
+
+Reported as: a dashboard left alone for a while shows "❌ Authentication Error: Missing
+user information. Please access this application through the main portal." The message
+is doubly wrong — the identity headers were present, and the page could not recover
+from it.
+
+## The lifetime mismatch
+
+`st.context.headers` is not "the current request". It resolves the *session's client*,
+so it is the HTTP handshake that opened the WebSocket — frozen for as long as that
+socket lives, which with Streamlit's pings is hours. The access token it carries lives
+minutes. Nothing a running script can do produces a newer one.
+
+Session auth then had local refresh **deliberately** disabled, on the reasoning that
+renewal is the proxy's job. That is true of the proxy's own traffic and false of the
+dashboard's: the proxy can only hand a credential over at handshake time, and the
+handshake happens once. So "the proxy handles it" meant nobody handled it.
+
+Three defects compounded it:
+
+- `auth_callback` sets the short-lived `st_access` cookie on every login, and both the
+  HTTP and WebSocket paths consulted that cookie *before* the server-side session — so
+  a perfectly normal login reached Streamlit as `auth_method="jwt"` with
+  `refresh_token: None`, an unrenewable credential, minutes from death;
+- `_sync_tokens_from_headers` adopted the header token whenever it merely *differed*
+  from the stored one. After a successful renewal the frozen header copy is the older
+  one, so every rerun reverted the renewal that had just landed;
+- the expiry path called `_invalidate_local_auth`, which cleared user id, email and
+  username. Hence the message. And it was sticky rather than transient: the next rerun
+  re-read the same frozen headers, found the same expired token, and invalidated again.
+
+## The fix
+
+A pull channel, because a push channel cannot exist. `GET /auth/token` on the proxy
+returns a currently-valid access token for the caller's session cookie; the co-located
+Streamlit process asks whenever it needs one. Refreshing stays exclusively the proxy's
+job, so the refresh token keeps exactly one writer and there is no rotation race — the
+hazard that made local refresh unusable in the first place. It is guarded by a shared
+secret rather than the session cookie alone: the cookie is HttpOnly, but page script
+can still `fetch` with `credentials: 'include'` and read the response body.
+
+Alongside it: credential precedence reordered to explicit `auth_token` → session →
+`st_access` cookie on both paths, so the renewable credential is what the handshake
+carries; the header token adopted only when strictly newer; renewal scheduled ahead of
+expiry for session auth too (which also keeps Keycloak's SSO idle clock from running
+out on an idle tab); the refresher bounded by the Streamlit session's actual lifetime
+rather than a flag nothing sets when a tab closes; permissions preserved when a UMA
+lookup fails instead of blanked; and identity decoupled from token freshness, with
+"Missing user information" reserved for the one case it describes — a connection that
+never carried the proxy's headers.
+
+When renewal genuinely cannot succeed (SSO max lifetime, a revoked session) the page
+rides it out for a grace window and then asks the parent shell to renew via the
+`lex-auth-required` message 1z already established, falling back to a `target="_top"`
+sign-in link. A Streamlit component iframe is sandboxed without `allow-top-navigation`,
+so a programmatic redirect would be silently blocked — the link is a user gesture and
+always permitted.
+
+`lex/streamlit_app.py`'s bootstrap moved under its `__name__ == "__main__"` guard so
+the module can be imported without firing Streamlit commands; Streamlit executes the
+file as `__main__`, so the app is unaffected and the lifecycle became testable.
+
+14 of the 17 scenarios fail against the pre-fix tree. The two that pass (1.228, 1.230)
+are pre-existing correct behaviours kept as guards.

--- a/lex/test_project/tests/init/test_1ab_streamlit_session_survival.py
+++ b/lex/test_project/tests/init/test_1ab_streamlit_session_survival.py
@@ -1,0 +1,576 @@
+"""An open Streamlit dashboard survives being left idle.
+
+Intent: the auth proxy hands Streamlit its credentials in the headers of the
+WebSocket handshake, and Streamlit reads those headers off the *session's
+client* -- so they are a snapshot taken once, when the socket opened, and the
+socket then stays open for as long as the tab does. Nothing in a running script
+can produce a newer token by re-reading them. A dashboard left idle therefore
+outlives the credential it started with, and the framework has to renew ahead of
+expiry from a channel that is still live: the proxy's ``/auth/token``, which owns
+the refresh token and stays the only component allowed to spend it.
+
+A regression here is what the user actually sees. Before this batch an idle tab
+died on the access token's own lifetime and reported "Authentication Error:
+Missing user information" -- a message about identity headers that were in fact
+present, on a page that could not recover, because the next rerun re-read the
+same frozen headers and invalidated all over again. The two halves that make it
+survivable are easy to break independently: the proxy must hand over the
+*renewable* credential (its session, not the short-lived ``st_access`` cookie),
+and Streamlit must never let the frozen handshake copy overwrite a token it has
+just renewed.
+
+Cluster 1ab — scenarios 1.223–1.239. Type: U.
+Covers: lex/proxy.py (internal_token, proxy credential precedence, ws_proxy
+        credential precedence), lex/streamlit_app.py (_adopt_header_token,
+        _sync_tokens_from_headers, renew_access_token,
+        authenticate_from_proxy_or_jwt, sync_keycloak_context_from_access_token,
+        _token_refresher, start_token_refresh_thread_if_needed,
+        _within_renewal_grace).
+Run: python -m lex pytest lex/test_project/tests/init/test_1ab_streamlit_session_survival.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from base64 import b64encode
+from unittest.mock import patch
+
+import httpx
+import itsdangerous
+import jwt
+import pytest
+from django.test import SimpleTestCase
+from starlette.testclient import TestClient
+
+import lex.proxy as proxy
+import lex.streamlit_app as sa
+
+pytestmark = pytest.mark.init
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _epoch(delta_seconds: int) -> int:
+    return int(time.time()) + delta_seconds
+
+
+def _token(exp: int, sub: str = "u1") -> str:
+    """A Keycloak-shaped access token carrying ``exp`` (signature irrelevant here)."""
+    return jwt.encode({"sub": sub, "email": "u@example.com", "exp": exp}, "irrelevant", algorithm="HS256")
+
+
+def _session_cookie(sid: str = "sid-1", email: str = "u@example.com") -> str:
+    """A cookie SessionMiddleware will accept, minted the way it mints them."""
+    signer = itsdangerous.TimestampSigner(str(proxy.SESSION_SECRET))
+    data = b64encode(json.dumps({"user": {"email": email, "sid": sid}}).encode("utf-8"))
+    return signer.sign(data).decode("utf-8")
+
+
+class _CapturingUpstream:
+    """Stands in for the Streamlit upstream, recording what the proxy forwarded."""
+
+    last_headers: dict = {}
+
+    def __init__(self, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def request(self, method, url, content=None, headers=None):
+        _CapturingUpstream.last_headers = {k.lower(): v for k, v in (headers or {}).items()}
+        return httpx.Response(200, content=b"upstream-ok")
+
+
+class _FakeUpstreamWS:
+    """Stands in for the Streamlit WebSocket, recording the handshake headers."""
+
+    captured: dict = {}
+    subprotocol = None
+
+    def __init__(self, url, **kwargs):
+        _FakeUpstreamWS.captured = {
+            k.lower(): v for k, v in (kwargs.get(proxy.WS_HEADER_KWARG) or [])
+        }
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def send(self, data):
+        pass
+
+    async def recv(self):
+        import websockets
+
+        raise websockets.exceptions.ConnectionClosedOK(None, None)
+
+
+class _FakeState(dict):
+    """``st.session_state`` outside a script run."""
+
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key) from None
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+
+# ---------------------------------------------------------------------------
+# the proxy: handing over a renewable credential, and a way to pull a fresh one
+# ---------------------------------------------------------------------------
+class TestCluster01ab_ProxyRenewalChannel(SimpleTestCase):
+    """Cluster 1ab: the proxy is the single refresh authority, readable on demand."""
+
+    def setUp(self):
+        self.client = TestClient(proxy.app)
+        _CapturingUpstream.last_headers = {}
+
+    def _get_token(self, cookies: dict, secret: str | None):
+        headers = {}
+        if secret is not None:
+            headers[proxy.INTERNAL_AUTH_HEADER] = secret
+        self.client.cookies.update(cookies)
+        return self.client.get("/auth/token", headers=headers)
+
+    def test_1_223_token_endpoint_refuses_a_caller_without_the_internal_secret(self):
+        """
+        Scenario 1.223: the browser cannot read the raw access token.
+        Given: a valid proxy session cookie
+        When: /auth/token is requested without the internal shared secret
+        Then: 403 and no token in the body — the session cookie is HttpOnly but
+              page script can still fetch with credentials, so cookie alone must
+              not be enough to exfiltrate a bearer token
+        """
+        async def _tokens(_session):
+            return {"access_token": _token(_epoch(300)), "expires_at": _epoch(300)}
+
+        with patch.object(proxy, "_ensure_valid_access_token", _tokens):
+            response = self._get_token({"session": _session_cookie()}, secret=None)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertNotIn("access_token", response.json())
+
+    def test_1_224_token_endpoint_returns_a_token_that_is_valid_now(self):
+        """
+        Scenario 1.224: the pull returns a *refreshed* token, not the stored one.
+        Given: a session whose stored access token has already expired
+        When: the co-located Streamlit process pulls from /auth/token
+        Then: the response carries the renewed token and its expiry — a dashboard
+              asks precisely because what it holds has aged out, so echoing the
+              stale copy back would renew nothing
+        """
+        renewed_exp = _epoch(600)
+
+        async def _tokens(_session):
+            # This is _ensure_valid_access_token's contract: it refreshes first.
+            return {"access_token": _token(renewed_exp), "expires_at": renewed_exp, "email": "u@example.com"}
+
+        with patch.object(proxy, "_ensure_valid_access_token", _tokens):
+            response = self._get_token({"session": _session_cookie()}, secret=proxy.INTERNAL_AUTH_SECRET)
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["access_token"], _token(renewed_exp))
+        self.assertEqual(body["expires_at"], renewed_exp)
+
+    def test_1_225_token_endpoint_never_hands_out_the_refresh_token(self):
+        """
+        Scenario 1.225: spending the refresh token stays single-writer.
+        Given: a session whose token set includes a refresh token
+        When: Streamlit pulls a fresh access token
+        Then: the refresh token is absent from the response — two components
+              rotating the same refresh token is exactly the race that made
+              local refresh unusable, and handing it over would reintroduce it
+        """
+        async def _tokens(_session):
+            return {
+                "access_token": _token(_epoch(300)),
+                "refresh_token": "rt-secret",
+                "expires_at": _epoch(300),
+            }
+
+        with patch.object(proxy, "_ensure_valid_access_token", _tokens):
+            response = self._get_token({"session": _session_cookie()}, secret=proxy.INTERNAL_AUTH_SECRET)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("refresh_token", response.json())
+        self.assertNotIn("rt-secret", response.text)
+
+    def test_1_226_token_endpoint_reports_an_unrenewable_session_as_401(self):
+        """
+        Scenario 1.226: a dead session is an auth answer, not an empty success.
+        Given: a session whose tokens can no longer be refreshed
+        When: Streamlit pulls
+        Then: 401 — the caller has to distinguish "renewed" from "sign in again",
+              and a 200 with no token would read as the former
+        """
+        async def _tokens(_session):
+            return None
+
+        with patch.object(proxy, "_ensure_valid_access_token", _tokens):
+            response = self._get_token({"session": _session_cookie()}, secret=proxy.INTERNAL_AUTH_SECRET)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_1_227_session_outranks_the_short_lived_access_cookie(self):
+        """
+        Scenario 1.227: the handshake gets the renewable credential.
+        Given: a request carrying both an st_access cookie and a proxy session
+        When: it is proxied to Streamlit
+        Then: it is forwarded as session auth *with* the refresh token — the
+              cookie is set on every login, so consulting it first classified a
+              freshly logged-in user as jwt with no refresh token at all, an
+              unrenewable credential that expired minutes into the session
+        """
+        cookie_exp = _epoch(300)
+
+        async def _tokens(_session):
+            return {
+                "access_token": _token(_epoch(600)),
+                "refresh_token": "rt-session",
+                "expires_at": _epoch(600),
+            }
+
+        with patch.object(proxy, "validate_jwt_token", lambda t: {"sub": "u1", "exp": cookie_exp}), \
+             patch.object(proxy, "_ensure_valid_access_token", _tokens), \
+             patch.object(proxy.httpx, "AsyncClient", _CapturingUpstream):
+            self.client.cookies.update({"st_access": _token(cookie_exp), "session": _session_cookie()})
+            response = self.client.get("/dashboard")
+
+        self.assertEqual(response.status_code, 200)
+        forwarded = _CapturingUpstream.last_headers
+        self.assertEqual(
+            forwarded.get("x-streamlit-auth-method"), "session",
+            "A request with a live session must reach Streamlit as session auth.",
+        )
+        self.assertEqual(
+            forwarded.get("x-streamlit-refresh-token"), "rt-session",
+            "Without the refresh token the dashboard has nothing to renew against.",
+        )
+
+    def test_1_228_an_explicit_auth_token_still_outranks_the_session(self):
+        """
+        Scenario 1.228: the embedded renewal handoff keeps its precedence.
+        Given: a request carrying both ?auth_token= and a proxy session
+        When: it is proxied
+        Then: the explicit token wins — re-sourcing the iframe with a fresh
+              auth_token is how the embedded dashboard renews, and demoting it
+              below the session would discard every renewal the frontend sends
+        """
+        handoff = _token(_epoch(900), sub="handoff")
+
+        async def _tokens(_session):
+            return {"access_token": _token(_epoch(600)), "refresh_token": "rt-session", "expires_at": _epoch(600)}
+
+        with patch.object(proxy, "validate_jwt_token", lambda t: {"sub": "handoff", "exp": _epoch(900)}), \
+             patch.object(proxy, "_ensure_valid_access_token", _tokens), \
+             patch.object(proxy, "PERSIST_JWT_AUTH_TO_SESSION", False), \
+             patch.object(proxy.httpx, "AsyncClient", _CapturingUpstream):
+            self.client.cookies.update({"session": _session_cookie()})
+            response = self.client.get(f"/dashboard?auth_token={handoff}")
+
+        self.assertEqual(response.status_code, 200)
+        forwarded = _CapturingUpstream.last_headers
+        self.assertEqual(forwarded.get("x-streamlit-auth-method"), "jwt")
+        self.assertEqual(forwarded.get("x-streamlit-access-token"), handoff)
+
+    def test_1_239_the_websocket_handshake_carries_the_renewable_credential(self):
+        """
+        Scenario 1.239: the one moment that matters gets the right credential.
+        Given: a WebSocket handshake carrying both an st_access cookie and a
+               proxy session
+        When: it is proxied to Streamlit
+        Then: it is forwarded as session auth with the refresh token — the
+              handshake is the *only* point at which a connection that then stays
+              open for hours is handed anything, so classifying it from the
+              short-lived cookie leaves the dashboard holding an unrenewable
+              token for the rest of its life
+        """
+        async def _tokens(_session):
+            return {
+                "access_token": _token(_epoch(600)),
+                "refresh_token": "rt-session",
+                "expires_at": _epoch(600),
+            }
+
+        with patch.object(proxy, "validate_jwt_token", lambda t: {"sub": "u1", "exp": _epoch(300)}), \
+             patch.object(proxy, "_ensure_valid_access_token", _tokens), \
+             patch.object(proxy, "ws_connect", _FakeUpstreamWS):
+            self.client.cookies.update({"st_access": _token(_epoch(300)), "session": _session_cookie()})
+            with self.client.websocket_connect("/_stcore/stream"):
+                pass
+
+        forwarded = _FakeUpstreamWS.captured
+        self.assertEqual(
+            forwarded.get("x-streamlit-auth-method"), "session",
+            "The handshake must classify a live session as session auth.",
+        )
+        self.assertEqual(
+            forwarded.get("x-streamlit-refresh-token"), "rt-session",
+            "Without a refresh token on the handshake the session cannot be renewed at all.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Streamlit: never lose a renewal, never lose the user
+# ---------------------------------------------------------------------------
+class TestCluster01ab_StreamlitTokenLifecycle(SimpleTestCase):
+    """Cluster 1ab: a running dashboard renews itself and keeps its user."""
+
+    def test_1_229_a_stale_handshake_token_never_replaces_a_renewed_one(self):
+        """
+        Scenario 1.229: renewals are not undone on the next rerun.
+        Given: session state holding a token renewed after the socket opened
+        When: the script reruns and re-reads the frozen handshake headers
+        Then: the renewed token is kept — the headers cannot change without a new
+              handshake, so adopting whatever differs from what we hold reverts
+              every renewal and puts the session back on the token it escaped
+        """
+        renewed = _token(_epoch(600))
+        stale = _token(_epoch(-60))
+        state = _FakeState(access_token=renewed, token_exp=_epoch(600), refresh_token="")
+
+        with patch.object(sa.st, "session_state", state):
+            sa._sync_tokens_from_headers({"x-streamlit-access-token": stale})
+
+        self.assertEqual(state["access_token"], renewed, "A renewal must not be reverted by frozen headers.")
+
+    def test_1_230_a_genuinely_newer_handshake_token_is_adopted(self):
+        """
+        Scenario 1.230: a reconnect or a re-sourced iframe is picked up.
+        Given: session state holding a token that is about to expire
+        When: a new handshake delivers one with a later expiry
+        Then: the newer token is adopted — a dropped socket reconnecting through
+              the proxy is a legitimate renewal path and must not be ignored just
+              because we already hold something
+        """
+        newer_exp = _epoch(900)
+        newer = _token(newer_exp)
+        state = _FakeState(access_token=_token(_epoch(30)), token_exp=_epoch(30), refresh_token="")
+
+        with patch.object(sa.st, "session_state", state):
+            sa._sync_tokens_from_headers({"x-streamlit-access-token": newer})
+
+        self.assertEqual(state["access_token"], newer)
+        self.assertEqual(state["token_exp"], newer_exp)
+
+    def test_1_231_renewal_pulls_from_the_proxy_and_leaves_the_refresh_token_alone(self):
+        """
+        Scenario 1.231: the proxy renews; Streamlit does not.
+        Given: an expired access token, a reachable proxy, and a refresh token in
+               session state
+        When: renewal runs
+        Then: the token comes from the proxy and the refresh token is untouched —
+              both sides spending the same refresh token is the rotation race the
+              pull channel exists to avoid
+        """
+        pulled = _token(_epoch(600))
+        state = _FakeState(access_token=_token(_epoch(-60)), token_exp=_epoch(-60), refresh_token="rt-original")
+
+        def _fake_get(url, headers=None, timeout=None):
+            self.assertIn("/auth/token", url)
+            self.assertEqual(headers["Cookie"], "session=abc")
+            return httpx.Response(200, json={"access_token": pulled, "expires_at": _epoch(600)})
+
+        def _must_not_refresh(_rt):
+            self.fail("Streamlit must not spend the refresh token while the proxy answers.")
+
+        with patch.object(sa.st, "session_state", state), \
+             patch.dict(os.environ, {"LEX_INTERNAL_AUTH_SECRET": "s3cret"}), \
+             patch.object(sa, "_live_headers", lambda: {"cookie": "session=abc"}), \
+             patch.object(sa.requests, "get", _fake_get), \
+             patch.object(sa, "_post_refresh", _must_not_refresh):
+            self.assertTrue(sa.renew_access_token())
+
+        self.assertEqual(state["access_token"], pulled)
+        self.assertEqual(state["refresh_token"], "rt-original")
+
+    def test_1_232_renewal_falls_back_to_the_refresh_token_when_no_proxy_answers(self):
+        """
+        Scenario 1.232: a deployment without the proxy still renews.
+        Given: an expired token, an unreachable proxy, and a refresh token
+        When: renewal runs
+        Then: the refresh token is spent and a new token stored — with the proxy
+              silent there is no second writer to race, and `streamlit run`
+              without the proxy must not be left with a dead session
+        """
+        refreshed = _token(_epoch(600))
+        state = _FakeState(access_token=_token(_epoch(-60)), token_exp=_epoch(-60), refresh_token="rt-original")
+
+        def _unreachable(*a, **kw):
+            raise ConnectionError("proxy down")
+
+        with patch.object(sa.st, "session_state", state), \
+             patch.dict(os.environ, {"LEX_INTERNAL_AUTH_SECRET": "s3cret"}), \
+             patch.object(sa, "_live_headers", lambda: {"cookie": "session=abc"}), \
+             patch.object(sa.requests, "get", _unreachable), \
+             patch.object(sa, "_post_refresh", lambda rt: {"access_token": refreshed, "refresh_token": "rt-next"}):
+            self.assertTrue(sa.renew_access_token())
+
+        self.assertEqual(state["access_token"], refreshed)
+        self.assertEqual(state["refresh_token"], "rt-next")
+
+    def test_1_233_identity_survives_a_token_that_cannot_be_renewed(self):
+        """
+        Scenario 1.233: an expired credential is not a missing user.
+        Given: an authenticated session whose token has expired and whose every
+               renewal path fails
+        When: the script reruns
+        Then: the user stays authenticated and identified, flagged only as
+              needing renewal — clearing identity here produced the "Missing user
+              information" dead end, a message about headers that were present,
+              on a page that re-entered the same failure on every rerun
+        """
+        state = _FakeState(
+            authenticated=True,
+            auth_method="session",
+            user_id="u1",
+            user_email="u@example.com",
+            user_username="u",
+            access_token=_token(_epoch(-60)),
+            token_exp=_epoch(-60),
+            refresh_token="",
+            permissions=["read"],
+        )
+
+        with patch.object(sa.st, "session_state", state), \
+             patch.object(sa, "_live_headers", lambda: {}), \
+             patch.object(sa.st, "context", type("C", (), {"headers": {}})()), \
+             patch.object(sa, "start_token_refresh_thread_if_needed", lambda: None), \
+             patch.object(sa, "sync_keycloak_context_from_access_token", lambda: None), \
+             patch.object(sa.requests, "get", lambda *a, **kw: httpx.Response(401)):
+            sa.authenticate_from_proxy_or_jwt()
+
+        self.assertTrue(state["authenticated"], "An aged-out token must not log the user out.")
+        self.assertEqual(state["user_id"], "u1")
+        self.assertEqual(state["user_email"], "u@example.com")
+        self.assertTrue(state["token_renewal_failed"], "The renewal problem must still be recorded.")
+
+    def test_1_234_permissions_are_kept_when_the_keycloak_lookup_fails(self):
+        """
+        Scenario 1.234: a Keycloak blip does not demote the user.
+        Given: a valid token and a UMA permission lookup that raises
+        When: the Keycloak context is synced
+        Then: the permissions already resolved are kept — replacing them with an
+              empty list silently strips the user's access mid-session, which
+              reads as a broken dashboard rather than a transient outage
+        """
+        state = _FakeState(
+            access_token=_token(_epoch(600)),
+            token_exp=_epoch(600),
+            refresh_token="",
+            permissions=["read", "write"],
+            keycloak_context_token="",
+            user_id="u1",
+            user_email="u@example.com",
+            user_username="u",
+            auth_method="session",
+        )
+
+        def _boom(*a, **kw):
+            raise RuntimeError("keycloak unreachable")
+
+        with patch.object(sa.st, "session_state", state), \
+             patch.object(sa, "get_user_info", lambda t: None), \
+             patch("lex.api.views.authentication.KeycloakManager.KeycloakManager.get_uma_permissions", _boom):
+            sa.sync_keycloak_context_from_access_token()
+
+        self.assertEqual(state["permissions"], ["read", "write"])
+
+    def test_1_235_the_refresher_runs_for_proxy_managed_session_auth(self):
+        """
+        Scenario 1.235: session auth is renewed too.
+        Given: session auth and no refresh token of our own
+        When: the app starts its token refresher
+        Then: a refresher thread is running — "the proxy handles it" meant nobody
+              handled it, because the proxy can only deliver a credential at
+              handshake time and the handshake happens once
+        """
+        state = _FakeState(auth_method="session", refresh_token="", access_token="", token_exp=0,
+                           stop_token_refresher=False, token_refresher_thread=None,
+                           token_refresher_started=False)
+
+        with patch.object(sa.st, "session_state", state), \
+             patch.object(sa, "RENEW_POLL_SECONDS", 0.01), \
+             patch.object(sa, "get_script_run_ctx", lambda: None), \
+             patch.object(sa, "add_script_run_ctx", lambda th, ctx: th):
+            sa.start_token_refresh_thread_if_needed()
+            thread = state["token_refresher_thread"]
+            try:
+                self.assertIsNotNone(thread, "Session auth must get a refresher, not be exempted from one.")
+                self.assertTrue(thread.is_alive())
+            finally:
+                state["stop_token_refresher"] = True
+                thread.join(timeout=5)
+
+        self.assertFalse(thread.is_alive())
+
+    def test_1_236_the_refresher_stops_once_the_streamlit_session_is_gone(self):
+        """
+        Scenario 1.236: a closed tab does not leave a thread renewing forever.
+        Given: a refresher whose Streamlit session has been torn down
+        When: it next checks
+        Then: it returns — closing a tab sets no session-state flag, so a
+              refresher that only watched that flag outlived every abandoned
+              session it was started for
+        """
+        state = _FakeState(stop_token_refresher=False, token_exp=_epoch(600))
+
+        with patch.object(sa.st, "session_state", state), \
+             patch.object(sa, "_session_is_live", lambda sid: False):
+            started = time.time()
+            sa._token_refresher("dead-session")
+            elapsed = time.time() - started
+
+        self.assertLess(elapsed, 2.0, "A refresher for a dead session must exit immediately.")
+
+    def test_1_237_a_transient_renewal_failure_stays_invisible(self):
+        """
+        Scenario 1.237: a proxy restart does not interrupt the reader.
+        Given: renewal has just started failing
+        When: the page renders
+        Then: it renders normally — a failure that the refresher is still
+              retrying must not put a re-authentication notice in front of
+              someone who is simply reading a chart
+        """
+        state = _FakeState(token_renewal_failed=True, renewal_failing_since=0)
+
+        with patch.object(sa.st, "session_state", state):
+            self.assertTrue(sa._within_renewal_grace())
+            self.assertTrue(state["renewal_failing_since"], "The failure must be stamped so the grace can expire.")
+
+    def test_1_238_a_persistent_renewal_failure_surfaces_recovery(self):
+        """
+        Scenario 1.238: a structurally dead session asks for a sign-in.
+        Given: renewal that has been failing for longer than the grace window
+        When: the page renders
+        Then: the grace is over — past this point the failure is Keycloak's SSO
+              max lifetime or a revoked session, and retrying silently forever
+              leaves the user staring at data that can no longer be refreshed
+        """
+        state = _FakeState(
+            token_renewal_failed=True,
+            renewal_failing_since=_epoch(-(sa.RENEWAL_GRACE_SECONDS + 10)),
+        )
+
+        with patch.object(sa.st, "session_state", state):
+            self.assertFalse(sa._within_renewal_grace())
+
+        # ...and a renewal that recovers clears the stamp, so the next blip gets
+        # its own full grace window rather than inheriting a stale deadline.
+        recovered = _FakeState(token_renewal_failed=False, renewal_failing_since=_epoch(-999))
+        with patch.object(sa.st, "session_state", recovered):
+            self.assertTrue(sa._within_renewal_grace())
+        self.assertEqual(recovered["renewal_failing_since"], 0)


### PR DESCRIPTION
## The bug

A Streamlit dashboard left idle shows:

> ❌ Authentication Error: Missing user information.
> Please access this application through the main portal.

The message is doubly wrong — the identity headers *were* present, and the page could not recover from it.

## Root cause

`st.context.headers` is not "the current request". It resolves the **session's client**, i.e. the HTTP handshake that opened the WebSocket — frozen for as long as that socket lives, which with Streamlit's pings is hours. The access token it carries lives minutes. Nothing a running script can do produces a newer one.

Session auth then had local refresh **deliberately** disabled, on the reasoning that renewal is the proxy's job. That is true of the proxy's own traffic and false of the dashboard's: the proxy can only hand a credential over at handshake time, and the handshake happens once. So "the proxy handles it" meant nobody handled it.

Three defects compounded it:

- `auth_callback` sets the short-lived `st_access` cookie on **every** login, and both the HTTP and WebSocket paths consulted that cookie *before* the server-side session — so a perfectly normal login reached Streamlit as `auth_method="jwt"` with `refresh_token: None`, an unrenewable credential, minutes from death.
- `_sync_tokens_from_headers` adopted the header token whenever it merely *differed* from the stored one. After a successful renewal the frozen header copy is the older one, so every rerun reverted the renewal that had just landed.
- The expiry path called `_invalidate_local_auth`, clearing user id, email and username — hence the message. And it was sticky rather than transient: the next rerun re-read the same frozen headers, found the same expired token, and invalidated again.

## The fix

A **pull** channel, because a push channel cannot exist. `GET /auth/token` on the proxy returns a currently-valid access token for the caller's session cookie; the co-located Streamlit process asks whenever it needs one. Refreshing stays exclusively the proxy's job, so the refresh token keeps exactly one writer and there is no rotation race — the hazard that made local refresh unusable in the first place. It is guarded by a shared secret rather than the session cookie alone: the cookie is HttpOnly, but page script can still `fetch` with `credentials: 'include'` and read the response body.

Alongside it:

- credential precedence reordered to explicit `auth_token` → session → `st_access` cookie on **both** paths, so the handshake carries the renewable credential;
- the header token adopted only when strictly newer;
- renewal scheduled ahead of expiry for session auth too — which also keeps Keycloak's SSO idle clock from running out on an idle tab;
- the refresher bounded by the Streamlit session's actual lifetime rather than a flag nothing sets when a tab closes;
- permissions preserved when a UMA lookup fails, instead of blanked to `[]`;
- identity decoupled from token freshness, with "Missing user information" reserved for the one case it describes — a connection that never carried the proxy's headers.

Renewal is invisible to the user. The recovery screen only appears past a 120s grace window, when the cause is structurally unfixable (Keycloak SSO max lifetime, a revoked session), and it first asks the parent shell to renew via the `lex-auth-required` message batch 1z already established. A Streamlit component iframe is sandboxed without `allow-top-navigation`, so a programmatic redirect would be silently blocked — the `target="_top"` link is a user gesture and always permitted.

`lex/streamlit_app.py`'s bootstrap moved under its `__name__ == "__main__"` guard so the module can be imported without firing Streamlit commands. Streamlit executes the file as `__main__`, so the app is unaffected and the lifecycle became testable.

## Verification

- **New batch 1ab**, scenarios 1.223–1.239 in `lex/test_project/tests/init/test_1ab_streamlit_session_survival.py` — **17 pass / 0 fail**.
- **14 of the 17 fail against the pre-fix tree.** The two that pass (1.228 explicit-`auth_token` precedence, 1.230 adopting a genuinely newer header token) are pre-existing correct behaviours kept as guards.
- Whole `init` cluster — which owns every test touching `lex/proxy.py`, `lex/streamlit_app.py` and `lex/bin/lex.py` — **315 pass / 13 skip, 87 subtests pass**.
- End-to-end smoke over a real socket: an expired token in a live session is replaced by a proxy-refreshed one, the local refresh token is never spent, and `/auth/token` 403s without the secret.

```bash
python -m lex pytest lex/test_project/tests/init/ -v
```

## Test-plan sync (directive 3)

`allocation.yaml` (`max_scenario` → 239, letter `ab`), `cluster.md`, `batches.md`, a new session record under `progress/sessions/`, and a regenerated `dashboard.md`. Docs updated for the three new environment variables and the staying-signed-in behaviour.

## Note, unrelated to this change

`python -m lex pytest lex/test_project/tests/` aborts before running: the `design_system` marker is not declared under `groups:` in `lex_test_config.yaml`. Pre-existing on `lex-app-v2`, left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)