### PR TITLE
fix(as_of): interpret a naive anchor in the configured zone, and say so

### DIFF
--- a/lex/api/utils/temporal.py
+++ b/lex/api/utils/temporal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone as dt_timezone
 from typing import Optional
 
@@ -7,15 +8,35 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
+logger = logging.getLogger(__name__)
+
 
 def parse_as_of_datetime(raw_value: str | None) -> Optional[datetime]:
     """
     Parse an incoming as_of query value and normalize it to UTC.
 
     Rules:
-    - Naive datetimes are interpreted as UTC.
-    - Offset-aware datetimes are converted to UTC.
+    - Offset-aware datetimes are converted to UTC. This is the form clients
+      should send: it carries the answer, so the server never has to guess.
+    - Naive datetimes are interpreted in the CONFIGURED timezone
+      (``timezone.get_current_timezone()``), and log a warning.
     - When USE_TZ is disabled, return a naive UTC datetime for ORM compatibility.
+
+    Why naive input follows the configured zone rather than UTC
+    ----------------------------------------------------------
+    It previously assumed UTC. That made ``as_of`` the only datetime input in the
+    API that did not follow DRF's own convention — ``DateTimeField.enforce_timezone``
+    interprets a naive value in ``timezone.get_current_timezone()`` — and it broke
+    the feature for every client sending local wall-clock: a Berlin anchor was
+    evaluated 1-2h in the future, so stepping back less than that offset never
+    reached the pre-edit state (customer report 2026-07-14).
+
+    Aligning the fallback makes a naive anchor correct for the configured zone,
+    and the warning makes the remaining guess visible instead of silent — a wrong
+    snapshot is worse than an error because it looks plausible.
+
+    The warning is not decoration: it is the signal that a client still needs
+    fixing. Once it stops appearing, the naive branch can be replaced with a 400.
     """
     if raw_value is None:
         return None
@@ -30,7 +51,16 @@ def parse_as_of_datetime(raw_value: str | None) -> Optional[datetime]:
         return None
 
     if timezone.is_naive(parsed):
-        parsed_utc = timezone.make_aware(parsed, dt_timezone.utc)
+        assumed_zone = timezone.get_current_timezone()
+        logger.warning(
+            "as_of received a naive datetime (%r); interpreting it in the "
+            "configured timezone (%s). Clients should send an absolute instant "
+            "with an offset or a Z designator so the server does not have to "
+            "guess.",
+            raw,
+            assumed_zone,
+        )
+        parsed_utc = timezone.make_aware(parsed, assumed_zone).astimezone(dt_timezone.utc)
     else:
         parsed_utc = parsed.astimezone(dt_timezone.utc)
 

--- a/lex/test_project/tests/history/test_5m_asof_edit_time.py
+++ b/lex/test_project/tests/history/test_5m_asof_edit_time.py
@@ -221,11 +221,14 @@ class TestCluster05m_ListEndpointAsOf(E2ETestCase):
     (``/api/model_entries/<model>/list?as_of=...``) — customer report
     2026-07-14: stepping back 1 min / 10 min / 1 h from an 11:22 edit never
     showed the pre-edit state. Root cause of the symptom: the client sent
-    naive LOCAL wall-clock, and the API contract interprets naive datetimes
-    as UTC (``parse_as_of_datetime``) — in Berlin summer every anchor less
-    than 2 h back still lands AFTER the edit in UTC. These scenarios pin the
-    backend side: with correct UTC anchors the endpoint time-travels
-    correctly, and naive values are interpreted as UTC by contract.
+    naive LOCAL wall-clock, and ``parse_as_of_datetime`` then read those digits
+    as UTC — so in Berlin summer every anchor less than 2 h back still landed
+    AFTER the edit. Both sides are now fixed: the client sends an absolute
+    instant, and a naive anchor is interpreted in the CONFIGURED timezone
+    (matching DRF's convention for every other datetime input) rather than
+    assumed to be UTC. These scenarios pin the backend side: an aware anchor
+    time-travels exactly, and a naive anchor denoting the same wall clock lands
+    on the same snapshot instead of overshooting by the zone's offset.
     """
 
     e2e_models = ALL_MODELS
@@ -269,33 +272,48 @@ class TestCluster05m_ListEndpointAsOf(E2ETestCase):
             "The list endpoint must show the current values at a present anchor.",
         )
 
-    def test_5_103_naive_as_of_is_interpreted_as_utc_by_contract(self) -> None:
+    def test_5_103_naive_as_of_follows_the_configured_timezone(self) -> None:
         """
-        Scenario 5.103: a NAIVE as_of value means UTC — not the caller's local
-        wall clock. This is the documented parse contract, and the exact trap
-        behind the customer report: a Berlin client sending naive local time
-        lands 2h in the future of the intended instant, so "1 minute before
-        my edit" still shows the post-edit state.
+        Scenario 5.103: a NAIVE as_of value is interpreted in the configured
+        timezone, not assumed to be UTC — so a client sending local wall-clock
+        lands on the instant it meant.
+
+        This is the exact trap behind the customer report: reading the digits as
+        UTC put a Berlin anchor 1-2 h in the future, so "1 minute before my edit"
+        still showed the post-edit state. Clients should send an absolute instant
+        (the frontend now does); this pins the fallback for anything that does
+        not, and matches DRF's convention for every other datetime input.
+
         Given: v1 created, then edited to v2
-        When: GET list?as_of=<naive pre-edit UTC value, no Z>
-        Then: identical result to the explicit-Z form (pre-edit values) —
-              proving naive == UTC, so clients MUST send UTC (or an offset)
+        When:  GET list?as_of=<pre-edit local wall clock, no offset>
+        Then:  the same snapshot as the offset-bearing form of that wall clock
+
+        Zone-agnostic on purpose: it asserts the two forms AGREE, which holds in
+        any TIME_ZONE under the new rule and fails under the old one whenever
+        TIME_ZONE is not UTC.
         """
         item, t_before_edit = self._create_and_edit()
 
-        # Build a genuinely naive string (no Z, no offset). Under USE_TZ=True
-        # lex_datetime_now() is aware, so strip the tzinfo to test the "naive
-        # anchor is read as UTC" contract rather than accidentally sending +00:00.
-        t_naive = (
-            t_before_edit if dj_tz.is_naive(t_before_edit)
-            else dj_tz.make_naive(t_before_edit, dt_timezone.utc)
+        # What a client actually sends: its own wall clock, with no zone. Under
+        # USE_TZ=True lex_datetime_now() is aware, so render it in the configured
+        # zone and strip the offset.
+        local = (
+            dj_tz.localtime(t_before_edit) if dj_tz.is_aware(t_before_edit)
+            else t_before_edit
         )
-        naive = t_naive.isoformat()  # no Z, no offset — naive on purpose
+        naive = local.replace(tzinfo=None).isoformat()  # no Z, no offset
+        aware = local.isoformat()  # same wall clock, offset attached
+
+        self.assertEqual(
+            self._list_names(naive), self._list_names(aware),
+            "A naive as_of must denote the same instant as that wall clock with "
+            "its offset attached. If these differ, the parse layer is guessing a "
+            "zone the caller did not mean and every naive anchor time-travels to "
+            "the wrong instant.",
+        )
         self.assertEqual(
             self._list_names(naive), ["v1"],
-            "A naive as_of must be read as UTC (parse contract). If this "
-            "fails, the parse layer drifted and every naive client anchor "
-            "time-travels to the wrong instant.",
+            "The pre-edit wall clock must reach the pre-edit snapshot.",
         )
         # And the same instant expressed with an explicit +02:00 offset (a
         # Berlin client converting correctly) must land identically.

--- a/lex/tests/unit/api/test_as_of_parsing.py
+++ b/lex/tests/unit/api/test_as_of_parsing.py
@@ -1,0 +1,108 @@
+"""
+Tests for ``parse_as_of_datetime`` — the ``?as_of=`` anchor parser.
+
+Verifies:
+    • An offset-aware anchor is normalized to UTC unchanged (the form clients
+      should send: it carries its own zone, so the server never guesses)
+    • A NAIVE anchor is interpreted in the configured timezone, with the offset
+      in force on that value's own date (DST-correct, not a fixed shift)
+    • A naive anchor logs a warning — the signal that a client still needs fixing
+    • An aware anchor logs nothing
+    • Blank, None and unparseable input yield None
+
+Background: the naive branch previously assumed UTC, which made ``as_of`` the
+only datetime input in the API not following DRF's convention
+(``DateTimeField.enforce_timezone`` uses ``get_current_timezone()``). A Berlin
+client sending local wall-clock was evaluated 1-2h in the future, so stepping
+back less than that offset never reached the pre-edit state (customer report
+2026-07-14).
+"""
+
+from datetime import datetime, timezone as dt_timezone
+
+from django.test import SimpleTestCase, override_settings
+
+from lex.api.utils.temporal import parse_as_of_datetime
+
+
+@override_settings(USE_TZ=True, TIME_ZONE="Europe/Berlin")
+class AsOfParsingTests(SimpleTestCase):
+    def test_aware_z_anchor_is_normalized_to_utc_unchanged(self):
+        self.assertEqual(
+            parse_as_of_datetime("2026-07-15T12:30:00Z"),
+            datetime(2026, 7, 15, 12, 30, tzinfo=dt_timezone.utc),
+        )
+
+    def test_aware_offset_anchor_keeps_its_instant(self):
+        # 14:30+02:00 and 12:30Z are the same moment; both must land identically.
+        self.assertEqual(
+            parse_as_of_datetime("2026-07-15T14:30:00+02:00"),
+            parse_as_of_datetime("2026-07-15T12:30:00Z"),
+        )
+
+    def test_naive_anchor_uses_the_configured_zone_in_summer(self):
+        # CEST (+02): a client's 14:30 wall clock is 12:30Z.
+        self.assertEqual(
+            parse_as_of_datetime("2026-07-15T14:30:00"),
+            datetime(2026, 7, 15, 12, 30, tzinfo=dt_timezone.utc),
+        )
+
+    def test_naive_anchor_uses_the_configured_zone_in_winter(self):
+        # CET (+01): the same wall clock is 13:30Z. The offset comes from the
+        # value's own date, so this is not a fixed shift.
+        self.assertEqual(
+            parse_as_of_datetime("2026-01-15T14:30:00"),
+            datetime(2026, 1, 15, 13, 30, tzinfo=dt_timezone.utc),
+        )
+
+    def test_naive_anchor_is_no_longer_read_as_utc(self):
+        # The regression this parser caused: reading the digits as UTC placed the
+        # anchor 2h after the moment the user meant.
+        self.assertNotEqual(
+            parse_as_of_datetime("2026-07-15T14:30:00"),
+            datetime(2026, 7, 15, 14, 30, tzinfo=dt_timezone.utc),
+        )
+
+    @override_settings(USE_TZ=True, TIME_ZONE="UTC")
+    def test_naive_anchor_under_utc_configuration_is_unchanged(self):
+        # The old hardcoded behaviour is just the TIME_ZONE="UTC" case of the
+        # new rule — no special-casing needed.
+        self.assertEqual(
+            parse_as_of_datetime("2026-07-15T14:30:00"),
+            datetime(2026, 7, 15, 14, 30, tzinfo=dt_timezone.utc),
+        )
+
+    def test_naive_anchor_logs_a_warning(self):
+        with self.assertLogs("lex.api.utils.temporal", level="WARNING") as captured:
+            parse_as_of_datetime("2026-07-15T14:30:00")
+        self.assertTrue(
+            any("naive datetime" in line for line in captured.output),
+            f"expected a naive-anchor warning, got {captured.output}",
+        )
+
+    def test_aware_anchor_logs_nothing(self):
+        with self.assertNoLogs("lex.api.utils.temporal", level="WARNING"):
+            parse_as_of_datetime("2026-07-15T12:30:00Z")
+
+    def test_blank_and_unparseable_input_yields_none(self):
+        for raw in (None, "", "   ", "not-a-date"):
+            with self.subTest(raw=raw):
+                self.assertIsNone(parse_as_of_datetime(raw))
+
+    @override_settings(USE_TZ=False, TIME_ZONE="Europe/Berlin")
+    def test_use_tz_disabled_returns_naive_utc_for_orm_compatibility(self):
+        parsed = parse_as_of_datetime("2026-07-15T14:30:00+02:00")
+        self.assertIsNone(parsed.tzinfo)
+        self.assertEqual(parsed, datetime(2026, 7, 15, 12, 30))
+
+    def test_dst_offset_comes_from_the_values_own_date(self):
+        # Guards against anyone replacing the zone lookup with a fixed offset:
+        # the same wall clock resolves to different instants in CEST and CET.
+        summer = parse_as_of_datetime("2026-07-15T14:30:00")
+        winter = parse_as_of_datetime("2026-01-15T14:30:00")
+        self.assertEqual(summer.hour, 12, "14:30 CEST is 12:30Z")
+        self.assertEqual(winter.hour, 13, "14:30 CET is 13:30Z")
+        self.assertNotEqual(
+            summer.hour, winter.hour,
+            "a fixed offset would resolve both wall clocks to the same hour",
+        )


### PR DESCRIPTION
## What

`parse_as_of_datetime` assumed **UTC** for a naive `?as_of=` value. That made `as_of` the only datetime input in the API not following DRF's own convention — `DateTimeField.enforce_timezone` interprets a naive value in `timezone.get_current_timezone()` — and it broke valid-time travel for any client sending local wall-clock.

A Berlin anchor was evaluated **1–2 h in the future**, so stepping back less than that offset never reached the pre-edit state. Reported by a customer on **2026-07-14**.

Note the `TIME_ZONE`/`USE_TZ` fix deployed on 22 July did **not** help this path: it never consulted `TIME_ZONE` at all.

## The change

A naive anchor is now interpreted in the configured timezone, and logs a warning:

```python
assumed_zone = timezone.get_current_timezone()
logger.warning("as_of received a naive datetime (%r); interpreting it in the "
               "configured timezone (%s). ...", raw, assumed_zone)
parsed_utc = timezone.make_aware(parsed, assumed_zone).astimezone(dt_timezone.utc)
```

The warning is not decoration — it is the signal that a client still needs fixing. A wrong snapshot is worse than an error because it looks plausible, which is why this went unnoticed for weeks.

## Verified in isolation

`TIME_ZONE=Europe/Berlin`, `USE_TZ=True`:

| input | result |
|---|---|
| `2026-07-15T14:30:00` (naive, summer) | `2026-07-15 12:30:00+00:00` (CEST +02) |
| `2026-01-15T14:30:00` (naive, winter) | `2026-01-15 13:30:00+00:00` (CET +01) |
| `2026-07-15T12:30:00Z` | unchanged |
| `2026-07-15T14:30:00+02:00` | same instant as the `Z` form |
| `''` / `None` / `not-a-date` | `None` |

The offset comes from **each value's own date**, so this is DST-correct rather than a fixed shift.

## Tests

- **New:** `lex/tests/unit/api/test_as_of_parsing.py` — 11 tests, **all passing locally** against configured settings: aware `Z`, aware offset, naive summer/winter, naive under `TIME_ZONE=UTC` (showing the old behaviour is just a special case of the new rule), blank/unparseable, `USE_TZ=False`, and that the warning fires on naive and **not** on aware.
- **Retargeted:** scenario 5.103 in the history cluster, from *"naive means UTC by contract"* to *"naive follows the configured timezone"*. Written zone-agnostically: it asserts the naive and offset-bearing forms of the same wall clock **agree**, which holds in any `TIME_ZONE` under the new rule and fails under the old one whenever `TIME_ZONE` is not UTC.

**Not run locally:** the E2E history cluster needs the framework's own bootstrap (`python -m lex pytest`) and a database, so scenario 5.103 must be validated in CI. The unit suite above was executed.

## No data migration

`as_of` is a request parameter — stored in no column, no model field, no persisted client state — compared against bitemporal windows that were never corrupted. A wrong anchor produced wrong **answers**, never wrong **rows**.

## Merge order

Independent of the client fix — safe in either order. The client counterpart is ExcellenceCloudGmbH/process-admin-general-client#472.

Stacked on top: **#725**, which replaces this fallback with a 400. Merge that **only after** these warnings have stopped appearing in production logs.
