### PR TITLE
fix(as_of)!: reject a naive anchor with 400 instead of guessing a zone

### DIFF
--- a/lex/api/utils/temporal.py
+++ b/lex/api/utils/temporal.py
@@ -7,6 +7,7 @@ from typing import Optional
 from django.conf import settings
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
+from rest_framework.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -16,27 +17,27 @@ def parse_as_of_datetime(raw_value: str | None) -> Optional[datetime]:
     Parse an incoming as_of query value and normalize it to UTC.
 
     Rules:
-    - Offset-aware datetimes are converted to UTC. This is the form clients
-      should send: it carries the answer, so the server never has to guess.
-    - Naive datetimes are interpreted in the CONFIGURED timezone
-      (``timezone.get_current_timezone()``), and log a warning.
+    - Offset-aware datetimes are converted to UTC. This is the only accepted
+      form: it carries its own zone, so the server never has to guess.
+    - Naive datetimes are REJECTED with a 400 (``ValidationError``).
     - When USE_TZ is disabled, return a naive UTC datetime for ORM compatibility.
 
-    Why naive input follows the configured zone rather than UTC
-    ----------------------------------------------------------
-    It previously assumed UTC. That made ``as_of`` the only datetime input in the
-    API that did not follow DRF's own convention — ``DateTimeField.enforce_timezone``
-    interprets a naive value in ``timezone.get_current_timezone()`` — and it broke
-    the feature for every client sending local wall-clock: a Berlin anchor was
-    evaluated 1-2h in the future, so stepping back less than that offset never
-    reached the pre-edit state (customer report 2026-07-14).
+    Why a naive anchor is rejected rather than assumed
+    -------------------------------------------------
+    Every guess here is a silent wrong answer. A naive anchor originally assumed
+    UTC, which put a Berlin client's wall clock 1-2h in the future: stepping back
+    less than that offset never reached the pre-edit state, and the endpoint
+    returned a plausible snapshot of the wrong version (customer report
+    2026-07-14). The previous commit made the guess follow the configured
+    timezone and logged it, which was correct for the common case but still a
+    guess — wrong for any caller in another zone.
 
-    Aligning the fallback makes a naive anchor correct for the configured zone,
-    and the warning makes the remaining guess visible instead of silent — a wrong
-    snapshot is worse than an error because it looks plausible.
-
-    The warning is not decoration: it is the signal that a client still needs
-    fixing. Once it stops appearing, the naive branch can be replaced with a 400.
+    Now that every first-party client sends an absolute instant
+    (process-admin-general-client ``toAsOfIsoString``), a naive anchor is a bug
+    rather than a use case, and failing loudly makes it immediately visible
+    instead of quietly time-travelling to the wrong instant. This is only
+    tenable because the callers are first-party; it is a deliberate contract
+    narrowing, not a defensive default.
     """
     if raw_value is None:
         return None
@@ -51,18 +52,25 @@ def parse_as_of_datetime(raw_value: str | None) -> Optional[datetime]:
         return None
 
     if timezone.is_naive(parsed):
-        assumed_zone = timezone.get_current_timezone()
+        # Logged as well as raised: the 400 tells the caller, the log tells us
+        # which client still needs fixing.
         logger.warning(
-            "as_of received a naive datetime (%r); interpreting it in the "
-            "configured timezone (%s). Clients should send an absolute instant "
-            "with an offset or a Z designator so the server does not have to "
-            "guess.",
+            "as_of rejected a naive datetime (%r): no timezone attached, so the "
+            "instant it denotes is ambiguous.",
             raw,
-            assumed_zone,
         )
-        parsed_utc = timezone.make_aware(parsed, assumed_zone).astimezone(dt_timezone.utc)
-    else:
-        parsed_utc = parsed.astimezone(dt_timezone.utc)
+        raise ValidationError(
+            {
+                "as_of": (
+                    "must carry a timezone — send an absolute instant such as "
+                    "2026-07-15T12:30:00Z or 2026-07-15T14:30:00+02:00. A value "
+                    "without an offset is ambiguous and would silently select "
+                    "the wrong snapshot."
+                )
+            }
+        )
+
+    parsed_utc = parsed.astimezone(dt_timezone.utc)
 
     if settings.USE_TZ:
         return parsed_utc

--- a/lex/test_project/tests/history/test_5m_asof_edit_time.py
+++ b/lex/test_project/tests/history/test_5m_asof_edit_time.py
@@ -224,11 +224,10 @@ class TestCluster05m_ListEndpointAsOf(E2ETestCase):
     naive LOCAL wall-clock, and ``parse_as_of_datetime`` then read those digits
     as UTC — so in Berlin summer every anchor less than 2 h back still landed
     AFTER the edit. Both sides are now fixed: the client sends an absolute
-    instant, and a naive anchor is interpreted in the CONFIGURED timezone
-    (matching DRF's convention for every other datetime input) rather than
-    assumed to be UTC. These scenarios pin the backend side: an aware anchor
-    time-travels exactly, and a naive anchor denoting the same wall clock lands
-    on the same snapshot instead of overshooting by the zone's offset.
+    instant, and the server REFUSES a naive anchor instead of guessing a zone
+    for it. These scenarios pin the backend side: an aware anchor time-travels
+    exactly, and an ambiguous one is a 400 rather than a plausible wrong
+    snapshot.
     """
 
     e2e_models = ALL_MODELS
@@ -242,9 +241,17 @@ class TestCluster05m_ListEndpointAsOf(E2ETestCase):
         item.save()
         return item, t_before_edit
 
-    def _list_names(self, as_of: str) -> list:
+    def _list_response(self, as_of: str):
+        """GET the list endpoint at ``as_of`` WITHOUT asserting the status.
+
+        ``_list_names`` requires 200; the rejection scenario needs the raw
+        response so it can assert a 400.
+        """
         url = self.url_list(HIST_SIMPLE) + f"?as_of={quote(str(as_of), safe='')}"
-        resp = self.client.get(url)
+        return self.client.get(url)
+
+    def _list_names(self, as_of: str) -> list:
+        resp = self._list_response(as_of)
         self.assertEqual(
             resp.status_code, status.HTTP_200_OK,
             f"list?as_of GET failed: {resp.status_code}",
@@ -272,31 +279,25 @@ class TestCluster05m_ListEndpointAsOf(E2ETestCase):
             "The list endpoint must show the current values at a present anchor.",
         )
 
-    def test_5_103_naive_as_of_follows_the_configured_timezone(self) -> None:
+    def test_5_103_naive_as_of_is_rejected_with_400(self) -> None:
         """
-        Scenario 5.103: a NAIVE as_of value is interpreted in the configured
-        timezone, not assumed to be UTC — so a client sending local wall-clock
-        lands on the instant it meant.
+        Scenario 5.103: a NAIVE as_of value is rejected, not guessed at.
 
-        This is the exact trap behind the customer report: reading the digits as
-        UTC put a Berlin anchor 1-2 h in the future, so "1 minute before my edit"
-        still showed the post-edit state. Clients should send an absolute instant
-        (the frontend now does); this pins the fallback for anything that does
-        not, and matches DRF's convention for every other datetime input.
+        A value with no offset does not denote an instant, and every guess the
+        server makes is a silent wrong answer: assuming UTC put a Berlin client's
+        wall clock 1-2 h in the future, so "1 minute before my edit" still showed
+        the post-edit state (customer report 2026-07-14). Every first-party
+        client now sends an absolute instant, so a naive anchor is a bug and a
+        400 surfaces it immediately.
 
         Given: v1 created, then edited to v2
-        When:  GET list?as_of=<pre-edit local wall clock, no offset>
-        Then:  the same snapshot as the offset-bearing form of that wall clock
-
-        Zone-agnostic on purpose: it asserts the two forms AGREE, which holds in
-        any TIME_ZONE under the new rule and fails under the old one whenever
-        TIME_ZONE is not UTC.
+        When:  GET list?as_of=<pre-edit wall clock, no offset>
+        Then:  400, and the error names the as_of field
+        And:   the same wall clock WITH its offset still returns the pre-edit
+               snapshot, proving only the ambiguous form is refused
         """
         item, t_before_edit = self._create_and_edit()
 
-        # What a client actually sends: its own wall clock, with no zone. Under
-        # USE_TZ=True lex_datetime_now() is aware, so render it in the configured
-        # zone and strip the offset.
         local = (
             dj_tz.localtime(t_before_edit) if dj_tz.is_aware(t_before_edit)
             else t_before_edit
@@ -304,16 +305,22 @@ class TestCluster05m_ListEndpointAsOf(E2ETestCase):
         naive = local.replace(tzinfo=None).isoformat()  # no Z, no offset
         aware = local.isoformat()  # same wall clock, offset attached
 
+        resp = self._list_response(naive)
         self.assertEqual(
-            self._list_names(naive), self._list_names(aware),
-            "A naive as_of must denote the same instant as that wall clock with "
-            "its offset attached. If these differ, the parse layer is guessing a "
-            "zone the caller did not mean and every naive anchor time-travels to "
-            "the wrong instant.",
+            resp.status_code, status.HTTP_400_BAD_REQUEST,
+            "A naive as_of must be refused. Accepting it means guessing a zone "
+            "the caller did not state, and the endpoint then returns a plausible "
+            "snapshot of the wrong version.",
         )
+        self.assertIn(
+            "as_of", str(resp.data),
+            f"the 400 should name the offending parameter, got {resp.data!r}",
+        )
+
         self.assertEqual(
-            self._list_names(naive), ["v1"],
-            "The pre-edit wall clock must reach the pre-edit snapshot.",
+            self._list_names(aware), ["v1"],
+            "The same wall clock with its offset attached must still time-travel "
+            "correctly — only the ambiguous form is refused.",
         )
         # And the same instant expressed with an explicit +02:00 offset (a
         # Berlin client converting correctly) must land identically.

--- a/lex/tests/unit/api/test_as_of_parsing.py
+++ b/lex/tests/unit/api/test_as_of_parsing.py
@@ -2,25 +2,26 @@
 Tests for ``parse_as_of_datetime`` — the ``?as_of=`` anchor parser.
 
 Verifies:
-    • An offset-aware anchor is normalized to UTC unchanged (the form clients
-      should send: it carries its own zone, so the server never guesses)
-    • A NAIVE anchor is interpreted in the configured timezone, with the offset
-      in force on that value's own date (DST-correct, not a fixed shift)
-    • A naive anchor logs a warning — the signal that a client still needs fixing
-    • An aware anchor logs nothing
-    • Blank, None and unparseable input yield None
+    • An offset-aware anchor is normalized to UTC unchanged (the only accepted
+      form: it carries its own zone, so the server never guesses)
+    • An aware anchor's own offset is honoured, so CEST and CET wall clocks
+      resolve to different instants
+    • A NAIVE anchor is REJECTED with a 400 (``ValidationError``), regardless of
+      the configured timezone, and logs which value was rejected
+    • Blank, None and unparseable input yield None (as_of is simply absent)
 
-Background: the naive branch previously assumed UTC, which made ``as_of`` the
-only datetime input in the API not following DRF's convention
-(``DateTimeField.enforce_timezone`` uses ``get_current_timezone()``). A Berlin
-client sending local wall-clock was evaluated 1-2h in the future, so stepping
-back less than that offset never reached the pre-edit state (customer report
-2026-07-14).
+Background: a naive anchor originally assumed UTC, which put a Berlin client's
+wall clock 1-2h in the future — stepping back less than that offset never
+reached the pre-edit state and the endpoint returned a plausible snapshot of the
+wrong version (customer report 2026-07-14). Every first-party client now sends an
+absolute instant, so a naive value is a bug rather than a use case: failing
+loudly beats guessing.
 """
 
 from datetime import datetime, timezone as dt_timezone
 
 from django.test import SimpleTestCase, override_settings
+from rest_framework.exceptions import ValidationError
 
 from lex.api.utils.temporal import parse_as_of_datetime
 
@@ -40,44 +41,31 @@ class AsOfParsingTests(SimpleTestCase):
             parse_as_of_datetime("2026-07-15T12:30:00Z"),
         )
 
-    def test_naive_anchor_uses_the_configured_zone_in_summer(self):
-        # CEST (+02): a client's 14:30 wall clock is 12:30Z.
-        self.assertEqual(
-            parse_as_of_datetime("2026-07-15T14:30:00"),
-            datetime(2026, 7, 15, 12, 30, tzinfo=dt_timezone.utc),
-        )
+    def test_aware_anchor_honours_its_own_offset_across_dst(self):
+        # The same wall clock in CEST and CET denotes different instants, and the
+        # offset the client sent is what decides — no server-side zone lookup.
+        self.assertEqual(parse_as_of_datetime("2026-07-15T14:30:00+02:00").hour, 12)
+        self.assertEqual(parse_as_of_datetime("2026-01-15T14:30:00+01:00").hour, 13)
 
-    def test_naive_anchor_uses_the_configured_zone_in_winter(self):
-        # CET (+01): the same wall clock is 13:30Z. The offset comes from the
-        # value's own date, so this is not a fixed shift.
-        self.assertEqual(
-            parse_as_of_datetime("2026-01-15T14:30:00"),
-            datetime(2026, 1, 15, 13, 30, tzinfo=dt_timezone.utc),
-        )
-
-    def test_naive_anchor_is_no_longer_read_as_utc(self):
-        # The regression this parser caused: reading the digits as UTC placed the
-        # anchor 2h after the moment the user meant.
-        self.assertNotEqual(
-            parse_as_of_datetime("2026-07-15T14:30:00"),
-            datetime(2026, 7, 15, 14, 30, tzinfo=dt_timezone.utc),
-        )
+    def test_naive_anchor_is_rejected(self):
+        with self.assertRaises(ValidationError) as caught:
+            parse_as_of_datetime("2026-07-15T14:30:00")
+        self.assertIn("as_of", caught.exception.detail)
 
     @override_settings(USE_TZ=True, TIME_ZONE="UTC")
-    def test_naive_anchor_under_utc_configuration_is_unchanged(self):
-        # The old hardcoded behaviour is just the TIME_ZONE="UTC" case of the
-        # new rule — no special-casing needed.
-        self.assertEqual(
-            parse_as_of_datetime("2026-07-15T14:30:00"),
-            datetime(2026, 7, 15, 14, 30, tzinfo=dt_timezone.utc),
-        )
-
-    def test_naive_anchor_logs_a_warning(self):
-        with self.assertLogs("lex.api.utils.temporal", level="WARNING") as captured:
+    def test_naive_anchor_is_rejected_under_utc_configuration_too(self):
+        # The rejection is unconditional: it is about the value being ambiguous,
+        # not about which zone happens to be configured.
+        with self.assertRaises(ValidationError):
             parse_as_of_datetime("2026-07-15T14:30:00")
+
+    def test_rejection_logs_the_offending_value(self):
+        with self.assertLogs("lex.api.utils.temporal", level="WARNING") as captured:
+            with self.assertRaises(ValidationError):
+                parse_as_of_datetime("2026-07-15T14:30:00")
         self.assertTrue(
-            any("naive datetime" in line for line in captured.output),
-            f"expected a naive-anchor warning, got {captured.output}",
+            any("2026-07-15T14:30:00" in line for line in captured.output),
+            f"expected the rejected value in the log, got {captured.output}",
         )
 
     def test_aware_anchor_logs_nothing(self):
@@ -85,6 +73,8 @@ class AsOfParsingTests(SimpleTestCase):
             parse_as_of_datetime("2026-07-15T12:30:00Z")
 
     def test_blank_and_unparseable_input_yields_none(self):
+        # Absent or malformed is not the same as ambiguous: as_of is simply not
+        # applied, which is the pre-existing behaviour and stays unchanged.
         for raw in (None, "", "   ", "not-a-date"):
             with self.subTest(raw=raw):
                 self.assertIsNone(parse_as_of_datetime(raw))
@@ -94,15 +84,3 @@ class AsOfParsingTests(SimpleTestCase):
         parsed = parse_as_of_datetime("2026-07-15T14:30:00+02:00")
         self.assertIsNone(parsed.tzinfo)
         self.assertEqual(parsed, datetime(2026, 7, 15, 12, 30))
-
-    def test_dst_offset_comes_from_the_values_own_date(self):
-        # Guards against anyone replacing the zone lookup with a fixed offset:
-        # the same wall clock resolves to different instants in CEST and CET.
-        summer = parse_as_of_datetime("2026-07-15T14:30:00")
-        winter = parse_as_of_datetime("2026-01-15T14:30:00")
-        self.assertEqual(summer.hour, 12, "14:30 CEST is 12:30Z")
-        self.assertEqual(winter.hour, 13, "14:30 CET is 13:30Z")
-        self.assertNotEqual(
-            summer.hour, winter.hour,
-            "a fixed offset would resolve both wall clocks to the same hour",
-        )


### PR DESCRIPTION
> **Draft, and stacked on #724.** Do not merge until the `"as_of received a naive datetime"` warnings introduced by #724 have **stopped appearing in production logs**. This is the gate that closes the incident, and it is breaking for any caller still sending naive values.

## What

#724 made a naive anchor follow the configured timezone and logged it. Correct for the common case — but still a guess, and wrong for any caller in another zone.

This removes the guess: a naive `?as_of=` is refused with a **400**.

## Why refuse rather than assume

A value with no offset does not denote an instant. Every guess the server makes is a silent wrong answer: assuming UTC put a Berlin client's wall clock 1–2 h in the future, so *"1 minute before my edit"* still showed the post-edit state (customer report 2026-07-14). Because the endpoint returned a **plausible snapshot of the wrong version** rather than an error, the failure survived for weeks.

Every first-party client now sends an absolute instant (`toAsOfIsoString`, ExcellenceCloudGmbH/process-admin-general-client#472), so a naive anchor is a **bug rather than a use case**. Failing loudly makes the next client regression immediately visible.

This is only tenable because the callers are first-party — a deliberate contract narrowing, not a defensive default.

## The change

```python
if timezone.is_naive(parsed):
    logger.warning("as_of rejected a naive datetime (%r): ...", raw)
    raise ValidationError({"as_of": "must carry a timezone — send an absolute "
                                    "instant such as 2026-07-15T12:30:00Z ..."})
```

Logged **and** raised: the 400 tells the caller, the log tells us which client still needs fixing.

All three call sites are DRF views (`ListAPIView` ×2, `GenericAPIView`), so the `ValidationError` surfaces as a 400 naming the `as_of` field.

## Unchanged on purpose

Absent, blank and unparseable values still yield `None` and simply skip the `as_of` filter. **Malformed is not the same as ambiguous**, and narrowing that too would be a separate decision — worth considering as a follow-up, since a typo'd anchor being silently ignored is its own quiet failure.

## Tests

- Unit suite retargeted: 9 tests, **all passing locally**. Asserts the rejection is *unconditional across `TIME_ZONE`* (it is about the value being ambiguous, not about which zone is configured), that the rejected value is logged, that an aware anchor logs nothing, and that aware offsets are still honoured across DST.
- Scenario 5.103 now asserts **400** for the naive form, while the same wall clock **with its offset** still returns the pre-edit snapshot — proving only the ambiguous form is refused. A new `_list_response` helper returns the raw response, since `_list_names` asserts 200.

**Not run locally:** the E2E cluster needs the framework bootstrap and a database — validate in CI.

## Order

1. ExcellenceCloudGmbH/process-admin-general-client#472 (client sends instants)
2. ExcellenceCloudGmbH/process-admin-general-client#473
3. #724 (tolerant fallback + warning)
4. **this PR** — once the logs from step 3 are clean
